### PR TITLE
Specify lvol/snaps limit and provisioning limit per storage node

### DIFF
--- a/simplyblock_cli/cli.py
+++ b/simplyblock_cli/cli.py
@@ -43,12 +43,14 @@ class CLIWrapper:
         sub_command.add_argument("--jm-percent", help='Number in percent to use for JM from each device',
                                  type=int, default=3, dest='jm_percent')
         sub_command.add_argument("--data-nics", help='Data interface names', nargs='+', dest='data_nics')
-        sub_command.add_argument("--memory", help='SPDK huge memory allocation, default is 4G', dest='spdk_mem')
+        sub_command.add_argument("--max-lvol", help='Max lvol per storage node', dest='max_lvol', type=int)
+        sub_command.add_argument("--max-snap", help='Max snapshot per storage node', dest='max_snap', type=int)
+        sub_command.add_argument("--max-prov", help='Max provisioning size of all storage nodes', dest='max_prov')
+        sub_command.add_argument("--number-of-devices", help='Number of devices per storage node if it\'s not supported EC2 instance', dest='number_of_devices', type=int)
+
         sub_command.add_argument("--spdk-image", help='SPDK image uri', dest='spdk_image')
         sub_command.add_argument("--spdk-debug", help='Enable spdk debug logs', dest='spdk_debug', required=False, action='store_true')
 
-        sub_command.add_argument("--iobuf_small_pool_count", help='bdev_set_options param', dest='small_pool_count',  type=int, default=0)
-        sub_command.add_argument("--iobuf_large_pool_count", help='bdev_set_options param', dest='large_pool_count',  type=int, default=0)
         sub_command.add_argument("--iobuf_small_bufsize", help='bdev_set_options param', dest='small_bufsize',  type=int, default=0)
         sub_command.add_argument("--iobuf_large_bufsize", help='bdev_set_options param', dest='large_bufsize',  type=int, default=0)
 
@@ -77,12 +79,14 @@ class CLIWrapper:
                                   'During restart, the node does not accept IO. In a high-availability setup, '
                                   'this will not impact operations')
         sub_command.add_argument("node_id", help='UUID of storage node')
-        sub_command.add_argument("--memory", help='SPDK huge memory allocation, default is 4G', dest='spdk_mem')
+        sub_command.add_argument("--max-lvol", help='Max lvol per storage node', dest='max_lvol', type=int, default=0)
+        sub_command.add_argument("--max-snap", help='Max snapshot per storage node', dest='max_snap', type=int, default=0)
+        sub_command.add_argument("--max-prov", help='Max provisioning size of all storage nodes', dest='max_prov', default="")
+        sub_command.add_argument("--number-of-devices", help='Number of devices per storage node if it\'s not supported EC2 instance', dest='number_of_devices', type=int)
+
         sub_command.add_argument("--spdk-image", help='SPDK image uri', dest='spdk_image')
         sub_command.add_argument("--spdk-debug", help='Enable spdk debug logs', dest='spdk_debug', required=False, action='store_true')
 
-        sub_command.add_argument("--iobuf_small_pool_count", help='bdev_set_options param', dest='small_pool_count',  type=int, default=0)
-        sub_command.add_argument("--iobuf_large_pool_count", help='bdev_set_options param', dest='large_pool_count',  type=int, default=0)
         sub_command.add_argument("--iobuf_small_bufsize", help='bdev_set_options param', dest='small_bufsize',  type=int, default=0)
         sub_command.add_argument("--iobuf_large_bufsize", help='bdev_set_options param', dest='large_bufsize',  type=int, default=0)
 
@@ -636,6 +640,12 @@ class CLIWrapper:
                 ret = storage_ops.deploy_cleaner()
 
             elif sub_command == "add-node":
+                if not args.max_lvol:
+                    self.parser.error(f"Mandatory argument '--max-lvol' not provided for {sub_command}")
+                if not args.max_snap:
+                    self.parser.error(f"Mandatory argument '--max-snap' not provided for {sub_command}")
+                if not args.max_prov:
+                    self.parser.error(f"Mandatory argument '--max-prov' not provided for {sub_command}")
                 cluster_id = args.cluster_id
                 node_ip = args.node_ip
                 ifname = args.ifname
@@ -643,22 +653,21 @@ class CLIWrapper:
                 spdk_image = args.spdk_image
                 spdk_debug = args.spdk_debug
 
-                small_pool_count = args.small_pool_count
-                large_pool_count = args.large_pool_count
                 small_bufsize = args.small_bufsize
                 large_bufsize = args.large_bufsize
                 num_partitions_per_dev = args.partitions
                 jm_percent = args.jm_percent
 
