### PR TITLE
sfam-535 fix prettytable

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ foundationdb
 requests
 numpy
 typing
-prettytable
+prettytable>=3.10.0
 docker
 psutil
 py-cpuinfo

--- a/simplyblock_core/controllers/lvol_events.py
+++ b/simplyblock_core/controllers/lvol_events.py
@@ -33,7 +33,7 @@ def lvol_status_change(lvol, new_state, old_status, caused_by=ec.CAUSED_BY_CLI):
 
 
 def lvol_migrate(lvol, old_node, new_node, caused_by=ec.CAUSED_BY_CLI):
-    _lvol_event(lvol, f"LVol migrated from: {old_node}, to {new_node}", caused_by, ec.EVENT_STATUS_CHANGE)
+    _lvol_event(lvol, f"LVol migrated from: {old_node}, \nto {new_node}", caused_by, ec.EVENT_STATUS_CHANGE)
 
 
 def lvol_health_check_change(lvol, new_state, old_status, caused_by=ec.CAUSED_BY_CLI):

--- a/simplyblock_core/utils.py
+++ b/simplyblock_core/utils.py
@@ -84,7 +84,7 @@ def get_iface_ip(ifname):
 
 def print_table(data: list):
     if data:
-        x = PrettyTable(field_names=data[0].keys())
+        x = PrettyTable(field_names=data[0].keys(), max_width=70)
         x.align = 'l'
         for node_data in data:
             row = []


### PR DESCRIPTION
2 alternatives (implemented both):
- add '\n' to avoid superlong line for lvol migration
- upgrade prettytable and use 'max_width' (will affect all printed tables, not just event log)