### PR TITLE
Adjust cluster status according to online nodes and devices

### DIFF
--- a/env_var
+++ b/env_var
@@ -1,5 +1,6 @@
-SIMPLY_BLOCK_COMMAND_NAME=sbcli-dev
-SIMPLY_BLOCK_VERSION=5.2.6
 
-SIMPLY_BLOCK_DOCKER_IMAGE=simplyblock/simplyblock:main
+SIMPLY_BLOCK_COMMAND_NAME=sbcli-dev-activate
+SIMPLY_BLOCK_VERSION=10.0.1
+
+SIMPLY_BLOCK_DOCKER_IMAGE=simplyblock/simplyblock:reactivate
 DOCKER_USER=hamdysimplyblock

--- a/simplyblock_cli/cli.py
+++ b/simplyblock_cli/cli.py
@@ -299,6 +299,8 @@ class CLIWrapper:
         sub_command.add_argument("--max-queue-size", help='The max size the queue will grow', type=int, default=128)
         sub_command.add_argument("--inflight-io-threshold", help='The number of inflight IOs allowed before the IO queuing starts', type=int, default=4)
         sub_command.add_argument("--enable-qos", help='Enable qos bdev for storage nodes', action='store_true', dest='enable_qos')
+        sub_command.add_argument("--strict-node-anti-affinity", help='Enable strict node anti affinity for storage nodes', action='store_true')
+
 
 
         # add cluster
@@ -327,6 +329,7 @@ class CLIWrapper:
         sub_command.add_argument("--max-queue-size", help='The max size the queue will grow', type=int, default=128)
         sub_command.add_argument("--inflight-io-threshold", help='The number of inflight IOs allowed before the IO queuing starts', type=int, default=4)
         sub_command.add_argument("--enable-qos", help='Enable qos bdev for storage nodes', action='store_true', dest='enable_qos')
+        sub_command.add_argument("--strict-node-anti-affinity", help='Enable strict node anti affinity for storage nodes', action='store_true')
 
         # Activate cluster
         sub_command = self.add_sub_command(subparser, 'activate', 'Create distribs and raid0 bdevs on all the storage node and move the cluster to active state')
@@ -1269,11 +1272,13 @@ class CLIWrapper:
         max_queue_size = args.max_queue_size
         inflight_io_threshold = args.inflight_io_threshold
         enable_qos = args.enable_qos
+        strict_node_anti_affinity = args.strict_node_anti_affinity
+
 
         return cluster_ops.add_cluster(
             blk_size, page_size_in_blocks, cap_warn, cap_crit, prov_cap_warn, prov_cap_crit,
             distr_ndcs, distr_npcs, distr_bs, distr_chunk_bs, ha_type, enable_node_affinity,
-            qpair_count, max_queue_size, inflight_io_threshold, enable_qos)
+            qpair_count, max_queue_size, inflight_io_threshold, enable_qos, strict_node_anti_affinity)
 
 
     def cluster_create(self, args):
@@ -1299,6 +1304,7 @@ class CLIWrapper:
         max_queue_size = args.max_queue_size
         inflight_io_threshold = args.inflight_io_threshold
         enable_qos = args.enable_qos
+        strict_node_anti_affinity = args.strict_node_anti_affinity
 
 
         return cluster_ops.create_cluster(
@@ -1306,7 +1312,7 @@ class CLIWrapper:
             CLI_PASS, cap_warn, cap_crit, prov_cap_warn, prov_cap_crit,
             ifname, log_del_interval, metrics_retention_period, contact_point, grafana_endpoint,
             distr_ndcs, distr_npcs, distr_bs, distr_chunk_bs, ha_type, enable_node_affinity,
-            qpair_count, max_queue_size, inflight_io_threshold, enable_qos)
+            qpair_count, max_queue_size, inflight_io_threshold, enable_qos, strict_node_anti_affinity)
 
 
     def query_yes_no(self, question, default="yes"):

--- a/simplyblock_core/constants.py
+++ b/simplyblock_core/constants.py
@@ -54,8 +54,8 @@ FDB_CHECK_INTERVAL_SEC = 60
 
 
 