-                spdk_mem = None
-                if args.spdk_mem:
-                    spdk_mem = self.parse_size(args.spdk_mem)
-                    if spdk_mem < 1 * 1024 * 1024:
-                        return f"SPDK memory:{args.spdk_mem} must be larger than 1G"
+                max_lvol = args.max_lvol
+                max_snap = args.max_snap
+                max_prov = self.parse_size(args.max_prov)
+                number_of_devices = args.number_of_devices
+                if max_prov < 1 * 1024 * 1024:
+                    return f"Max provisioning memory:{args.max_prov} must be larger than 1G"
 
                 out = storage_ops.add_node(
-                    cluster_id, node_ip, ifname, data_nics, spdk_mem, spdk_image, spdk_debug,
-                    small_pool_count, large_pool_count, small_bufsize, large_bufsize, num_partitions_per_dev, jm_percent)
+                    cluster_id, node_ip, ifname, data_nics, max_lvol, max_snap, max_prov, spdk_image, spdk_debug,
+                    small_bufsize, large_bufsize, num_partitions_per_dev, jm_percent, number_of_devices)
                 return out
 
             elif sub_command == "list":
@@ -676,22 +685,17 @@ class CLIWrapper:
                 spdk_image = args.spdk_image
                 spdk_debug = args.spdk_debug
 
-                spdk_mem = None
-                if args.spdk_mem:
-                    spdk_mem = self.parse_size(args.spdk_mem)
-                    if spdk_mem < 1 * 1024 * 1024:
-                        return f"SPDK memory:{args.spdk_mem} must be larger than 1G"
 
+                max_lvol = args.max_lvol
+                max_snap = args.max_snap
+                max_prov = self.parse_size(args.max_prov)
 
-                small_pool_count = args.small_pool_count
-                large_pool_count = args.large_pool_count
                 small_bufsize = args.small_bufsize
                 large_bufsize = args.large_bufsize
 
                 ret = storage_ops.restart_storage_node(
-                    node_id, spdk_mem,
+                    node_id, max_lvol, max_snap, max_prov,
                     spdk_image, spdk_debug,
-                    small_pool_count, large_pool_count,
                     small_bufsize, large_bufsize)
 
             elif sub_command == "list-devices":

--- a/simplyblock_core/constants.py
+++ b/simplyblock_core/constants.py
@@ -61,3 +61,31 @@ SIMPLY_BLOCK_SPDK_CORE_IMAGE = "simplyblock/spdk-core:latest"
 SIMPLY_BLOCK_SPDK_ULTRA_IMAGE = "simplyblock/spdk:prerelease-latest"
 
 GELF_PORT = 12201
+
+MIN_HUGE_PAGE_MEMORY_FOR_LVOL = 209715200
+MIN_SYS_MEMORY_FOR_LVOL = 524288000
+EXTRA_SMALL_POOL_COUNT = 1024
+EXTRA_LARGE_POOL_COUNT = 128
+EXTRA_HUGE_PAGE_MEMORY = 2147483648
+EXTRA_SYS_MEMORY = 2147483648
+
+INSTANCE_STORAGE_DATA = {
+        'i4i.large': {'number_of_devices': 1, 'size_per_device_gb': 468},
+        'i4i.xlarge': {'number_of_devices': 1, 'size_per_device_gb': 937},
+        'i4i.2xlarge': {'number_of_devices': 1, 'size_per_device_gb': 1875},
+        'i4i.4xlarge': {'number_of_devices': 1, 'size_per_device_gb': 3750},
+        'i4i.8xlarge': {'number_of_devices': 2, 'size_per_device_gb': 3750},
+        'i4i.12xlarge': {'number_of_devices': 3, 'size_per_device_gb': 3750},
+        'i4i.16xlarge': {'number_of_devices': 4, 'size_per_device_gb': 3750},
+        'i4i.24xlarge': {'number_of_devices': 6, 'size_per_device_gb': 3750},
+        'i4i.32xlarge': {'number_of_devices': 8, 'size_per_device_gb': 3750},
+        'i4i.metal': {'number_of_devices': 8, 'size_per_device_gb': 3750},
+        'i3en.large': {'number_of_devices': 1, 'size_per_device_gb': 1250},
+        'i3en.xlarge': {'number_of_devices': 1, 'size_per_device_gb': 2500},
+        'i3en.2xlarge': {'number_of_devices': 2, 'size_per_device_gb': 2500},
+        'i3en.3xlarge': {'number_of_devices': 1, 'size_per_device_gb': 7500},
+        'i3en.6xlarge': {'number_of_devices': 2, 'size_per_device_gb': 7500},
+        'i3en.12xlarge': {'number_of_devices': 4, 'size_per_device_gb': 7500},
+        'i3en.24xlarge': {'number_of_devices': 8, 'size_per_device_gb': 7500},
+        'i3en.metal': {'number_of_devices': 8, 'size_per_device_gb': 7500},
+    }

