### PR TITLE
pass additional parameters in terraform template

### DIFF
--- a/simplyblock_web/app.py
+++ b/simplyblock_web/app.py
@@ -47,4 +47,4 @@ def status():
 
 app.config['JSONIFY_PRETTYPRINT_REGULAR'] = True
 if __name__ == '__main__':
-    app.run(host='0.0.0.0', port=7000, debug=constants.LOG_WEB_DEBUG)
+    app.run(host='0.0.0.0', debug=constants.LOG_WEB_DEBUG)


### PR DESCRIPTION
Changes:
* pass additional parameter: `volumes_per_storage_nodes` in the request path
* Changed the order of terraform commands. First run `terraform init` and then `terraform workspace select`

Tested the following cases: 
* ✅ Deleted the `manohar-tfengine` instance and tried to run the `/deployer` API
* ✅ adding a new node and change the zone, will create instances in the specified zone
* ✅ Tried to increase and reduce the instances