-SIMPLY_BLOCK_DOCKER_IMAGE = "simplyblock/simplyblock:main"
-SIMPLY_BLOCK_CLI_NAME = "sbcli-dev"
+SIMPLY_BLOCK_DOCKER_IMAGE = "simplyblock/simplyblock:reactivate"
+SIMPLY_BLOCK_CLI_NAME = "sbcli-dev-activate"
 TASK_EXEC_INTERVAL_SEC = 30
 TASK_EXEC_RETRY_COUNT = 8
 

--- a/simplyblock_core/models/cluster.py
+++ b/simplyblock_core/models/cluster.py
@@ -43,6 +43,8 @@ class Cluster(BaseModel):
         "distr_bs": {"type": int, 'default': 0},
         "distr_chunk_bs": {"type": int, 'default': 0},
         "cluster_max_size": {"type": int, 'default': 0},
+        "cluster_max_devices": {"type": int, 'default': 0},
+        "cluster_max_nodes": {"type": int, 'default': 0},
 
         ## cluster-level: cap-warn ( % ), cap-crit ( % ), prov-cap-warn ( % ), prov-cap-crit. ( % )
         "cap_warn": {"type": int, "default": 80},
@@ -59,7 +61,8 @@ class Cluster(BaseModel):
         "enable_node_affinity": {"type": bool, 'default': False},
         "max_queue_size": {"type": int, "default": 128},
         "inflight_io_threshold": {"type": int, "default": 4},
-        "enable_qos": {"type": bool, 'default': False}
+        "enable_qos": {"type": bool, 'default': False},
+        "strict_node_anti_affinity": {"type": bool, 'default': False},
     }
 
     def __init__(self, data=None):

--- a/simplyblock_web/blueprints/web_api_cluster.py
+++ b/simplyblock_web/blueprints/web_api_cluster.py
@@ -50,10 +50,11 @@ def add_cluster():
     max_queue_size = cl_data.get('max_queue_size', 128)
     inflight_io_threshold = cl_data.get('inflight_io_threshold', 4)
     enable_qos = cl_data.get('enable_qos', False)
+    strict_node_anti_affinity = cl_data.get('strict_node_anti_affinity', False)
 
     ret = cluster_ops.add_cluster(blk_size, page_size_in_blocks, cap_warn, cap_crit, prov_cap_warn, prov_cap_crit,
                                   distr_ndcs, distr_npcs, distr_bs, distr_chunk_bs, ha_type, enable_node_affinity,
-                                  qpair_count, max_queue_size, inflight_io_threshold, enable_qos)
+                                  qpair_count, max_queue_size, inflight_io_threshold, enable_qos, strict_node_anti_affinity)
 
     return utils.get_response(ret)
 


### PR DESCRIPTION
Adjust the cluster status according to the following criteria

ndcs n
npcs k (0,1,2)

number of devices in cluster in total
number of devices in cluster unavailable
number of nodes in cluster in total
number of nodes in cluster online
Single node outage --> degraded
single device unavailability --> degraded
if number of devices in the cluster unavailable on DIFFERENT nodes > k --> I cannot read and, in some cases, cannot write (suspended)
if number of devices in the cluster available < n + k --> I cannot write and I cannot read (suspended)
if (number of online nodes = number of total nodes -2 and k=2) --> we lose availability on one node, but generally cluster continues to run
Cluster create parameter - "strict-node-anti-affinity" yes/no
If set --> the below cases go to "suspended", if not set they go to "degraded"
if (number of online nodes < number of total nodes - k) --> degraded?
if (number of online nodes < n+1) --> degraded?
if (number of online nodes < n+2 and k=2) --> degraded?
A removed node is the same as an offline node UNTIL ITS FULLY MIGRATED. Once its fully migrated it does not count for any rule (its gone from cluster).
An added node does not count as a new node UNTIL EXPANSION MIGRATION FULLY FINISHED.
1+1
6 devices, 6 nodes
1. restart devices/nodes [online]
2. reactivate cluster (automated based on rules above)