### PR TITLE
Github Actions: Clone a repo using Actions/Checkout

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -49,6 +49,8 @@ jobs:
           repository: simplyblock-io/simplyBlockDeploy
           ref: refs/heads/${{ github.event.inputs.simplyBlockDeploy_branch || 'main'}}
           path: 'simplyBlockDeploy'
+          token: ${{ secrets.GH_ACCESS_KEY_ID_HAMDI }}
+
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v2


### PR DESCRIPTION
Currently Github Actions runners uses my SSH Keys. This is not a safe practice. So this PR proposes an alternative solution.


```
Cloning into '/home/ubuntu/actions-runner/_work/sbcli/sbcli/simplyBlockDeploy'...
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
Error: Process completed with exit code 128.
```