### PR TITLE
Set cpu count to 64 if it's more than that

### DIFF
--- a/simplyblock_core/utils.py
+++ b/simplyblock_core/utils.py
@@ -295,6 +295,9 @@ def calculate_core_allocation(cpu_count):
     https://simplyblock.atlassian.net/browse/SFAM-885
     '''
 
+    if cpu_count > 64:
+        cpu_count = 64
+
     all_cores = list(range(0, cpu_count))
     app_thread_core = all_cores[1:2]
     jm_cpu_core = all_cores[2:3]


### PR DESCRIPTION
This's a current limitaion for bdb_lcpu_mask
because it's uint64_t (64 bit)

## JIRA ticket link/s

-   [EXAMPLE-123](https://simplyblock.atlassian.net/browse/EXAMPLE-123)

## Summary of changes

1.  [ Provide some key summary of changes to give context as to why these changes have been made ]

## Additional Info

_[Any additional info such as screenshots or postman collections,etc that will help the reviewer review your changes]_
