### PR TITLE
updated node-exporter network to monitoring-net

### DIFF
--- a/simplyblock_core/scripts/docker-compose-swarm-monitoring.yml
+++ b/simplyblock_core/scripts/docker-compose-swarm-monitoring.yml
@@ -238,7 +238,3 @@ volumes:
 networks:
   monitoring-net:
     external: true
-
-  hostnet:
-    external: true
-    name: host


### PR DESCRIPTION
## JIRA ticket link/s

-   [EXAMPLE-123](https://simplyblock.atlassian.net/browse/EXAMPLE-123)

## Summary of changes

1.  reverted changes to previous node-exporter network as we are currently not receiving metrics with the current network `hostnet`