--- a/simplyblock_core/kv_store.py
+++ b/simplyblock_core/kv_store.py
@@ -279,3 +279,18 @@ class DBController:
         for task in self.get_job_tasks(""):
             if task.uuid == task_id:
                 return task
+
+    def get_snapshots_by_node_id(self, node_id):
+        ret = []
+        snaps = SnapShot().read_from_db(self.kv_store)
+        for snap in snaps:
+            if snap.lvol.host_id == node_id:
+                ret.append(snap)
+        return ret
+
+    def get_snode_size(self, node_id):
+        snode = self.get_storage_node_by_id(node_id)
+        total_node_capacity = 0
+        for dev in snode.nvme_devices:
+            total_node_capacity += dev.size
+        return total_node_capacity

--- a/simplyblock_core/models/storage_node.py
+++ b/simplyblock_core/models/storage_node.py
@@ -61,7 +61,9 @@ class StorageNode(BaseModel):
         "remote_devices": {"type": List[NVMeDevice], 'default': []},
         "host_secret": {"type": str, "default": ""},
         "ctrl_secret": {"type": str, "default": ""},
-
+        "max_lvol": {"type": int, "default": 0},
+        "max_snap": {"type": int, "default": 0},
+        "max_prov": {"type": str, "default": ""},
         "cpu": {"type": int, "default": 0},
         "cpu_hz": {"type": int, "default": 0},
         "memory": {"type": int, "default": 0},
@@ -73,10 +75,12 @@ class StorageNode(BaseModel):
         "app_thread_mask": {"type": str, "default": ""},
         "pollers_mask": {"type": str, "default": ""},
         "os_cores": {"type": str, "default": []},
+        "nvme_pollers_cores": {"type": str, "default": ""},
         "dev_cpu_mask": {"type": str, "default": ""},
         "spdk_mem": {"type": int, "default": 0},
         "spdk_image": {"type": str, "default": ""},
         "spdk_debug": {"type": bool, "default": False},
+
 
         "ec2_metadata": {"type": dict, "default": {}},
         "ec2_instance_id": {"type": str, "default": ""},

--- a/simplyblock_core/utils.py
+++ b/simplyblock_core/utils.py
@@ -325,3 +325,83 @@ def generate_mask(cores):
     for core in cores:
         mask |= (1 << core)
     return f'0x{mask:X}'
