### PR TITLE
fix get_task_by_id: task.id is not the same as task.uuid

### DIFF
--- a/simplyblock_core/kv_store.py
+++ b/simplyblock_core/kv_store.py
@@ -286,5 +286,5 @@ class DBController:
 
     def get_task_by_id(self, task_id):
         for task in self.get_job_tasks(""):
-            if task.uuid == task_id:
+            if task_id.split('/')[-1] == task.uuid:
                 return task


### PR DESCRIPTION
## JIRA ticket link/s

-   [SFAM-942](https://simplyblock.atlassian.net/browse/SFAM-942)

## Summary of changes

1.  [ Provide some key summary of changes to give context as to why these changes have been made ]

## Additional Info

_[Any additional info such as screenshots or postman collections,etc that will help the reviewer review your changes]_