+
+def calculate_pool_count(alceml_count, lvol_count, snap_count, cpu_count, poller_count):
+    '''
+    				        Small pool count				            Large pool count
+    Create JM			    256						                    32					                    For each JM
+
+    Create Alceml 			256						                    32					                    For each Alceml
+
+    Create Distrib 			256						                    32					                    For each distrib
+
+    First Send cluster map	256						                    32					                    Calculated or one time
+
+    NVMF transport TCP 		127 * poll_groups_mask||CPUCount + 384		15 * poll_groups_mask||CPUCount + 384 	Calculated or one time
+
+    Subsystem add NS		128 * poll_groups_mask||CPUCount		    16 * poll_groups_mask||CPUCount		    Calculated or one time
+
+    Create snapshot			512						                    64					                    For each snapshot
+
+    Clone lvol			    256						                    32					                    For each clone
+    '''
+    poller_number = poller_count if poller_count else cpu_count
+    small_pool_count = (3 + alceml_count + lvol_count + 2 * snap_count + 1) * 256 + poller_number * 127 + 384 + 128 * poller_number + constants.EXTRA_SMALL_POOL_COUNT
+    large_pool_count = (3 + alceml_count + lvol_count + 2 * snap_count + 1) * 32 + poller_number * 15 + 384 + 16 * poller_number + constants.EXTRA_LARGE_POOL_COUNT
+    return small_pool_count, large_pool_count
+
+
+def calculate_minimum_hp_memory(small_pool_count, large_pool_count, lvol_count, snap_count, cpu_count):
+    '''
+    1092 (initial consumption) + 4 * CPU + 1.0277 * POOL_COUNT(Sum in MB) + (7 + 6) * lvol_count + 12 * snap_count
+    then you can amend the expected memory need for the creation of lvols (6MB),
+    connection number over lvols (7MB per connection), creation of snaps (12MB),
+    extra buffer 2GB
+    return: minimum_hp_memory in bytes
+    '''
+    pool_consumption = (small_pool_count * 8 + large_pool_count * 128) / 1024 + 1092
+    memory_consumption = (4 * cpu_count + 1.0277 * pool_consumption + (6 + 7) * lvol_count + 12 * snap_count) * (1024 * 1024) + constants.EXTRA_HUGE_PAGE_MEMORY
+    return memory_consumption
+
+
+def calculate_minimum_sys_memory(max_prov):
+    max_prov_tb = max_prov / (1024 * 1024 * 1024 * 1024)
+    minimum_sys_memory = (250 * 1024 * 1024) * 1.1 * max_prov_tb + constants.EXTRA_SYS_MEMORY
+    logger.debug(f"Minimum system memory is {humanbytes(minimum_sys_memory)}")
+    return minimum_sys_memory
+
+
+def calculate_spdk_memory(minimum_hp_memory, minimum_sys_memory, free_sys_memory, huge_total_memory):
+    total_free_memory = free_sys_memory + huge_total_memory
+    if total_free_memory < (minimum_hp_memory + minimum_sys_memory):
+        logger.warning(f"Total free memory:{humanbytes(total_free_memory)}, "
+                       f"Minimum huge pages memory: {humanbytes(minimum_hp_memory)}, "
+                       f"Minimum system memory: {humanbytes(minimum_sys_memory)}")
+        return False, 0
+    spdk_mem = minimum_hp_memory + (total_free_memory - minimum_hp_memory - minimum_sys_memory) * 0.2
+    logger.debug(f"SPDK memory is {humanbytes(spdk_mem)}")
+    return True, spdk_mem
+
+
+def get_total_size_per_instance_type(instance_type):
+    instance_storage_data = constants.INSTANCE_STORAGE_DATA
+    if instance_type in instance_storage_data:
+        number_of_devices = instance_storage_data[instance_type]["number_of_devices"]
+        device_size = instance_storage_data[instance_type]["size_per_device_gb"]
+        return True, number_of_devices, device_size
+
+    return False, 0, 0
+
+
+def validate_add_lvol_or_snap_on_node(memory_free, huge_free, max_lvol_or_snap,
+                                      lvol_or_snap_size, node_capacity, node_lvol_or_snap_count):
+    min_sys_memory = 2 / 4096 * lvol_or_snap_size +  1 / 4096 * node_capacity + constants.MIN_SYS_MEMORY_FOR_LVOL
+    if huge_free < constants.MIN_HUGE_PAGE_MEMORY_FOR_LVOL:
+        return f"No enough huge pages memory on the node, Free memory: {humanbytes(huge_free)}, " \
+               f"Min Huge memory required: {humanbytes(constants.MIN_HUGE_PAGE_MEMORY_FOR_LVOL)}"
+    if memory_free < min_sys_memory:
+        return f"No enough system memory on the node, Free Memory: {humanbytes(memory_free)}, " \
+               f"Min Sys memory required: {humanbytes(min_sys_memory)}"
+    if node_lvol_or_snap_count >= max_lvol_or_snap:
+        return f"You have exceeded the max number of lvol/snap {max_lvol_or_snap}"
+    return ""

--- a/simplyblock_web/blueprints/web_api_storage_node.py
+++ b/simplyblock_web/blueprints/web_api_storage_node.py
@@ -163,9 +163,21 @@ def storage_node_add():
     if 'ifname' not in req_data:
         return utils.get_response_error("missing required param: ifname", 400)
 
+    if 'max_lvol' not in req_data:
+        return utils.get_response_error("missing required param: max_lvol", 400)
+
+    if 'max_snap' not in req_data:
+        return utils.get_response_error("missing required param: max_snap", 400)
+
+    if 'max_prov' not in req_data:
+        return utils.get_response_error("missing required param: max_prov", 400)
+
     cluster_id = req_data['cluster_id']
     node_ip = req_data['node_ip']
     ifname = req_data['ifname']
+    max_lvol = req_data['max_lvol']
+    max_snap = req_data['max_snap']
+    max_prov = req_data['max_prov']
 
     spdk_image = None
     if 'spdk_image' in req_data:
@@ -180,15 +192,10 @@ def storage_node_add():
         data_nics = req_data['data_nics']
         data_nics = data_nics.split(",")
 
-    spdk_mem = None
-    if 'spdk_mem' in req_data:
-        mem = req_data['spdk_mem']
-        spdk_mem = utils.parse_size(mem)
-        if spdk_mem < 1 * 1024 * 1024:
-            return utils.get_response_error(f"SPDK memory:{mem} must be larger than 1G", 400)
+
 
     out = storage_node_ops.add_node(
-        cluster_id, node_ip, ifname, data_nics, spdk_mem,
+        cluster_id, node_ip, ifname, data_nics, max_lvol, max_snap, max_prov,
         spdk_image=spdk_image, spdk_debug=spdk_debug)
 
     return utils.get_response(out)


### PR DESCRIPTION
In this change, user can specify --max-lvol, --max-snap, --max-prov,
--number-of-device (Optional, mandatory if the instance is
not supported ec2 instance)
parameters that determine the required small pool count, large pool
count and required huge pages.

## JIRA ticket link/s

-   [SFAM-396](https://simplyblock.atlassian.net/jira/software/c/projects/SFAM/issues/SFAM-396)


