### PR TITLE
Additional fixes for the cli.py generator

### DIFF
--- a/cli-reference.yaml
+++ b/cli-reference.yaml
@@ -412,7 +412,7 @@ commands:
         arguments:
           - name: "device_id"
             help: "Device id"
-            dest: id
+            dest: device_id
             type: str
       - name: add-device
         help: "Adds a new storage device"
@@ -423,7 +423,7 @@ commands:
         arguments:
           - name: "device_id"
             help: "Device id"
-            dest: id
+            dest: device_id
             type: str
       - name: remove-device
         help: "Logically removes a storage device"
@@ -450,7 +450,7 @@ commands:
         arguments:
           - name: "device_id"
             help: "Device ID"
-            dest: id
+            dest: device_id
             type: str
       - name: get-capacity-device
         help: "Gets a device's capacity"
@@ -515,7 +515,7 @@ commands:
         arguments:
           - name: "device_id"
             help: "Device id"
-            dest: id
+            dest: device_id
             type: str
       - name: info
         help: "Gets the node's information"
@@ -1381,7 +1381,7 @@ commands:
         arguments:
           - name: "task_id"
             help: "Task id"
-            dest: id
+            dest: task_id
             type: str
       - name: delete
         help: "Deletes a cluster"

--- a/cli-reference.yaml
+++ b/cli-reference.yaml
@@ -124,7 +124,7 @@ commands:
             private: true
           - name: "--enable-test-device"
             help: "Enable creation of test device"
-            dest: enable-test-device
+            dest: enable_test_device
             type: bool
             action: store_true
             private: true
@@ -632,12 +632,12 @@ commands:
             private: true
           - name: "--data-chunks-per-stripe"
             help: "Erasure coding schema parameter k (distributed raid), default: 1"
-            dest: distr-ndcs
+            dest: distr_ndcs
             type: int
             default: 1
           - name: "--parity-chunks-per-stripe"
             help: "Erasure coding schema parameter n (distributed raid), default: 1"
-            dest: distr-npcs
+            dest: distr_npcs
             type: int
             default: 1
           - name: "--enable-qos"
@@ -713,18 +713,18 @@ commands:
             private: true
           - name: "--distr-bs"
             help: "(Dev) distrb bdev block size, default: 4096"
-            dest: distr-bs
+            dest: distr_bs
             type: str
             default: 4096
             private: true
           - name: "--chunk-size-in-bytes"
             help: "(Dev) distrb bdev chunk block size, default: 4096"
-            dest: distr-chunk-bs
+            dest: distr_chunk_bs
             type: str
             default: 4096
           - name: "--enable-node-affinity"
             help: "Enable node affinity for storage nodes"
-            dest: enable-node-affinity
+            dest: enable_node_affinity
             type: bool
             action: store_true
           - name: "--qpair-count"
@@ -738,13 +738,13 @@ commands:
             default: 3
           - name: "--max-queue-size"
             help: "The max size the queue will grow"
-            dest: max-queue-size
+            dest: max_queue_size
             type: str
             default: 128
             private: true
           - name: "--inflight-io-threshold"
             help: "The number of inflight IOs allowed before the IO queuing starts"
-            dest: inflight-io-threshold
+            dest: inflight_io_threshold
             type: str
             default: 4
             private: true
@@ -752,7 +752,7 @@ commands:
             help: >
               Enable strict node anti affinity for storage nodes. Never more than one chunk is placed on a node.
               This requires a minimum of _data-chunks-in-stripe + parity-chunks-in-stripe + 1_ nodes in the cluster."
-            dest: strict-node-anti-affinity
+            dest: strict_node_anti_affinity
             type: bool
             action: store_true
           - name: "--journal-partition"
@@ -844,7 +844,7 @@ commands:
             private: true
           - name: "--enable-test-device"
             help: "Enable creation of test device"
-            dest: enable-test-device
+            dest: enable_test_device
             type: bool
             action: store_true
             private: true
@@ -893,9 +893,8 @@ commands:
             private: true
           - name: "--pool-max"
             help: "Pool maximum size: 20M, 20G, 0(default)"
-            dest: pool-max
+            dest: pool_max
             type: str
-            default: 0
             default: 25G
             private: true
           - name: "--snapshot"
@@ -934,27 +933,27 @@ commands:
             private: true
           - name: "--max-rw-iops"
             help: "Maximum Read Write IO Per Second"
-            dest: max-rw-iops
+            dest: max_rw_iops
             type: int
             private: true
           - name: "--max-rw-mbytes"
             help: "Maximum Read Write Megabytes Per Second"
-            dest: max-rw-mbytes
+            dest: max_rw_mbytes
             type: int
             private: true
           - name: "--max-r-mbytes"
             help: "Maximum Read Megabytes Per Second"
-            dest: max-r-mbytes
+            dest: max_r_mbytes
             type: int
             private: true
           - name: "--max-w-mbytes"
             help: "Maximum Write Megabytes Per Second"
-            dest: max-w-mbytes
+            dest: max_w_mbytes
             type: int
             private: true
           - name: "--distr-vuid"
             help: "(Dev) set vuid manually, default: random (1-99999)"
-            dest: distr-vuid
+            dest: distr_vuid
             type: str
             default: 0
             private: true
@@ -970,7 +969,7 @@ commands:
             private: true
           - name: "--lvol-priority-class"
             help: "Logical volume priority class"
-            dest: lvol-priority-class
+            dest: lvol_priority_class
             type: int
             default: 0
             private: false
@@ -1045,23 +1044,23 @@ commands:
             default: 
           - name: "--data-chunks-per-stripe"
             help: "Erasure coding schema parameter k (distributed raid), default: 1"
-            dest: distr-ndcs
+            dest: distr_ndcs
             type: int
             default: 1
           - name: "--parity-chunks-per-stripe"
             help: "Erasure coding schema parameter n (distributed raid), default: 1"
-            dest: distr-npcs
+            dest: distr_npcs
             type: int
             default: 1
           - name: "--distr-bs"
             help: "(Dev) distrb bdev block size, default: 4096"
-            dest: distr-bs
+            dest: distr_bs
             type: str
             default: 4096
             private: true
           - name: "--distr-chunk-bs"
             help: "(Dev) distrb bdev chunk block size, default: 4096"
-            dest: distr-chunk-bs
+            dest: distr_chunk_bs
             type: str
             default: 4096
             private: true
@@ -1076,7 +1075,7 @@ commands:
             private: true
           - name: "--enable-node-affinity"
             help: "Enable node affinity for storage nodes"
-            dest: enable-node-affinity
+            dest: enable_node_affinity
             type: bool
             action: store_true
           - name: "--qpair-count"
@@ -1090,13 +1089,13 @@ commands:
             default: 0
           - name: "--max-queue-size"
             help: "The max size the queue will grow"
-            dest: max-queue-size
+            dest: max_queue_size
             type: str
             default: 128
             private: true
           - name: "--inflight-io-threshold"
             help: "The number of inflight IOs allowed before the IO queuing starts"
-            dest: inflight-io-threshold
+            dest: inflight_io_threshold
             type: str
             default: 4
             private: true
@@ -1110,7 +1109,7 @@ commands:
             help: >
               Enable strict node anti affinity for storage nodes. Never more than one chunk is placed on a node. This
               requires a minimum of _data-chunks-in-stripe + parity-chunks-in-stripe + 1_ nodes in the cluster.
-            dest: strict-node-anti-affinity
+            dest: strict_node_anti_affinity
             type: bool
             action: store_true
       - name: add
@@ -1144,23 +1143,23 @@ commands:
             default: 500
           - name: "--data-chunks-per-stripe"
             help: "Erasure coding schema parameter k (distributed raid), default: 1"
-            dest: distr-ndcs
+            dest: distr_ndcs
             type: int
             default: 0
           - name: "--parity-chunks-per-stripe"
             help: "Erasure coding schema parameter n (distributed raid), default: 1"
-            dest: distr-npcs
+            dest: distr_npcs
             type: int
             default: 0
           - name: "--distr-bs"
             help: "(Dev) distrb bdev block size, default: 4096"
-            dest: distr-bs
+            dest: distr_bs
             type: str
             default: 4096
             private: true
           - name: "--distr-chunk-bs"
             help: "(Dev) distrb bdev chunk block size, default: 4096"
-            dest: distr-chunk-bs
+            dest: distr_chunk_bs
             type: str
             default: 4096
             private: true
@@ -1175,7 +1174,7 @@ commands:
             private: true
           - name: "--enable-node-affinity"
             help: "Enables node affinity for storage nodes"
-            dest: enable-node-affinity
+            dest: enable_node_affinity
             type: bool
             action: store_true
           - name: "--qpair-count"
@@ -1189,13 +1188,13 @@ commands:
             default: 0
           - name: "--max-queue-size"
             help: "The max size the queue will grow"
-            dest: max-queue-size
+            dest: max_queue_size
             type: str
             default: 128
             private: true
           - name: "--inflight-io-threshold"
             help: "The number of inflight IOs allowed before the IO queuing starts"
-            dest: inflight-io-threshold
+            dest: inflight_io_threshold
             type: str
             default: 4
             private: true
@@ -1209,7 +1208,7 @@ commands:
             help: >
               Enable strict node anti affinity for storage nodes. Never more than one chunk is placed on a node.
               This requires a minimum of _data-chunks-in-stripe + parity-chunks-in-stripe + 1_ nodes in the cluster."
-            dest: strict-node-anti-affinity
+            dest: strict_node_anti_affinity
             type: bool
             action: store_true
       - name: activate
@@ -1449,23 +1448,23 @@ commands:
             type: str
           - name: "--max-rw-iops"
             help: "Maximum Read Write IO Per Second"
-            dest: max-rw-iops
+            dest: max_rw_iops
             type: int
           - name: "--max-rw-mbytes"
             help: "Maximum Read Write Megabytes Per Second"
-            dest: max-rw-mbytes
+            dest: max_rw_mbytes
             type: int
           - name: "--max-r-mbytes"
             help: "Maximum Read Megabytes Per Second"
-            dest: max-r-mbytes
+            dest: max_r_mbytes
             type: int
           - name: "--max-w-mbytes"
             help: "Maximum Write Megabytes Per Second"
-            dest: max-w-mbytes
+            dest: max_w_mbytes
             type: int
           - name: "--distr-vuid"
             help: "(Dev) set vuid manually, default: random (1-99999)"
-            dest: distr-vuid
+            dest: distr_vuid
             type: str
             default: 0
             private: true
@@ -1481,7 +1480,7 @@ commands:
             private: true
           - name: "--lvol-priority-class"
             help: "Logical volume priority class"
-            dest: lvol-priority-class
+            dest: lvol_priority_class
             type: int
             default: 0
           - name: "--namespace"
@@ -1506,19 +1505,19 @@ commands:
             type: str
           - name: "--max-rw-iops"
             help: "Maximum Read Write IO Per Second"
-            dest: max-rw-iops
+            dest: max_rw_iops
             type: int
           - name: "--max-rw-mbytes"
             help: "Maximum Read Write Megabytes Per Second"
-            dest: max-rw-mbytes
+            dest: max_rw_mbytes
             type: int
           - name: "--max-r-mbytes"
             help: "Maximum Read Megabytes Per Second"
-            dest: max-r-mbytes
+            dest: max_r_mbytes
             type: int
           - name: "--max-w-mbytes"
             help: "Maximum Write Megabytes Per Second"
-            dest: max-w-mbytes
+            dest: max_w_mbytes
             type: int
       - name: list
         help: "Lists logical volumes"
@@ -1753,33 +1752,33 @@ commands:
             type: str
           - name: "--pool-max"
             help: "Pool maximum size: 20M, 20G, 0. Default: 0"
-            dest: pool-max
+            dest: pool_max
             type: str
             default: 0
           - name: "--lvol-max"
             help: "Logical volume maximum size: 20M, 20G, 0. Default: 0"
-            dest: lvol-max
+            dest: lvol_max
             type: str
             default: 0
           - name: "--max-rw-iops"
             help: "Maximum Read Write IO Per Second"
-            dest: max-rw-iops
+            dest: max_rw_iops
             type: int
           - name: "--max-rw-mbytes"
             help: "Maximum Read Write Megabytes Per Second"
-            dest: max-rw-mbytes
+            dest: max_rw_mbytes
             type: int
           - name: "--max-r-mbytes"
             help: "Maximum Read Megabytes Per Second"
-            dest: max-r-mbytes
+            dest: max_r_mbytes
             type: int
           - name: "--max-w-mbytes"
             help: "Maximum Write Megabytes Per Second"
-            dest: max-w-mbytes
+            dest: max_w_mbytes
             type: int
           - name: "--has-secret"
             help: "Pool is created with a secret (all further API interactions with the pool and logical volumes in the pool require this secret)"
-            dest: has-secret
+            dest: has_secret
             type: bool
             action: store_true
             private: true
@@ -1792,27 +1791,27 @@ commands:
             type: str
           - name: "--pool-max"
             help: "Pool maximum size: 20M, 20G"
-            dest: pool-max
+            dest: pool_max
             type: str
           - name: "--lvol-max"
             help: "Logical volume maximum size: 20M, 20G"
-            dest: lvol-max
+            dest: lvol_max
             type: str
           - name: "--max-rw-iops"
             help: "Maximum Read Write IO Per Second"
-            dest: max-rw-iops
+            dest: max_rw_iops
             type: int
           - name: "--max-rw-mbytes"
             help: "Maximum Read Write Megabytes Per Second"
-            dest: max-rw-mbytes
+            dest: max_rw_mbytes
             type: int
           - name: "--max-r-mbytes"
             help: "Maximum Read Megabytes Per Second"
-            dest: max-r-mbytes
+            dest: max_r_mbytes
             type: int
           - name: "--max-w-mbytes"
             help: "Maximum Write Megabytes Per Second"
-            dest: max-w-mbytes
+            dest: max_w_mbytes
             type: int
       - name: list
         help: "Lists all storage pools"

--- a/cli-reference.yaml
+++ b/cli-reference.yaml
@@ -17,7 +17,6 @@ commands:
               The network interface to be used for communication between the control plane
               and the storage node.
             dest: ifname
-            required: true
             type: str
       - name: deploy-cleaner
         help: "Cleans a previous simplyblock deploy (local run)"
@@ -30,28 +29,23 @@ commands:
           - name: "cluster_id"
             help: "Cluster id"
             dest: cluster_id
-            required: true
             type: str
           - name: "node_ip"
             help: "IP of storage node to add"
             dest: node_ip
-            required: true
             type: str
           - name: "ifname"
             help: "Management interface name"
             dest: ifname
-            required: true
             type: str
           - name: "--journal-partition"
             help: "1: auto-create small partitions for journal on nvme devices. 0: use a separate (the smallest) nvme device of the node for journal. The journal needs a maximum of 3 percent of total available raw disk space."
             dest: partitions
-            required: true
             type: int
             default: 1
           - name: "--jm-percent"
             help: "Number in percent to use for JM from each device"
             dest: jm_percent
-            required: true
             type: str
             default: 3
             private: true
@@ -60,13 +54,11 @@ commands:
             description: >
               Storage network interface name(s). Can be more than one. Comma-separated list: e.g. eth0,eth1
             dest: data_nics
-            required: true
             type: str
             nargs: +
           - name: "--max-lvol"
             help: "Max logical volume per storage node"
             dest: max_lvol
-            required: true
             type: int
           - name: "--max-size"
             help: "Maximum amount of GB to be utilized on this storage node"
@@ -77,26 +69,22 @@ commands:
               (two replicas), the effective cluster capacity is _100 TiB * 3 / 2 = 150 TiB_. Setting this parameter to
               _150 TiB / 3 * 2 = 100TiB_ would be a safe choice.
             dest: max_prov
-            required: true
             type: str
             default: ""
           - name: "--number-of-distribs"
             help: "The number of distirbs to be created on the node"
             dest: number_of_distribs
-            required: false
             type: int
             default: 4
             private: true
           - name: "--number-of-devices"
             help: "Number of devices per storage node if it's not supported EC2 instance"
             dest: number_of_devices
-            required: true
             type: str
             private: true
           - name: "--size-of-device"
             help: "Size of device per storage node"
             dest: partition_size
-            required: true
             type: str
             private: true
           - name: "--vcpu-count"
@@ -104,53 +92,45 @@ commands:
               Number of vCPUs used for SPDK. Remaining CPUs will be used for Linux system, TCP/IP processing, and
               other workloads. The default on non-Kubernetes hosts is 80%.
             dest: vcpu_count
-            required: true
             type: int
           - name: "--cpu-mask"
             help: >
               SPDK app CPU mask, default is all cores found
             dest: spdk_cpu_mask
-            required: true
             type: str
             private: true
           - name: "--spdk-image"
             help: "SPDK image uri"
             dest: spdk_image
-            required: true
             type: str
             private: true
           - name: "--spdk-debug"
             help: "Enable spdk debug logs"
             dest: spdk_debug
-            required: true
             type: bool
             action: store_true
             private: true
           - name: "--iobuf_small_bufsize"
             help: "bdev_set_options param"
             dest: small_bufsize
-            required: true
             type: str
             default: 0
             private: true
           - name: "--iobuf_large_bufsize"
             help: "bdev_set_options param"
             dest: large_bufsize
-            required: true
             type: str
             default: 0
             private: true
           - name: "--enable-test-device"
             help: "Enable creation of test device"
             dest: enable-test-device
-            required: true
             type: bool
             action: store_true
             private: true
           - name: "--disable-ha-jm"
             help: "Disable HA JM for distrib creation"
             dest: enable_ha_jm
-            required: true
             type: bool
             default: true
             action: store_false
@@ -158,7 +138,6 @@ commands:
           - name: "--ha-jm-count"
             help: "HA JM count"
             dest: ha_jm_count
-            required: true
             type: str
             default: 3
             private: true
@@ -167,19 +146,16 @@ commands:
               Adds as secondary node. A secondary node does not have any disks attached. It is only used for I/O
               processing in case a primary goes down.
             dest: is_secondary_node
-            required: true
             type: bool
             default: false
             action: store_true
           - name: "--namespace"
             help: "Kubernetes namespace to deploy on"
             dest: namespace
-            required: true
             type: str
           - name: "--id-device-by-nqn"
             help: "Use device nqn to identify it instead of serial number"
             dest: id_device_by_nqn
-            required: true
             type: bool
             default: false
             action: store_true
@@ -194,7 +170,6 @@ commands:
             help: Storage node id
             completer: _completer_get_sn_list
             type: str
-            required: true
       - name: remove
         help: "Removes a storage node from the cluster"
         description: >
@@ -209,11 +184,9 @@ commands:
             help: Storage node id
             completer: _completer_get_sn_list
             type: str
-            required: true
           - name: "--force-remove"
             help: "Force remove all logical volumes and snapshots"
             dest: force_remove
-            required: true
             type: bool
             action: store_true
       - name: list
@@ -222,12 +195,10 @@ commands:
           - name: "--cluster-id"
             help: "Cluster id"
             dest: cluster_id
-            required: true
             type: str
           - name: "--json"
             help: "Print outputs in json format"
             dest: json
-            required: true
             type: bool
             action: store_true
       - name: get
@@ -237,7 +208,6 @@ commands:
             help: Storage node id
             completer: _completer_get_sn_list
             type: str
-            required: true
       - name: restart
         help: "Restarts a storage node"
         description: >
@@ -249,17 +219,14 @@ commands:
             help: Storage node id
             completer: _completer_get_sn_list
             type: str
-            required: true
           - name: "--max-lvol"
             help: "Max logical volume per storage node"
             dest: max_lvol
-            required: true
             type: int
             default: 0
           - name: "--max-snap"
             help: "Max snapshot per storage node"
             dest: max_snap
-            required: true
             type: str
             default: 0
             private: true
@@ -272,7 +239,6 @@ commands:
               (two replicas), the effective cluster capacity is _100 TiB * 3 / 2 = 150 TiB_. Setting this parameter to
               _150 TiB / 3 * 2 = 100TiB_ would be a safe choice.
             dest: max_prov
-            required: true
             type: str
             default:
             private: true
@@ -283,46 +249,39 @@ commands:
               have to be attached to new hosts. Otherwise, they have to be marked as failed and removed from cluster.
               Triggers a pro-active migration of data from those devices onto other storage nodes.
             dest: node_ip
-            required: true
             type: str
           - name: "--number-of-devices"
             help: "Number of devices per storage node if it's not supported EC2 instance"
             dest: number_of_devices
-            required: true
             type: str
             default: 0
             private: true
           - name: "--spdk-image"
             help: "SPDK image uri"
             dest: spdk_image
-            required: true
             type: str
             private: true
           - name: "--spdk-debug"
             help: "Enable spdk debug logs"
             dest: spdk_debug
-            required: true
             type: bool
             action: store_true
             private: true
           - name: "--iobuf_small_bufsize"
             help: "bdev_set_options param"
             dest: small_bufsize
-            required: true
             type: str
             default: 0
             private: true
           - name: "--iobuf_large_bufsize"
             help: "bdev_set_options param"
             dest: large_bufsize
-            required: true
             type: str
             default: 0
             private: true
           - name: "--force"
             help: "Force restart"
             dest: force
-            required: true
             type: bool
             action: store_true
       - name: shutdown
@@ -333,11 +292,9 @@ commands:
             help: Storage node id
             completer: _completer_get_sn_list
             type: str
-            required: true
           - name: "--force"
             help: "Force node shutdown"
             dest: force
-            required: true
             type: bool
             action: store_true
       - name: suspend
@@ -348,11 +305,9 @@ commands:
             help: Storage node id
             completer: _completer_get_sn_list
             type: str
-            required: true
           - name: "--force"
             help: "Force node suspend"
             dest: force
-            required: true
             type: bool
             action: store_true
       - name: resume
@@ -362,7 +317,6 @@ commands:
             help: Storage node id
             completer: _completer_get_sn_list
             type: str
-            required: true
       - name: get-io-stats
         help: "Get node IO statistics"
         arguments:
@@ -370,16 +324,13 @@ commands:
             help: Storage node id
             completer: _completer_get_sn_list
             type: str
-            required: true
           - name: "--history"
             help: "list history records -one for every 15 minutes- for XX days and YY hours -up to 10 days in total-, format: XXdYYh"
             dest: history
-            required: true
             type: str
           - name: "--records"
             help: "Number of records, default: 20"
             dest: records
-            required: true
             type: str
             default: 20
       - name: get-capacity
@@ -389,11 +340,9 @@ commands:
             help: Storage node id
             completer: _completer_get_sn_list
             type: str
-            required: true
           - name: "--history"
             help: "list history records -one for every 15 minutes- for XX days and YY hours -up to 10 days in total-, format: XXdYYh"
             dest: history
-            required: true
             type: str
       - name: list-devices
         help: "Lists storage devices"
@@ -402,11 +351,9 @@ commands:
             help: Storage node id
             completer: _completer_get_sn_list
             type: str
-            required: true
           - name: "-s"
             help: "Sort the outputs"
             dest: -s
-            required: true
             type: str
             choices:
               - node-seq
@@ -417,7 +364,6 @@ commands:
           - name: "--json"
             help: "Print outputs in json format"
             dest: json
-            required: true
             type: bool
             action: store_true
       - name: device-testing-mode
@@ -427,12 +373,10 @@ commands:
           - name: "device_id"
             help: "Device id"
             dest: device_id
-            required: true
             type: str
           - name: "mode"
             help: "Testing mode"
             dest: mode
-            required: true
             type: str
             choices:
               - full_pass_through
@@ -449,7 +393,6 @@ commands:
           - name: "device_id"
             help: "Device id"
             dest: device_id
-            required: true
             type: str
       - name: reset-device
         help: "Resets a storage device"
@@ -460,7 +403,6 @@ commands:
           - name: "device_id"
             help: "Device id"
             dest: device_id
-            required: true
             type: str
       - name: restart-device
         help: "Restarts a storage device"
@@ -472,7 +414,6 @@ commands:
           - name: "device_id"
             help: "Device id"
             dest: id
-            required: true
             type: str
       - name: add-device
         help: "Adds a new storage device"
@@ -484,7 +425,6 @@ commands:
           - name: "device_id"
             help: "Device id"
             dest: id
-            required: true
             type: str
       - name: remove-device
         help: "Logically removes a storage device"
@@ -496,12 +436,10 @@ commands:
           - name: "device_id"
             help: "Device id"
             dest: device_id
-            required: true
             type: str
           - name: "--force"
             help: "Force device remove"
             dest: force
-            required: true
             type: bool
             action: store_true
       - name: set-failed-device
@@ -514,7 +452,6 @@ commands:
           - name: "device_id"
             help: "Device ID"
             dest: id
-            required: true
             type: str
       - name: get-capacity-device
         help: "Gets a device's capacity"
@@ -522,12 +459,10 @@ commands:
           - name: "device_id"
             help: "Device id"
             dest: device_id
-            required: true
             type: str
           - name: "--history"
             help: "list history records -one for every 15 minutes- for XX days and YY hours -up to 10 days in total-, format: XXdYYh"
             dest: history
-            required: true
             type: str
       - name: get-io-stats-device
         help: "Gets a device's IO statistics"
@@ -535,17 +470,14 @@ commands:
           - name: "device_id"
             help: "Device id"
             dest: device_id
-            required: true
             type: str
           - name: "--history"
             help: "list history records -one for every 15 minutes- for XX days and YY hours -up to 10 days in total-, format: XXdYYh"
             dest: history
-            required: true
             type: str
           - name: "--records"
             help: "Number of records, default: 20"
             dest: records
-            required: true
             type: str
             default: 20
       - name: port-list
@@ -554,7 +486,6 @@ commands:
           - name: "node_id"
             help: "Storage node id"
             dest: node_id
-            required: true
             type: str
             completer: _completer_get_sn_list
       - name: port-io-stats
@@ -563,12 +494,10 @@ commands:
           - name: "port_id"
             help: "Data port id"
             dest: port_id
-            required: true
             type: str
           - name: "--history"
             help: "list history records -one for every 15 minutes- for XX days and YY hours -up to 10 days in total, format: XXdYYh"
             dest: history
-            required: true
             type: str
       - name: check
         help: "Checks the health status of a storage node"
@@ -580,7 +509,6 @@ commands:
           - name: "node_id"
             help: "Storage node id"
             dest: node_id
-            required: true
             type: str
             completer: _completer_get_sn_list
       - name: check-device
@@ -589,7 +517,6 @@ commands:
           - name: "device_id"
             help: "Device id"
             dest: id
-            required: true
             type: str
       - name: info
         help: "Gets the node's information"
@@ -597,7 +524,6 @@ commands:
           - name: "node_id"
             help: "Storage node id"
             dest: node_id
-            required: true
             type: str
             completer: _completer_get_sn_list
       - name: info-spdk
@@ -607,7 +533,6 @@ commands:
           - name: "node_id"
             help: "Storage node id"
             dest: node_id
-            required: true
             type: str
             completer: _completer_get_sn_list
       - name: remove-jm-device
@@ -617,12 +542,10 @@ commands:
           - name: "jm_device_id"
             help: "Journaling device id"
             dest: jm_device_id
-            required: true
             type: str
           - name: "--force"
             help: "Force device remove"
             dest: force
-            required: true
             type: bool
             action: store_true
       - name: restart-jm-device
@@ -631,12 +554,10 @@ commands:
           - name: "jm_device_id"
             help: "Journaling device id"
             dest: jm_device_id
-            required: true
             type: str
           - name: "--force"
             help: "Force device remove"
             dest: force
-            required: true
             type: bool
             action: store_true
       - name: send-cluster-map
@@ -646,7 +567,6 @@ commands:
           - name: "node_id"
             help: "Storage node id"
             dest: node_id
-            required: true
             type: str
             completer: _completer_get_sn_list
       - name: get-cluster-map
@@ -656,7 +576,6 @@ commands:
           - name: "node_id"
             help: "Storage node id"
             dest: node_id
-            required: true
             type: str
             completer: _completer_get_sn_list
       - name: make-primary
@@ -666,7 +585,6 @@ commands:
           - name: "node_id"
             help: "Storage node id"
             dest: node_id
-            required: true
             type: str
             completer: _completer_get_sn_list
       - name: dump-lvstore
@@ -676,7 +594,6 @@ commands:
           - name: "node_id"
             help: "Storage node id"
             dest: node_id
-            required: true
             type: str
             completer: _completer_get_sn_list
   - name: "cluster"
@@ -689,23 +606,19 @@ commands:
           - name: "--storage-nodes"
             help: "comma separated ip addresses"
             dest: storage_nodes
-            required: true
             type: str
           - name: "--test"
             help: "Test Cluster"
             dest: test
-            required: true
             type: bool
             action: store_true
           - name: "--secondary-nodes"
             help: "comma separated ip addresses"
             dest: secondary_nodes
-            required: true
             type: str
           - name: "--ha-type"
             help: "Logical volume HA type (single, ha), default is cluster HA type"
             dest: ha_type
-            required: true
             type: str
             choices:
               - single
@@ -714,38 +627,32 @@ commands:
           - name: "--ha-jm-count"
             help: "HA JM count"
             dest: ha_jm_count
-            required: false
             type: str
             default: 3
             private: true
           - name: "--data-chunks-per-stripe"
             help: "Erasure coding schema parameter k (distributed raid), default: 1"
             dest: distr-ndcs
-            required: true
             type: int
             default: 1
           - name: "--parity-chunks-per-stripe"
             help: "Erasure coding schema parameter n (distributed raid), default: 1"
             dest: distr-npcs
-            required: true
             type: int
             default: 1
           - name: "--enable-qos"
             help: "Enable qos bdev for storage nodes"
             dest: enable_qos
-            required: false
             type: bool
             action: store_true
             private: true
           - name: "--ifname"
             help: "Management interface name, e.g. eth0"
             dest: ifname
-            required: true
             type: str
           - name: "--blk_size"
             help: "The block size in bytes"
             dest: blk_size
-            required: false
             type: str
             choices:
               - 512
@@ -755,82 +662,69 @@ commands:
           - name: "--page_size"
             help: "The size of a data page in bytes"
             dest: page_size
-            required: false
             type: str
             default: 2097152
             private: true
           - name: "--CLI_PASS"
             help: "Password for CLI SSH connection"
             dest: CLI_PASS
-            required: false
             type: str
             private: true
           - name: "--cap-warn"
             help: "Capacity warning level in percent, default: 89"
             dest: cap_warn
-            required: false
             type: int
             default: 89
           - name: "--cap-crit"
             help: "Capacity critical level in percent, default: 99"
             dest: cap_crit
-            required: false
             type: int
             default: 99
           - name: "--prov-cap-warn"
             help: "Capacity warning level in percent, default: 250"
             dest: prov_cap_warn
-            required: false
             type: int
             default: 250
           - name: "--prov-cap-crit"
             help: "Capacity critical level in percent, default: 500"
             dest: prov_cap_crit
-            required: false
             type: int
             default: 500
           - name: "--log-del-interval"
             help: "Logging retention period, default: 3d"
             dest: log_del_interval
-            required: false
             type: str
             default: 3d
           - name: "--metrics-retention-period"
             help: "Retention period for I/O statistics (Prometheus), default: 7d"
             dest: metrics_retention_period
-            required: false
             type: str
             default: 7d
           - name: "--contact-point"
             help: "Email or slack webhook url to be used for alerting"
             dest: contact_point
-            required: false
             type: str
             default: 
           - name: "--grafana-endpoint"
             help: "Endpoint url for Grafana"
             dest: grafana_endpoint
-            required: false
             type: str
             default: 
             private: true
           - name: "--distr-bs"
             help: "(Dev) distrb bdev block size, default: 4096"
             dest: distr-bs
-            required: false
             type: str
             default: 4096
             private: true
           - name: "--chunk-size-in-bytes"
             help: "(Dev) distrb bdev chunk block size, default: 4096"
             dest: distr-chunk-bs
-            required: false
             type: str
             default: 4096
           - name: "--enable-node-affinity"
             help: "Enable node affinity for storage nodes"
             dest: enable-node-affinity
-            required: false
             type: bool
             action: store_true
           - name: "--qpair-count"
@@ -839,21 +733,18 @@ commands:
               Increase for clusters with few but very large logical volumes or decrease for clusters with a large number
               of very small logical volumes.
             dest: qpair_count
-            required: false
             type: int
             value_range: 1..128
             default: 3
           - name: "--max-queue-size"
             help: "The max size the queue will grow"
             dest: max-queue-size
-            required: false
             type: str
             default: 128
             private: true
           - name: "--inflight-io-threshold"
             help: "The number of inflight IOs allowed before the IO queuing starts"
             dest: inflight-io-threshold
-            required: false
             type: str
             default: 4
             private: true
@@ -862,7 +753,6 @@ commands:
               Enable strict node anti affinity for storage nodes. Never more than one chunk is placed on a node.
               This requires a minimum of _data-chunks-in-stripe + parity-chunks-in-stripe + 1_ nodes in the cluster."
             dest: strict-node-anti-affinity
-            required: false
             type: bool
             action: store_true
           - name: "--journal-partition"
@@ -872,13 +762,11 @@ commands:
               the entire node’s NVMe capacity. If set to false, partitions on other devices will be auto-created to
               store the journal.
             dest: partitions
-            required: false
             type: str
             default: true
           - name: "--jm-percent"
             help: "Number in percent to use for JM from each device"
             dest: jm_percent
-            required: false
             type: str
             default: 3
             private: true
@@ -887,44 +775,37 @@ commands:
             description: >
               Storage network interface name(s). Can be more than one. Comma-separated list: e.g. eth0,eth1
             dest: data_nics
-            required: true
             type: str
             nargs: +
           - name: "--max-lvol"
             help: "Max logical volume per storage node"
             dest: max_lvol
-            required: true
             type: int
           - name: "--max-snap"
             help: "Max snapshot per storage node"
             dest: max_snap
-            required: false
             type: str
             default: 500
             private: true
           - name: "--max-size"
             help: "Maximum amount of GB to be provisioned via all storage nodes"
             dest: max_prov
-            required: true
             type: str
             default: ""
           - name: "--number-of-distribs"
             help: "The number of distirbs to be created on the node"
             dest: number_of_distribs
-            required: false
             type: str
             default: 4
             private: true
           - name: "--number-of-devices"
             help: "Number of devices per storage node if it's not supported EC2 instance"
             dest: number_of_devices
-            required: true
             type: str
             private: true
           - name: "--size-of-device"
             help: "Size of device per storage node"
             dest: partition_size
-            required: true
             type: str
             private: true
           - name: "--vcpu-count"
@@ -932,52 +813,44 @@ commands:
               Number of vCPUs used for SPDK. Remaining CPUs will be used for Linux system, TCP/IP processing, and
               other workloads. The default on non-Kubernetes hosts is 80%.
             dest: vcpu_count
-            required: true
             type: int
           - name: "--cpu-mask"
             help: "SPDK app CPU mask, default is all cores found"
             dest: spdk_cpu_mask
-            required: false
             type: str
             private: true
           - name: "--spdk-image"
             help: "SPDK image uri"
             dest: spdk_image
-            required: true
             type: str
             private: true
           - name: "--spdk-debug"
             help: "Enable spdk debug logs"
             dest: spdk_debug
-            required: false
             type: bool
             action: store_true
             private: true
           - name: "--iobuf_small_bufsize"
             help: "bdev_set_options param"
             dest: small_bufsize
-            required: false
             type: str
             default: 0
             private: true
           - name: "--iobuf_large_bufsize"
             help: "bdev_set_options param"
             dest: large_bufsize
-            required: false
             type: str
             default: 0
             private: true
           - name: "--enable-test-device"
             help: "Enable creation of test device"
             dest: enable-test-device
-            required: false
             type: bool
             action: store_true
             private: true
           - name: "--disable-ha-jm"
             help: "Disable HA JM for distrib creation"
             dest: enable_ha_jm
-            required: false
             type: bool
             default: true
             action: store_false
@@ -987,47 +860,40 @@ commands:
               Adds as secondary node. A secondary node does not have any disks attached. It is only used for I/O
               processing in case a primary goes down.
             dest: is_secondary_node
-            required: true
             type: bool
             default: false
             action: store_true
           - name: "--namespace"
             help: "k8s namespace to deploy on"
             dest: namespace
-            required: true
             type: str
           - name: "--id-device-by-nqn"
             help: "Use device nqn to identify it instead of serial number"
             dest: id_device_by_nqn
-            required: true
             type: bool
             default: false
             action: store_true
           - name: "--lvol-name"
             help: "Logical volume name or id"
             dest: lvol_name
-            required: false
             type: str
             default: lvol01
             private: true
           - name: "--lvol-size"
             help: "Logical volume size: 10M, 10G, 10(bytes)"
             dest: lvol_size
-            required: false
             type: str
             default: 10G
             private: true
           - name: "--pool-name"
             help: "Pool id or name"
             dest: pool_name
-            required: false
             type: str
             default: pool01
             private: true
           - name: "--pool-max"
             help: "Pool maximum size: 20M, 20G, 0(default)"
             dest: pool-max
-            required: false
             type: str
             default: 0
             default: 25G
@@ -1035,7 +901,6 @@ commands:
           - name: "--snapshot"
             help: "Make logical volume with snapshot capability, default: false"
             dest: snapshot
-            required: false
             type: bool
             action: store_true
             default: false
@@ -1043,19 +908,16 @@ commands:
           - name: "--max-volume-size"
             help: "Logical volume max size"
             dest: max_size
-            required: false
             type: str
             default: 1000G
             private: true
           - name: "--host-id"
             help: "Primary storage node id or hostname"
             dest: host_id
-            required: false
             type: str
           - name: "--encrypt"
             help: "Use inline data encryption and decryption on the logical volume"
             dest: encrypt
-            required: false
             type: bool
             action: store_true
             default: false
@@ -1063,50 +925,42 @@ commands:
           - name: "--crypto-key1"
             help: "Hex value of key1 to be used for logical volume encryption"
             dest: crypto_key1
-            required: false
             type: str
             private: true
           - name: "--crypto-key2"
             help: "Hex value of key2 to be used for logical volume encryption"
             dest: crypto_key2
-            required: false
             type: str
             private: true
           - name: "--max-rw-iops"
             help: "Maximum Read Write IO Per Second"
             dest: max-rw-iops
-            required: false
             type: int
             private: true
           - name: "--max-rw-mbytes"
             help: "Maximum Read Write Megabytes Per Second"
             dest: max-rw-mbytes
-            required: false
             type: int
             private: true
           - name: "--max-r-mbytes"
             help: "Maximum Read Megabytes Per Second"
             dest: max-r-mbytes
-            required: false
             type: int
             private: true
           - name: "--max-w-mbytes"
             help: "Maximum Write Megabytes Per Second"
             dest: max-w-mbytes
-            required: false
             type: int
             private: true
           - name: "--distr-vuid"
             help: "(Dev) set vuid manually, default: random (1-99999)"
             dest: distr-vuid
-            required: false
             type: str
             default: 0
             private: true
           - name: "--lvol-ha-type"
             help: "Logical volume HA type (single, ha), default is cluster HA type"
             dest: lvol_ha_type
-            required: true
             type: str
             choices:
               - single
@@ -1117,14 +971,12 @@ commands:
           - name: "--lvol-priority-class"
             help: "Logical volume priority class"
             dest: lvol-priority-class
-            required: true
             type: int
             default: 0
             private: false
           - name: "--fstype"
             help: "Filesystem type for testing (ext4, xfs)"
             dest: fstype
-            required: true
             type: str
             choices:
               - ext4
@@ -1139,99 +991,83 @@ commands:
           - name: "--page_size"
             help: "The size of a data page in bytes"
             dest: page_size
-            required: true
             type: str
             default: 2097152
             private: true
           - name: "--CLI_PASS"
             help: "Password for CLI SSH connection"
             dest: CLI_PASS
-            required: true
             type: str
             private: true
           - name: "--cap-warn"
             help: "Capacity warning level in percent, default: 89"
             dest: cap_warn
-            required: true
             type: int
             default: 89
           - name: "--cap-crit"
             help: "Capacity critical level in percent, default: 99"
             dest: cap_crit
-            required: true
             type: int
             default: 99
           - name: "--prov-cap-warn"
             help: "Capacity warning level in percent, default: 250"
             dest: prov_cap_warn
-            required: true
             type: int
             default: 250
           - name: "--prov-cap-crit"
             help: "Capacity critical level in percent, default: 500"
             dest: prov_cap_crit
-            required: true
             type: int
             default: 500
           - name: "--ifname"
             help: "Management interface name, e.g. eth0"
             dest: ifname
-            required: true
             type: str
           - name: "--log-del-interval"
             help: "Logging retention policy, default: 3d"
             dest: log_del_interval
-            required: true
             type: str
             default: 3d
           - name: "--metrics-retention-period"
             help: "Retention period for I/O statistics (Prometheus), default: 7d"
             dest: metrics_retention_period
-            required: true
             type: str
             default: 7d
           - name: "--contact-point"
             help: "Email or slack webhook url to be used for alerting"
             dest: contact_point
-            required: true
             type: str
             default: 
           - name: "--grafana-endpoint"
             help: "Endpoint url for Grafana"
             dest: grafana_endpoint
-            required: true
             type: str
             default: 
           - name: "--data-chunks-per-stripe"
             help: "Erasure coding schema parameter k (distributed raid), default: 1"
             dest: distr-ndcs
-            required: true
             type: int
             default: 1
           - name: "--parity-chunks-per-stripe"
             help: "Erasure coding schema parameter n (distributed raid), default: 1"
             dest: distr-npcs
-            required: true
             type: int
             default: 1
           - name: "--distr-bs"
             help: "(Dev) distrb bdev block size, default: 4096"
             dest: distr-bs
-            required: true
             type: str
             default: 4096
             private: true
           - name: "--distr-chunk-bs"
             help: "(Dev) distrb bdev chunk block size, default: 4096"
             dest: distr-chunk-bs
-            required: true
             type: str
             default: 4096
             private: true
           - name: "--ha-type"
             help: "Logical volume HA type (single, ha), default is cluster single type"
             dest: ha_type
-            required: true
             type: str
             choices:
               - single
@@ -1241,7 +1077,6 @@ commands:
           - name: "--enable-node-affinity"
             help: "Enable node affinity for storage nodes"
             dest: enable-node-affinity
-            required: true
             type: bool
             action: store_true
           - name: "--qpair-count"
@@ -1250,28 +1085,24 @@ commands:
               Increase for clusters with few but very large logical volumes or decrease for clusters with a large number
               of very small logical volumes.
             dest: qpair_count
-            required: true
             type: int
             value_range: 0..128
             default: 0
           - name: "--max-queue-size"
             help: "The max size the queue will grow"
             dest: max-queue-size
-            required: true
             type: str
             default: 128
             private: true
           - name: "--inflight-io-threshold"
             help: "The number of inflight IOs allowed before the IO queuing starts"
             dest: inflight-io-threshold
-            required: true
             type: str
             default: 4
             private: true
           - name: "--enable-qos"
             help: "Enable qos bdev for storage nodes, true by default"
             dest: enable_qos
-            required: true
             type: bool
             default: true
             private: true
@@ -1280,7 +1111,6 @@ commands:
               Enable strict node anti affinity for storage nodes. Never more than one chunk is placed on a node. This
               requires a minimum of _data-chunks-in-stripe + parity-chunks-in-stripe + 1_ nodes in the cluster.
             dest: strict-node-anti-affinity
-            required: true
             type: bool
             action: store_true
       - name: add
@@ -1289,64 +1119,54 @@ commands:
           - name: "--page_size"
             help: "The size of a data page in bytes"
             dest: page_size
-            required: true
             type: str
             default: 2097152
             private: true
           - name: "--cap-warn"
             help: "Capacity warning level in percent, default: 89"
             dest: cap_warn
-            required: true
             type: int
             default: 89
           - name: "--cap-crit"
             help: "Capacity critical level in percent, default: 99"
             dest: cap_crit
-            required: true
             type: int
             default: 99
           - name: "--prov-cap-warn"
             help: "Capacity warning level in percent, default: 250"
             dest: prov_cap_warn
-            required: true
             type: int
             default: 250
           - name: "--prov-cap-crit"
             help: "Capacity critical level in percent, default: 500"
             dest: prov_cap_crit
-            required: true
             type: int
             default: 500
           - name: "--data-chunks-per-stripe"
             help: "Erasure coding schema parameter k (distributed raid), default: 1"
             dest: distr-ndcs
-            required: true
             type: int
             default: 0
           - name: "--parity-chunks-per-stripe"
             help: "Erasure coding schema parameter n (distributed raid), default: 1"
             dest: distr-npcs
-            required: true
             type: int
             default: 0
           - name: "--distr-bs"
             help: "(Dev) distrb bdev block size, default: 4096"
             dest: distr-bs
-            required: true
             type: str
             default: 4096
             private: true
           - name: "--distr-chunk-bs"
             help: "(Dev) distrb bdev chunk block size, default: 4096"
             dest: distr-chunk-bs
-            required: true
             type: str
             default: 4096
             private: true
           - name: "--ha-type"
             help: "Logical volume HA type (single, ha), default is cluster single type"
             dest: ha_type
-            required: true
             type: str
             choices:
               - single
@@ -1356,7 +1176,6 @@ commands:
           - name: "--enable-node-affinity"
             help: "Enables node affinity for storage nodes"
             dest: enable-node-affinity
-            required: true
             type: bool
             action: store_true
           - name: "--qpair-count"
@@ -1365,28 +1184,24 @@ commands:
               Increase for clusters with few but very large logical volumes or decrease for clusters with a large number
               of very small logical volumes.
             dest: qpair_count
-            required: true
             type: int
             value_range: 0..128
             default: 0
           - name: "--max-queue-size"
             help: "The max size the queue will grow"
             dest: max-queue-size
-            required: true
             type: str
             default: 128
             private: true
           - name: "--inflight-io-threshold"
             help: "The number of inflight IOs allowed before the IO queuing starts"
             dest: inflight-io-threshold
-            required: true
             type: str
             default: 4
             private: true
           - name: "--enable-qos"
             help: "Enable qos bdev for storage nodes, default: true"
             dest: enable_qos
-            required: true
             type: bool
             default: true
             private: true
@@ -1395,7 +1210,6 @@ commands:
               Enable strict node anti affinity for storage nodes. Never more than one chunk is placed on a node.
               This requires a minimum of _data-chunks-in-stripe + parity-chunks-in-stripe + 1_ nodes in the cluster."
             dest: strict-node-anti-affinity
-            required: true
             type: bool
             action: store_true
       - name: activate
@@ -1407,13 +1221,11 @@ commands:
           - name: "--force"
             help: "Force recreate distr and lv stores"
             dest: force
-            required: true
             type: bool
             action: store_true
           - name: "--force-lvstore-create"
             help: "Force recreate lv stores"
             dest: force_lvstore_create
-            required: true
             type: bool
             action: store_true
             completer: _completer_get_cluster_list
@@ -1425,7 +1237,6 @@ commands:
           - name: "cluster_id"
             help: "Cluster id"
             dest: cluster_id
-            required: true
             type: str
             completer: _completer_get_cluster_list
       - name: show
@@ -1434,7 +1245,6 @@ commands:
           - name: "cluster_id"
             help: "Cluster id"
             dest: cluster_id
-            required: true
             type: str
             completer: _completer_get_cluster_list
       - name: get
@@ -1443,7 +1253,6 @@ commands:
           - name: "cluster_id"
             help: "Cluster id"
             dest: cluster_id
-            required: true
             type: str
             completer: _completer_get_cluster_list
       - name: get-capacity
@@ -1452,19 +1261,16 @@ commands:
           - name: "cluster_id"
             help: "Cluster id"
             dest: cluster_id
-            required: true
             type: str
             completer: _completer_get_cluster_list
           - name: "--json"
             help: "Print json output"
             dest: json
-            required: true
             type: bool
             action: store_true
           - name: "--history"
             help: "(XXdYYh), list history records (one for every 15 minutes) for XX days and YY hours (up to 10 days in total)."
             dest: history
-            required: true
             type: str
       - name: get-io-stats
         help: "Gets a cluster's I/O statistics"
@@ -1472,19 +1278,16 @@ commands:
           - name: "cluster_id"
             help: "Cluster id"
             dest: cluster_id
-            required: true
             type: str
             completer: _completer_get_cluster_list
           - name: "--records"
             help: "Number of records, default: 20"
             dest: records
-            required: true
             type: str
             default: 20
           - name: "--history"
             help: "(XXdYYh), list history records (one for every 15 minutes) for XX days and YY hours (up to 10 days in total)."
             dest: history
-            required: true
             type: str
       - name: get-logs
         help: "Returns a cluster's status logs"
@@ -1492,7 +1295,6 @@ commands:
           - name: "cluster_id"
             help: "Cluster id"
             dest: cluster_id
-            required: true
             type: str
             completer: _completer_get_cluster_list
       - name: get-secret
@@ -1501,7 +1303,6 @@ commands:
           - name: "cluster_id"
             help: "Cluster id"
             dest: cluster_id
-            required: true
             type: str
             completer: _completer_get_cluster_list
       - name: update-secret
@@ -1510,13 +1311,11 @@ commands:
           - name: "cluster_id"
             help: "Cluster id"
             dest: cluster_id
-            required: true
             type: str
             completer: _completer_get_cluster_list
           - name: "secret"
             help: "new 20 characters password"
             dest: secret
-            required: true
             type: str
       - name: check
         help: "Checks a cluster's health"
@@ -1524,7 +1323,6 @@ commands:
           - name: "cluster_id"
             help: "Cluster id"
             dest: cluster_id
-            required: true
             type: str
             completer: _completer_get_cluster_list
       - name: update
@@ -1537,19 +1335,16 @@ commands:
           - name: "cluster_id"
             help: "Cluster id"
             dest: cluster_id
-            required: true
             type: str
             completer: _completer_get_cluster_list
           - name: "--cp-only"
             help: "Update the control plane only"
             dest: mgmt_only
-            required: true
             type: bool
             default: false
           - name: "--restart"
             help: "Restart the management services"
             dest: restart
-            required: true
             type: bool
             default: false
       - name: graceful-shutdown
@@ -1559,7 +1354,6 @@ commands:
           - name: "cluster_id"
             help: "Cluster id"
             dest: cluster_id
-            required: true
             type: str
             completer: _completer_get_cluster_list
       - name: graceful-startup
@@ -1569,19 +1363,16 @@ commands:
           - name: "cluster_id"
             help: "Cluster id"
             dest: cluster_id
-            required: true
             type: str
             completer: _completer_get_cluster_list
           - name: "--clear-data"
             help: "clear Alceml data"
             dest: clear_data
-            required: true
             type: bool
             action: store_true
           - name: "--spdk-image"
             help: "SPDK image uri"
             dest: spdk_image
-            required: true
             type: str
       - name: list-tasks
         help: "Lists tasks of a cluster"
@@ -1589,7 +1380,6 @@ commands:
           - name: "cluster_id"
             help: "Cluster id"
             dest: cluster_id
-            required: true
             type: str
             completer: _completer_get_cluster_list
       - name: cancel-task
@@ -1598,7 +1388,6 @@ commands:
           - name: "task_id"
             help: "Task id"
             dest: id
-            required: true
             type: str
       - name: delete
         help: "Deletes a cluster"
@@ -1607,7 +1396,6 @@ commands:
           - name: "cluster_id"
             help: "Cluster id"
             dest: cluster_id
-            required: true
             type: str
             completer: _completer_get_cluster_list
   - name: "volume"
@@ -1622,83 +1410,68 @@ commands:
           - name: "name"
             help: "New logical volume name"
             dest: name
-            required: true
             type: str
           - name: "size"
             help: "Logical volume size: 10M, 10G, 10(bytes)"
             dest: size
-            required: true
             type: str
           - name: "pool"
             help: "Pool id or name"
             dest: pool
-            required: true
             type: str
           - name: "--snapshot"
             help: "Make logical volume with snapshot capability, default: false"
             dest: snapshot
-            required: true
             type: bool
             action: store_true
             default: false
           - name: "--max-size"
             help: "Logical volume max size"
             dest: max_size
-            required: true
             type: str
             default: ""
           - name: "--host-id"
             help: "Primary storage node id or Hostname"
             dest: host_id
-            required: true
             type: str
           - name: "--encrypt"
             help: "Use inline data encryption and decryption on the logical volume"
             dest: encrypt
-            required: true
             type: bool
             action: store_true
           - name: "--crypto-key1"
             help: "Hex value of key1 to be used for logical volume encryption"
             dest: crypto_key1
-            required: true
             type: str
           - name: "--crypto-key2"
             help: "Hex value of key2 to be used for logical volume encryption"
             dest: crypto_key2
-            required: true
             type: str
           - name: "--max-rw-iops"
             help: "Maximum Read Write IO Per Second"
             dest: max-rw-iops
-            required: true
             type: int
           - name: "--max-rw-mbytes"
             help: "Maximum Read Write Megabytes Per Second"
             dest: max-rw-mbytes
-            required: true
             type: int
           - name: "--max-r-mbytes"
             help: "Maximum Read Megabytes Per Second"
             dest: max-r-mbytes
-            required: true
             type: int
           - name: "--max-w-mbytes"
             help: "Maximum Write Megabytes Per Second"
             dest: max-w-mbytes
-            required: true
             type: int
           - name: "--distr-vuid"
             help: "(Dev) set vuid manually, default: random (1-99999)"
             dest: distr-vuid
-            required: true
             type: str
             default: 0
             private: true
           - name: "--ha-type"
             help: "Logical volume HA type (single, ha), default is cluster HA type"
             dest: ha_type
-            required: true
             type: str
             choices:
               - single
@@ -1709,24 +1482,20 @@ commands:
           - name: "--lvol-priority-class"
             help: "Logical volume priority class"
             dest: lvol-priority-class
-            required: true
             type: int
             default: 0
           - name: "--namespace"
             help: "Set logical volume namespace for k8s clients"
             dest: namespace
-            required: true
             type: str
           - name: "--uid"
             help: "Set logical volume id"
             dest: uid
-            required: true
             type: str
             private: true
           - name: "--pvc_name"
             help: "Set logical volume PVC name for k8s clients"
             dest: pvc_name
-            required: true
             type: str
       - name: qos-set
         help: "Changes QoS settings for an active logical volume"
@@ -1734,27 +1503,22 @@ commands:
           - name: "volume_id"
             help: "Logical volume id"
             dest: volume_id
-            required: true
             type: str
           - name: "--max-rw-iops"
             help: "Maximum Read Write IO Per Second"
             dest: max-rw-iops
-            required: true
             type: int
           - name: "--max-rw-mbytes"
             help: "Maximum Read Write Megabytes Per Second"
             dest: max-rw-mbytes
-            required: true
             type: int
           - name: "--max-r-mbytes"
             help: "Maximum Read Megabytes Per Second"
             dest: max-r-mbytes
-            required: true
             type: int
           - name: "--max-w-mbytes"
             help: "Maximum Write Megabytes Per Second"
             dest: max-w-mbytes
-            required: true
             type: int
       - name: list
         help: "Lists logical volumes"
@@ -1762,23 +1526,19 @@ commands:
           - name: "--cluster-id"
             help: "List logical volumes in particular cluster"
             dest: cluster_id
-            required: true
             type: str
           - name: "--pool"
             help: "List logical volumes in particular pool id or name"
             dest: pool
-            required: true
             type: str
           - name: "--json"
             help: "Print outputs in json format"
             dest: json
-            required: true
             type: bool
             action: store_true
           - name: "--all"
             help: "List soft deleted logical volumes"
             dest: all
-            required: true
             type: bool
             action: store_true
       - name: list-mem
@@ -1788,13 +1548,11 @@ commands:
           - name: "--json"
             help: "Print outputs in json format"
             dest: json
-            required: true
             type: bool
             action: store_true
           - name: "--csv"
             help: "Print outputs in csv format"
             dest: csv
-            required: true
             type: bool
             action: store_true
       - name: get
@@ -1803,12 +1561,10 @@ commands:
           - name: "volume_id"
             help: "Logical volume id or name"
             dest: volume_id
-            required: true
             type: str
           - name: "--json"
             help: "Print outputs in json format"
             dest: json
-            required: true
             type: bool
             action: store_true
       - name: delete
@@ -1821,13 +1577,11 @@ commands:
           - name: "volume_id"
             help: "Logical volumes id or ids"
             dest: volume_id
-            required: true
             type: str
             nargs: +
           - name: "--force"
             help: "Force delete logical volume from the cluster"
             dest: force
-            required: true
             type: bool
             action: store_true
       - name: connect
@@ -1837,7 +1591,6 @@ commands:
           - name: "volume_id"
             help: "Logical volume id"
             dest: volume_id
-            required: true
             type: str
       - name: resize
         help: "Resizes a logical volume"
@@ -1848,12 +1601,10 @@ commands:
           - name: "volume_id"
             help: "Logical volume id"
             dest: volume_id
-            required: true
             type: str
           - name: "size"
             help: "New logical volume size size: 10M, 10G, 10(bytes)"
             dest: size
-            required: true
             type: str
       - name: create-snapshot
         help: "Creates a snapshot from a logical volume"
@@ -1861,12 +1612,10 @@ commands:
           - name: "volume_id"
             help: "Logical volume id"
             dest: volume_id
-            required: true
             type: str
           - name: "name"
             help: "Snapshot name"
             dest: name
-            required: true
             type: str
       - name: clone
         help: "Provisions a logical volumes from an existing snapshot"
@@ -1874,17 +1623,14 @@ commands:
           - name: "snapshot_id"
             help: "Snapshot id"
             dest: snapshot_id
-            required: true
             type: str
           - name: "clone_name"
             help: "Clone name"
             dest: clone_name
-            required: true
             type: str
           - name: "--resize"
             help: "New logical volume size: 10M, 10G, 10(bytes). Can only increase."
             dest: resize
-            required: true
             type: str
       - name: move
         help: "Moves a full copy of the logical volume between nodes"
@@ -1893,17 +1639,14 @@ commands:
           - name: "volume_id"
             help: "Logical volume id"
             dest: volume_id
-            required: true
             type: str
           - name: "node_id"
             help: "Destination node id"
             dest: node_id
-            required: true
             type: str
           - name: "--force"
             help: "Force logical volume delete from source node"
             dest: force
-            required: true
             type: bool
             action: store_true
       - name: get-capacity
@@ -1912,12 +1655,10 @@ commands:
           - name: "volume_id"
             help: "Logical volume id"
             dest: volume_id
-            required: true
             type: str
           - name: "--history"
             help: "(XXdYYh), list history records (one for every 15 minutes) for XX days and YY hours (up to 10 days in total)."
             dest: history
-            required: true
             type: str
       - name: get-io-stats
         help: "Gets a logical volume's I/O statistics"
@@ -1925,17 +1666,14 @@ commands:
           - name: "volume_id"
             help: "Logical volume id"
             dest: volume_id
-            required: true
             type: str
           - name: "--history"
             help: "(XXdYYh), list history records (one for every 15 minutes) for XX days and YY hours (up to 10 days in total)."
             dest: history
-            required: true
             type: str
           - name: "--records"
             help: "Number of records, default: 20"
             dest: records
-            required: true
             type: int
             default: 20
       - name: check
@@ -1944,7 +1682,6 @@ commands:
           - name: "volume_id"
             help: "Logical volume id"
             dest: volume_id
-            required: true
             type: str
       - name: inflate
         help: "Inflate a logical volume"
@@ -1955,7 +1692,6 @@ commands:
           - name: "volume_id"
             help: "Cloned logical volume id"
             dest: volume_id
-            required: true
             type: str
   - name: "control-plane"
     help: "Control plane commands"
@@ -1970,22 +1706,18 @@ commands:
           - name: "cluster_ip"
             help: "Cluster IP address"
             dest: cluster_ip
-            required: true
             type: str
           - name: "cluster_id"
             help: "Cluster id"
             dest: cluster_id
-            required: true
             type: str
           - name: "cluster_secret"
             help: "Cluster secret"
             dest: cluster_secret
-            required: true
             type: str
           - name: "ifname"
             help: "Management interface name"
             dest: ifname
-            required: true
             type: str
       - name: list
         help: "Lists all control plane nodes"
@@ -1993,7 +1725,6 @@ commands:
           - name: "--json"
             help: "Print outputs in json format"
             dest: json
-            required: true
             type: bool
             action: store_true
       - name: remove
@@ -2002,7 +1733,6 @@ commands:
           - name: "node_id"
             help: "Control plane node id"
             dest: node_id
-            required: true
             type: str
   - name: "storage-pool"
     help: "Storage pool commands"
@@ -2016,49 +1746,40 @@ commands:
           - name: "name"
             help: "New pool name"
             dest: name
-            required: true
             type: str
           - name: "cluster_id"
             help: "Cluster id"
             dest: cluster_id
-            required: true
             type: str
           - name: "--pool-max"
             help: "Pool maximum size: 20M, 20G, 0. Default: 0"
             dest: pool-max
-            required: true
             type: str
             default: 0
           - name: "--lvol-max"
             help: "Logical volume maximum size: 20M, 20G, 0. Default: 0"
             dest: lvol-max
-            required: true
             type: str
             default: 0
           - name: "--max-rw-iops"
             help: "Maximum Read Write IO Per Second"
             dest: max-rw-iops
-            required: true
             type: int
           - name: "--max-rw-mbytes"
             help: "Maximum Read Write Megabytes Per Second"
             dest: max-rw-mbytes
-            required: true
             type: int
           - name: "--max-r-mbytes"
             help: "Maximum Read Megabytes Per Second"
             dest: max-r-mbytes
-            required: true
             type: int
           - name: "--max-w-mbytes"
             help: "Maximum Write Megabytes Per Second"
             dest: max-w-mbytes
-            required: true
             type: int
           - name: "--has-secret"
             help: "Pool is created with a secret (all further API interactions with the pool and logical volumes in the pool require this secret)"
             dest: has-secret
-            required: true
             type: bool
             action: store_true
             private: true
@@ -2068,37 +1789,30 @@ commands:
           - name: "pool_id"
             help: "Pool id"
             dest: pool_id
-            required: true
             type: str
           - name: "--pool-max"
             help: "Pool maximum size: 20M, 20G"
             dest: pool-max
-            required: true
             type: str
           - name: "--lvol-max"
             help: "Logical volume maximum size: 20M, 20G"
             dest: lvol-max
-            required: true
             type: str
           - name: "--max-rw-iops"
             help: "Maximum Read Write IO Per Second"
             dest: max-rw-iops
-            required: true
             type: int
           - name: "--max-rw-mbytes"
             help: "Maximum Read Write Megabytes Per Second"
             dest: max-rw-mbytes
-            required: true
             type: int
           - name: "--max-r-mbytes"
             help: "Maximum Read Megabytes Per Second"
             dest: max-r-mbytes
-            required: true
             type: int
           - name: "--max-w-mbytes"
             help: "Maximum Write Megabytes Per Second"
             dest: max-w-mbytes
-            required: true
             type: int
       - name: list
         help: "Lists all storage pools"
@@ -2106,13 +1820,11 @@ commands:
           - name: "--json"
             help: "Print outputs in json format"
             dest: json
-            required: true
             type: bool
             action: store_true
           - name: "--cluster-id"
             help: "Cluster id"
             dest: cluster_id
-            required: true
             type: str
       - name: get
         help: "Gets a storage pool's details"
@@ -2120,12 +1832,10 @@ commands:
           - name: "pool_id"
             help: "Pool id"
             dest: pool_id
-            required: true
             type: str
           - name: "--json"
             help: "Print outputs in json format"
             dest: json
-            required: true
             type: bool
             action: store_true
       - name: delete
@@ -2135,7 +1845,6 @@ commands:
           - name: "pool_id"
             help: "Pool id"
             dest: pool_id
-            required: true
             type: str
       - name: enable
         help: "Set a storage pool's status to Active"
@@ -2143,7 +1852,6 @@ commands:
           - name: "pool_id"
             help: "Pool id"
             dest: pool_id
-            required: true
             type: str
       - name: disable
         help: "Sets a storage pool's status to Inactive."
@@ -2151,7 +1859,6 @@ commands:
           - name: "pool_id"
             help: "Pool id"
             dest: pool_id
-            required: true
             type: str
       - name: get-capacity
         help: "Gets a storage pool's capacity"
@@ -2159,7 +1866,6 @@ commands:
           - name: "pool_id"
             help: "Pool id"
             dest: pool_id
-            required: true
             type: str
       - name: get-io-stats
         help: "Gets a storage pool's I/O statistics"
@@ -2167,17 +1873,14 @@ commands:
           - name: "pool_id"
             help: "Pool id"
             dest: pool_id
-            required: true
             type: str
           - name: "--history"
             help: "(XXdYYh), list history records (one for every 15 minutes) for XX days and YY hours (up to 10 days in total)."
             dest: history
-            required: true
             type: str
           - name: "--records"
             help: "Number of records, default: 20"
             dest: records
-            required: true
             type: str
             default: 20
   - name: "snapshot"
@@ -2190,12 +1893,10 @@ commands:
           - name: "snapshot_id"
             help: "Logical volume id"
             dest: snapshot_id
-            required: true
             type: str
           - name: "name"
             help: "New snapshot name"
             dest: name
-            required: true
             type: str
       - name: list
         help: "Lists all snapshots"
@@ -2203,7 +1904,6 @@ commands:
           - name: "--all"
             help: "List soft deleted snapshots"
             dest: all
-            required: true
             type: bool
             action: store_true
       - name: delete
@@ -2212,12 +1912,10 @@ commands:
           - name: "snapshot_id"
             help: "Snapshot id"
             dest: snapshot_id
-            required: true
             type: str
           - name: "--force"
             help: "Force remove"
             dest: force
-            required: true
             type: bool
             action: store_true
       - name: clone
@@ -2226,17 +1924,14 @@ commands:
           - name: "snapshot_id"
             help: "Snapshot id"
             dest: snapshot_id
-            required: true
             type: str
           - name: "lvol_name"
             help: "Logical volume name"
             dest: lvol_name
-            required: true
             type: str
           - name: "--resize"
             help: "New logical volume size: 10M, 10G, 10(bytes)"
             dest: resize
-            required: true
             type: str
   - name: "caching-node"
     help: "Caching node commands"
@@ -2250,7 +1945,6 @@ commands:
           - name: "--ifname"
             help: "Management interface name, e.g. eth0"
             dest: ifname
-            required: true
             type: str
       - name: add-node
         help: "Adds a new caching node to the cluster"
@@ -2258,52 +1952,43 @@ commands:
           - name: "cluster_id"
             help: "Cluster id"
             dest: cluster_id
-            required: true
             type: str
           - name: "node_ip"
             help: "Node IP address"
             dest: node_ip
-            required: true
             type: str
           - name: "ifname"
             help: "Management interface name"
             dest: ifname
-            required: true
             type: str
           - name: "--vcpu-count"
             help: >
               Number of vCPUs used for SPDK. Remaining CPUs will be used for Linux system, TCP/IP processing, and
               other workloads. The default on non-Kubernetes hosts is 80%.
             dest: vcpu_count
-            required: true
             type: int
           - name: "--cpu-mask"
             help: "SPDK app CPU mask, default is all cores found"
             dest: spdk_cpu_mask
-            required: true
             type: str
             private: true
           - name: "--memory"
             help: "SPDK huge memory allocation. By default it will acquire all available huge pages."
             dest: spdk_mem
-            required: true
             type: int
             private: true
           - name: "--spdk-image"
             help: "SPDK image uri"
             dest: spdk_image
-            required: true
             type: str
             private: true
           - name: "--namespace"
             help: "k8s namespace to deploy on"
             dest: namespace
-            required: true
             type: str
           - name: "--multipathing"
             help: "Enable multipathing for logical volume connection, default: on"
             dest: multipathing
-            required: true
             type: str
             choices:
               - "on"
@@ -2317,7 +2002,6 @@ commands:
           - name: "node_id"
             help: "Caching node id"
             dest: node_id
-            required: true
             type: str
       - name: remove
         help: "Removes a caching node from the cluster"
@@ -2325,12 +2009,10 @@ commands:
           - name: "node_id"
             help: "Caching node id"
             dest: node_id
-            required: true
             type: str
           - name: "--force"
             help: "Force remove"
             dest: force
-            required: true
             type: bool
             action: store_true
       - name: connect
@@ -2339,12 +2021,10 @@ commands:
           - name: "node_id"
             help: "Caching node id"
             dest: node_id
-            required: true
             type: str
           - name: "lvol_id"
             help: "Logical volume id"
             dest: lvol_id
-            required: true
             type: str
       - name: disconnect
         help: "Disconnects a logical volume from the caching node"
@@ -2352,12 +2032,10 @@ commands:
           - name: "node_id"
             help: "Caching node id"
             dest: node_id
-            required: true
             type: str
           - name: "lvol_id"
             help: "Logical volume id"
             dest: lvol_id
-            required: true
             type: str
       - name: recreate
         help: "Recreate a caching node's bdevs"
@@ -2365,7 +2043,6 @@ commands:
           - name: "node_id"
             help: "Caching node id"
             dest: node_id
-            required: true
             type: str
       - name: get-lvol-stats
         help: "Gets a logical volume's statistics"
@@ -2373,10 +2050,8 @@ commands:
           - name: "lvol_id"
             help: "Logical volume id"
             dest: lvol_id
-            required: true
             type: str
           - name: "--history"
             help: "(XXdYYh), list history records (one for every 15 minutes) for XX days and YY hours (up to 10 days in total)."
             dest: history
-            required: true
             type: str

--- a/cli-reference.yaml
+++ b/cli-reference.yaml
@@ -70,7 +70,6 @@ commands:
               _150 TiB / 3 * 2 = 100TiB_ would be a safe choice.
             dest: max_prov
             type: str
-            default: ""
           - name: "--number-of-distribs"
             help: "The number of distirbs to be created on the node"
             dest: number_of_distribs
@@ -704,12 +703,10 @@ commands:
             help: "Email or slack webhook url to be used for alerting"
             dest: contact_point
             type: str
-            default: 
           - name: "--grafana-endpoint"
             help: "Endpoint url for Grafana"
             dest: grafana_endpoint
             type: str
-            default: 
             private: true
           - name: "--distr-bs"
             help: "(Dev) distrb bdev block size, default: 4096"
@@ -1036,12 +1033,10 @@ commands:
             help: "Email or slack webhook url to be used for alerting"
             dest: contact_point
             type: str
-            default: 
           - name: "--grafana-endpoint"
             help: "Endpoint url for Grafana"
             dest: grafana_endpoint
             type: str
-            default: 
           - name: "--data-chunks-per-stripe"
             help: "Erasure coding schema parameter k (distributed raid), default: 1"
             dest: distr_ndcs
@@ -1428,7 +1423,6 @@ commands:
             help: "Logical volume max size"
             dest: max_size
             type: str
-            default: ""
           - name: "--host-id"
             help: "Primary storage node id or Hostname"
             dest: host_id

--- a/scripts/cli-wrapper-gen.py
+++ b/scripts/cli-wrapper-gen.py
@@ -28,7 +28,13 @@ def required(item):
         return False
     elif "default" in item:
         return False
-    return True
+    elif "private" in item and item["private"]:
+        return False
+    elif "required" in item and item["required"]:
+        return True
+    elif not item["name"].startswith("--"):
+        return True
+    return False
 
 
 def data_type_name(item):
@@ -131,6 +137,8 @@ with open("%s/cli-reference.yaml" % base_path) as stream:
         output = template.render({"commands": reference["commands"]})
         with open("%s/simplyblock_cli/cli.py" % base_path, "t+w") as target:
             target.write(output)
+
+        print("Successfully generated cli.py")
 
     except yaml.YAMLError as exc:
         print(exc)

--- a/scripts/cli-wrapper.jinja2
+++ b/scripts/cli-wrapper.jinja2
@@ -77,8 +77,6 @@ class CLIWrapper(CLIWrapperBase):
 
         logging.getLogger("urllib3.connectionpool").setLevel(logging.WARNING)
 
-        developer_mode = True if args.dev else False
-
         ret = ""
         args_dict = args.__dict__
 
@@ -87,8 +85,13 @@ class CLIWrapper(CLIWrapperBase):
             sub_command = args_dict['{{ command.name }}']
 {%- for subcommand in command.subcommands %}
             if sub_command in ['{{ subcommand.name }}'{% if subcommand.aliases is defined %}{% for alias in subcommand.aliases %}, '{{ alias }}'{% endfor %}{% endif %}]:
+{%- for argument in subcommand.arguments -%}
+{%- if argument.dest is defined and argument.dest != argument.name %}
+                args.{{ argument.dest }} = args.{{ argument.name }}
+{%- endif -%}
+{%- endfor -%}
 {%- if subcommand.private %}
-                if not developer_mode:
+                if not self.developer_mode:
                     print("This command is private.")
                     ret = False
                 else:

--- a/simplyblock_cli/cli.py
+++ b/simplyblock_cli/cli.py
@@ -66,7 +66,7 @@ class CLIWrapper(CLIWrapperBase):
 
     def init_storage_node__deploy(self, subparser):
         subcommand = self.add_sub_command(subparser, 'deploy', 'Prepares a host to be used as a storage node')
-        argument = subcommand.add_argument('--ifname', help='Management interface name, e.g. eth0', type=str, dest='ifname', required=True)
+        argument = subcommand.add_argument('--ifname', help='Management interface name, e.g. eth0', type=str, dest='ifname', required=False)
 
     def init_storage_node__deploy_cleaner(self, subparser):
         subcommand = self.add_sub_command(subparser, 'deploy-cleaner', 'Cleans a previous simplyblock deploy (local run)')
@@ -76,22 +76,23 @@ class CLIWrapper(CLIWrapperBase):
         subcommand.add_argument('cluster_id', help='Cluster id', type=str)
         subcommand.add_argument('node_ip', help='IP of storage node to add', type=str)
         subcommand.add_argument('ifname', help='Management interface name', type=str)
-        argument = subcommand.add_argument('--partitions', help='Number of partitions to create per device', type=int, default=1, dest='partitions', required=False)
+        argument = subcommand.add_argument('--journal-partition', help='1: auto-create small partitions for journal on nvme devices. 0: use a separate (the smallest) nvme device of the node for journal. The journal needs a maximum of 3 percent of total available raw disk space.', type=int, default=1, dest='partitions', required=False)
         if self.developer_mode:
             argument = subcommand.add_argument('--jm-percent', help='Number in percent to use for JM from each device', type=str, default='3', dest='jm_percent', required=False)
-        argument = subcommand.add_argument('--storage-nics', help='Storage network interface name(s). Can be more than one.', type=str, dest='data_nics', required=True, nargs='+')
-        argument = subcommand.add_argument('--max-lvol', help='Max logical volume per storage node', type=int, dest='max_lvol', required=True)
-        argument = subcommand.add_argument('--max-size', help='Maximum amount of GB to be utilized on this storage node', type=str, default='', dest='max_prov', required=False)
-        argument = subcommand.add_argument('--number-of-distribs', help='The number of distirbs to be created on the node', type=int, default=2, dest='number_of_distribs', required=False)
+        argument = subcommand.add_argument('--data-nics', help='Storage network interface name(s). Can be more than one.', type=str, dest='data_nics', required=False, nargs='+')
+        argument = subcommand.add_argument('--max-lvol', help='Max logical volume per storage node', type=int, dest='max_lvol', required=False)
+        argument = subcommand.add_argument('--max-size', help='Maximum amount of GB to be utilized on this storage node', type=str, dest='max_prov', required=False)
         if self.developer_mode:
-            argument = subcommand.add_argument('--number-of-devices', help='Number of devices per storage node if it\'s not supported EC2 instance', type=str, dest='number_of_devices', required=True)
+            argument = subcommand.add_argument('--number-of-distribs', help='The number of distirbs to be created on the node', type=int, default=4, dest='number_of_distribs', required=False)
         if self.developer_mode:
-            argument = subcommand.add_argument('--size-of-device', help='Size of device per storage node', type=str, dest='partition_size', required=True)
-        argument = subcommand.add_argument('--number-of-vcpus', help='Number of vCPUs used for SPDK. Remaining CPUs will be used for Linux system, TCP/IP processing, and other workloads. The default on non-Kubernetes hosts is 80%.', type=int, dest='vcpu_count', required=True)
+            argument = subcommand.add_argument('--number-of-devices', help='Number of devices per storage node if it\'s not supported EC2 instance', type=str, dest='number_of_devices', required=False)
         if self.developer_mode:
-            argument = subcommand.add_argument('--cpu-mask', help='SPDK app CPU mask, default is all cores found', type=str, dest='spdk_cpu_mask', required=True)
+            argument = subcommand.add_argument('--size-of-device', help='Size of device per storage node', type=str, dest='partition_size', required=False)
+        argument = subcommand.add_argument('--vcpu-count', help='Number of vCPUs used for SPDK. Remaining CPUs will be used for Linux system, TCP/IP processing, and other workloads. The default on non-Kubernetes hosts is 80%.', type=int, dest='vcpu_count', required=False)
         if self.developer_mode:
-            argument = subcommand.add_argument('--spdk-image', help='SPDK image uri', type=str, dest='spdk_image', required=True)
+            argument = subcommand.add_argument('--cpu-mask', help='SPDK app CPU mask, default is all cores found', type=str, dest='spdk_cpu_mask', required=False)
+        if self.developer_mode:
+            argument = subcommand.add_argument('--spdk-image', help='SPDK image uri', type=str, dest='spdk_image', required=False)
         if self.developer_mode:
             argument = subcommand.add_argument('--spdk-debug', help='Enable spdk debug logs', dest='spdk_debug', required=False, action='store_true')
         if self.developer_mode:
@@ -99,13 +100,13 @@ class CLIWrapper(CLIWrapperBase):
         if self.developer_mode:
             argument = subcommand.add_argument('--iobuf_large_bufsize', help='bdev_set_options param', type=str, default='0', dest='large_bufsize', required=False)
         if self.developer_mode:
-            argument = subcommand.add_argument('--enable-test-device', help='Enable creation of test device', dest='enable-test-device', required=False, action='store_true')
+            argument = subcommand.add_argument('--enable-test-device', help='Enable creation of test device', dest='enable_test_device', required=False, action='store_true')
         if self.developer_mode:
             argument = subcommand.add_argument('--disable-ha-jm', help='Disable HA JM for distrib creation', dest='enable_ha_jm', required=False, action='store_false')
         if self.developer_mode:
             argument = subcommand.add_argument('--ha-jm-count', help='HA JM count', type=str, default='3', dest='ha_jm_count', required=False)
         argument = subcommand.add_argument('--is-secondary-node', help='Adds as secondary node. A secondary node does not have any disks attached. It is only used for I/O processing in case a primary goes down.', dest='is_secondary_node', required=False, action='store_true')
-        argument = subcommand.add_argument('--namespace', help='Kubernetes namespace to deploy on', type=str, dest='namespace', required=True)
+        argument = subcommand.add_argument('--namespace', help='Kubernetes namespace to deploy on', type=str, dest='namespace', required=False)
         if self.developer_mode:
             argument = subcommand.add_argument('--id-device-by-nqn', help='Use device nqn to identify it instead of serial number', dest='id_device_by_nqn', required=False, action='store_true')
 
@@ -120,7 +121,7 @@ class CLIWrapper(CLIWrapperBase):
 
     def init_storage_node__list(self, subparser):
         subcommand = self.add_sub_command(subparser, 'list', 'Lists all storage nodes')
-        argument = subcommand.add_argument('--cluster-id', help='Cluster id', type=str, dest='cluster_id', required=True)
+        argument = subcommand.add_argument('--cluster-id', help='Cluster id', type=str, dest='cluster_id', required=False)
         argument = subcommand.add_argument('--json', help='Print outputs in json format', dest='json', required=False, action='store_true')
 
     def init_storage_node__get(self, subparser):
@@ -133,12 +134,13 @@ class CLIWrapper(CLIWrapperBase):
         argument = subcommand.add_argument('--max-lvol', help='Max logical volume per storage node', type=int, default=0, dest='max_lvol', required=False)
         if self.developer_mode:
             argument = subcommand.add_argument('--max-snap', help='Max snapshot per storage node', type=str, default='0', dest='max_snap', required=False)
-        argument = subcommand.add_argument('--max-size', help='Maximum amount of GB to be utilized on this storage node', type=str, default='None', dest='max_prov', required=False)
-        argument = subcommand.add_argument('--node-ip', help='Restart Node on new node', type=str, dest='node_ip', required=True)
+        if self.developer_mode:
+            argument = subcommand.add_argument('--max-size', help='Maximum amount of GB to be utilized on this storage node', type=str, default='None', dest='max_prov', required=False)
+        argument = subcommand.add_argument('--node-ip', help='Restart Node on new node', type=str, dest='node_ip', required=False)
         if self.developer_mode:
             argument = subcommand.add_argument('--number-of-devices', help='Number of devices per storage node if it\'s not supported EC2 instance', type=str, default='0', dest='number_of_devices', required=False)
         if self.developer_mode:
-            argument = subcommand.add_argument('--spdk-image', help='SPDK image uri', type=str, dest='spdk_image', required=True)
+            argument = subcommand.add_argument('--spdk-image', help='SPDK image uri', type=str, dest='spdk_image', required=False)
         if self.developer_mode:
             argument = subcommand.add_argument('--spdk-debug', help='Enable spdk debug logs', dest='spdk_debug', required=False, action='store_true')
         if self.developer_mode:
@@ -164,13 +166,13 @@ class CLIWrapper(CLIWrapperBase):
     def init_storage_node__get_io_stats(self, subparser):
         subcommand = self.add_sub_command(subparser, 'get-io-stats', 'Get node IO statistics')
         subcommand.add_argument('node_id', help='Storage node id', type=str).completer = self._completer_get_sn_list
-        argument = subcommand.add_argument('--history', help='list history records -one for every 15 minutes- for XX days and YY hours -up to 10 days in total-, format: XXdYYh', type=str, dest='history', required=True)
+        argument = subcommand.add_argument('--history', help='list history records -one for every 15 minutes- for XX days and YY hours -up to 10 days in total-, format: XXdYYh', type=str, dest='history', required=False)
         argument = subcommand.add_argument('--records', help='Number of records, default: 20', type=str, default='20', dest='records', required=False)
 
     def init_storage_node__get_capacity(self, subparser):
         subcommand = self.add_sub_command(subparser, 'get-capacity', 'Gets a storage node\'s capacity statistics')
         subcommand.add_argument('node_id', help='Storage node id', type=str).completer = self._completer_get_sn_list
-        argument = subcommand.add_argument('--history', help='list history records -one for every 15 minutes- for XX days and YY hours -up to 10 days in total-, format: XXdYYh', type=str, dest='history', required=True)
+        argument = subcommand.add_argument('--history', help='list history records -one for every 15 minutes- for XX days and YY hours -up to 10 days in total-, format: XXdYYh', type=str, dest='history', required=False)
 
     def init_storage_node__list_devices(self, subparser):
         subcommand = self.add_sub_command(subparser, 'list-devices', 'Lists storage devices')
@@ -211,12 +213,12 @@ class CLIWrapper(CLIWrapperBase):
     def init_storage_node__get_capacity_device(self, subparser):
         subcommand = self.add_sub_command(subparser, 'get-capacity-device', 'Gets a device\'s capacity')
         subcommand.add_argument('device_id', help='Device id', type=str)
-        argument = subcommand.add_argument('--history', help='list history records -one for every 15 minutes- for XX days and YY hours -up to 10 days in total-, format: XXdYYh', type=str, dest='history', required=True)
+        argument = subcommand.add_argument('--history', help='list history records -one for every 15 minutes- for XX days and YY hours -up to 10 days in total-, format: XXdYYh', type=str, dest='history', required=False)
 
     def init_storage_node__get_io_stats_device(self, subparser):
         subcommand = self.add_sub_command(subparser, 'get-io-stats-device', 'Gets a device\'s IO statistics')
         subcommand.add_argument('device_id', help='Device id', type=str)
-        argument = subcommand.add_argument('--history', help='list history records -one for every 15 minutes- for XX days and YY hours -up to 10 days in total-, format: XXdYYh', type=str, dest='history', required=True)
+        argument = subcommand.add_argument('--history', help='list history records -one for every 15 minutes- for XX days and YY hours -up to 10 days in total-, format: XXdYYh', type=str, dest='history', required=False)
         argument = subcommand.add_argument('--records', help='Number of records, default: 20', type=str, default='20', dest='records', required=False)
 
     def init_storage_node__port_list(self, subparser):
@@ -226,7 +228,7 @@ class CLIWrapper(CLIWrapperBase):
     def init_storage_node__port_io_stats(self, subparser):
         subcommand = self.add_sub_command(subparser, 'port-io-stats', 'Gets the data interfaces\' IO stats')
         subcommand.add_argument('port_id', help='Data port id', type=str)
-        argument = subcommand.add_argument('--history', help='list history records -one for every 15 minutes- for XX days and YY hours -up to 10 days in total, format: XXdYYh', type=str, dest='history', required=True)
+        argument = subcommand.add_argument('--history', help='list history records -one for every 15 minutes- for XX days and YY hours -up to 10 days in total, format: XXdYYh', type=str, dest='history', required=False)
 
     def init_storage_node__check(self, subparser):
         subcommand = self.add_sub_command(subparser, 'check', 'Checks the health status of a storage node')
@@ -299,61 +301,61 @@ class CLIWrapper(CLIWrapperBase):
 
     def init_cluster__deploy(self, subparser):
         subcommand = self.add_sub_command(subparser, 'deploy', 'Deploys a storage nodes')
-        argument = subcommand.add_argument('--storage-nodes', help='comma separated ip addresses', type=str, dest='storage_nodes', required=True)
+        argument = subcommand.add_argument('--storage-nodes', help='comma separated ip addresses', type=str, dest='storage_nodes', required=False)
         argument = subcommand.add_argument('--test', help='Test Cluster', dest='test', required=False, action='store_true')
-        argument = subcommand.add_argument('--secondary-nodes', help='comma separated ip addresses', type=str, dest='secondary_nodes', required=True)
+        argument = subcommand.add_argument('--secondary-nodes', help='comma separated ip addresses', type=str, dest='secondary_nodes', required=False)
         argument = subcommand.add_argument('--ha-type', help='Logical volume HA type (single, ha), default is cluster HA type', type=str, default='single', dest='ha_type', required=False, choices=['single','ha',])
         if self.developer_mode:
             argument = subcommand.add_argument('--ha-jm-count', help='HA JM count', type=str, default='3', dest='ha_jm_count', required=False)
-        argument = subcommand.add_argument('--data-chunks-per-stripe', help='Erasure coding schema parameter k (distributed raid), default: 1', type=int, default=1, dest='distr-ndcs', required=False)
-        argument = subcommand.add_argument('--parity-chunks-per-stripe', help='Erasure coding schema parameter n (distributed raid), default: 1', type=int, default=1, dest='distr-npcs', required=False)
+        argument = subcommand.add_argument('--data-chunks-per-stripe', help='Erasure coding schema parameter k (distributed raid), default: 1', type=int, default=1, dest='distr_ndcs', required=False)
+        argument = subcommand.add_argument('--parity-chunks-per-stripe', help='Erasure coding schema parameter n (distributed raid), default: 1', type=int, default=1, dest='distr_npcs', required=False)
         if self.developer_mode:
             argument = subcommand.add_argument('--enable-qos', help='Enable qos bdev for storage nodes', dest='enable_qos', required=False, action='store_true')
-        argument = subcommand.add_argument('--ifname', help='Management interface name, e.g. eth0', type=str, dest='ifname', required=True)
+        argument = subcommand.add_argument('--ifname', help='Management interface name, e.g. eth0', type=str, dest='ifname', required=False)
         if self.developer_mode:
             argument = subcommand.add_argument('--blk_size', help='The block size in bytes', type=str, default='512', dest='blk_size', required=False, choices=['512','4096',])
         if self.developer_mode:
             argument = subcommand.add_argument('--page_size', help='The size of a data page in bytes', type=str, default='2097152', dest='page_size', required=False)
         if self.developer_mode:
-            argument = subcommand.add_argument('--CLI_PASS', help='Password for CLI SSH connection', type=str, dest='CLI_PASS', required=True)
+            argument = subcommand.add_argument('--CLI_PASS', help='Password for CLI SSH connection', type=str, dest='CLI_PASS', required=False)
         argument = subcommand.add_argument('--cap-warn', help='Capacity warning level in percent, default: 89', type=int, default=89, dest='cap_warn', required=False)
         argument = subcommand.add_argument('--cap-crit', help='Capacity critical level in percent, default: 99', type=int, default=99, dest='cap_crit', required=False)
         argument = subcommand.add_argument('--prov-cap-warn', help='Capacity warning level in percent, default: 250', type=int, default=250, dest='prov_cap_warn', required=False)
         argument = subcommand.add_argument('--prov-cap-crit', help='Capacity critical level in percent, default: 500', type=int, default=500, dest='prov_cap_crit', required=False)
         argument = subcommand.add_argument('--log-del-interval', help='Logging retention period, default: 3d', type=str, default='3d', dest='log_del_interval', required=False)
         argument = subcommand.add_argument('--metrics-retention-period', help='Retention period for I/O statistics (Prometheus), default: 7d', type=str, default='7d', dest='metrics_retention_period', required=False)
-        argument = subcommand.add_argument('--contact-point', help='Email or slack webhook url to be used for alerting', type=str, default='None', dest='contact_point', required=False)
-        argument = subcommand.add_argument('--grafana-endpoint', help='Endpoint url for Grafana', type=str, default='None', dest='grafana_endpoint', required=False)
+        argument = subcommand.add_argument('--contact-point', help='Email or slack webhook url to be used for alerting', type=str, dest='contact_point', required=False)
         if self.developer_mode:
-            argument = subcommand.add_argument('--distr-bs', help='(Dev) distrb bdev block size, default: 4096', type=str, default='4096', dest='distr-bs', required=False)
+            argument = subcommand.add_argument('--grafana-endpoint', help='Endpoint url for Grafana', type=str, dest='grafana_endpoint', required=False)
         if self.developer_mode:
-            argument = subcommand.add_argument('--distr-chunk-bs', help='(Dev) distrb bdev chunk block size, default: 4096', type=str, default='4096', dest='distr-chunk-bs', required=False)
-        argument = subcommand.add_argument('--enable-node-affinity', help='Enable node affinity for storage nodes', dest='enable-node-affinity', required=False, action='store_true')
-        argument = subcommand.add_argument('--qpair-count', help='NVMe/TCP transport qpair count per logical volume', type=int, default=0, dest='qpair_count', required=False, choices=range(0, 128))
+            argument = subcommand.add_argument('--distr-bs', help='(Dev) distrb bdev block size, default: 4096', type=str, default='4096', dest='distr_bs', required=False)
+        argument = subcommand.add_argument('--chunk-size-in-bytes', help='(Dev) distrb bdev chunk block size, default: 4096', type=str, default='4096', dest='distr_chunk_bs', required=False)
+        argument = subcommand.add_argument('--enable-node-affinity', help='Enable node affinity for storage nodes', dest='enable_node_affinity', required=False, action='store_true')
+        argument = subcommand.add_argument('--qpair-count', help='NVMe/TCP transport qpair count per logical volume', type=int, default=3, dest='qpair_count', required=False, choices=range(1, 128))
         if self.developer_mode:
-            argument = subcommand.add_argument('--max-queue-size', help='The max size the queue will grow', type=str, default='128', dest='max-queue-size', required=False)
+            argument = subcommand.add_argument('--max-queue-size', help='The max size the queue will grow', type=str, default='128', dest='max_queue_size', required=False)
         if self.developer_mode:
-            argument = subcommand.add_argument('--inflight-io-threshold', help='The number of inflight IOs allowed before the IO queuing starts', type=str, default='4', dest='inflight-io-threshold', required=False)
-        argument = subcommand.add_argument('--strict-node-anti-affinity', help='Enable strict node anti affinity for storage nodes. Never more than one chunk is placed on a node. This requires a minimum of _data-chunks-in-stripe + parity-chunks-in-stripe + 1_ nodes in the cluster."', dest='strict-node-anti-affinity', required=False, action='store_true')
-        argument = subcommand.add_argument('--separate-journal-device', help='Enables a separate journaling devices. Set to true, if separate NVMe device is available to store journal. The smallest NVMe device available on the host will be chosen as a journal. It should provide about 3% of the entire node’s NVMe capacity. If set to false, partitions on other devices will be auto-created to store the journal.', type=bool, default=False, dest='partitions', required=False)
+            argument = subcommand.add_argument('--inflight-io-threshold', help='The number of inflight IOs allowed before the IO queuing starts', type=str, default='4', dest='inflight_io_threshold', required=False)
+        argument = subcommand.add_argument('--strict-node-anti-affinity', help='Enable strict node anti affinity for storage nodes. Never more than one chunk is placed on a node. This requires a minimum of _data-chunks-in-stripe + parity-chunks-in-stripe + 1_ nodes in the cluster."', dest='strict_node_anti_affinity', required=False, action='store_true')
+        argument = subcommand.add_argument('--journal-partition', help='1: auto-partition nvme devices for journal. 0: use a separate nvme device for journal. The smallest NVMe device available on the host will be chosen as a journal. It should provide about 3% of the entire node’s NVMe capacity. If set to false, partitions on other devices will be auto-created to store the journal.', type=str, default='True', dest='partitions', required=False)
         if self.developer_mode:
             argument = subcommand.add_argument('--jm-percent', help='Number in percent to use for JM from each device', type=str, default='3', dest='jm_percent', required=False)
-        argument = subcommand.add_argument('--storage-nics', help='Storage network interface name(s). Can be more than one.', type=str, dest='data_nics', required=True, nargs='+')
-        argument = subcommand.add_argument('--max-lvol', help='Max logical volume per storage node', type=int, dest='max_lvol', required=True)
+        argument = subcommand.add_argument('--data-nics', help='Storage network interface name(s). Can be more than one.', type=str, dest='data_nics', required=False, nargs='+')
+        argument = subcommand.add_argument('--max-lvol', help='Max logical volume per storage node', type=int, dest='max_lvol', required=False)
         if self.developer_mode:
             argument = subcommand.add_argument('--max-snap', help='Max snapshot per storage node', type=str, default='500', dest='max_snap', required=False)
         argument = subcommand.add_argument('--max-size', help='Maximum amount of GB to be provisioned via all storage nodes', type=str, default='', dest='max_prov', required=False)
         if self.developer_mode:
-            argument = subcommand.add_argument('--number-of-distribs', help='The number of distirbs to be created on the node', type=str, default='2', dest='number_of_distribs', required=False)
+            argument = subcommand.add_argument('--number-of-distribs', help='The number of distirbs to be created on the node', type=str, default='4', dest='number_of_distribs', required=False)
         if self.developer_mode:
-            argument = subcommand.add_argument('--number-of-devices', help='Number of devices per storage node if it\'s not supported EC2 instance', type=str, dest='number_of_devices', required=True)
+            argument = subcommand.add_argument('--number-of-devices', help='Number of devices per storage node if it\'s not supported EC2 instance', type=str, dest='number_of_devices', required=False)
         if self.developer_mode:
-            argument = subcommand.add_argument('--size-of-device', help='Size of device per storage node', type=str, dest='partition_size', required=True)
-        argument = subcommand.add_argument('--number-of-vcpus', help='Number of vCPUs used for SPDK. Remaining CPUs will be used for Linux system, TCP/IP processing, and other workloads. The default on non-Kubernetes hosts is 80%.', type=int, dest='vcpu_count', required=True)
+            argument = subcommand.add_argument('--size-of-device', help='Size of device per storage node', type=str, dest='partition_size', required=False)
+        argument = subcommand.add_argument('--vcpu-count', help='Number of vCPUs used for SPDK. Remaining CPUs will be used for Linux system, TCP/IP processing, and other workloads. The default on non-Kubernetes hosts is 80%.', type=int, dest='vcpu_count', required=False)
         if self.developer_mode:
-            argument = subcommand.add_argument('--cpu-mask', help='SPDK app CPU mask, default is all cores found', type=str, dest='spdk_cpu_mask', required=True)
+            argument = subcommand.add_argument('--cpu-mask', help='SPDK app CPU mask, default is all cores found', type=str, dest='spdk_cpu_mask', required=False)
         if self.developer_mode:
-            argument = subcommand.add_argument('--spdk-image', help='SPDK image uri', type=str, dest='spdk_image', required=True)
+            argument = subcommand.add_argument('--spdk-image', help='SPDK image uri', type=str, dest='spdk_image', required=False)
         if self.developer_mode:
             argument = subcommand.add_argument('--spdk-debug', help='Enable spdk debug logs', dest='spdk_debug', required=False, action='store_true')
         if self.developer_mode:
@@ -361,64 +363,79 @@ class CLIWrapper(CLIWrapperBase):
         if self.developer_mode:
             argument = subcommand.add_argument('--iobuf_large_bufsize', help='bdev_set_options param', type=str, default='0', dest='large_bufsize', required=False)
         if self.developer_mode:
-            argument = subcommand.add_argument('--enable-test-device', help='Enable creation of test device', dest='enable-test-device', required=False, action='store_true')
+            argument = subcommand.add_argument('--enable-test-device', help='Enable creation of test device', dest='enable_test_device', required=False, action='store_true')
         if self.developer_mode:
             argument = subcommand.add_argument('--disable-ha-jm', help='Disable HA JM for distrib creation', dest='enable_ha_jm', required=False, action='store_false')
         argument = subcommand.add_argument('--is-secondary-node', help='Adds as secondary node. A secondary node does not have any disks attached. It is only used for I/O processing in case a primary goes down.', dest='is_secondary_node', required=False, action='store_true')
-        argument = subcommand.add_argument('--namespace', help='k8s namespace to deploy on', type=str, dest='namespace', required=True)
+        argument = subcommand.add_argument('--namespace', help='k8s namespace to deploy on', type=str, dest='namespace', required=False)
         argument = subcommand.add_argument('--id-device-by-nqn', help='Use device nqn to identify it instead of serial number', dest='id_device_by_nqn', required=False, action='store_true')
-        argument = subcommand.add_argument('--lvol-name', help='Logical volume name or id', type=str, dest='lvol_name', required=True)
-        argument = subcommand.add_argument('--lvol-size', help='Logical volume size: 10M, 10G, 10(bytes)', type=str, dest='lvol_size', required=True)
-        argument = subcommand.add_argument('--pool-name', help='Pool id or name', type=str, dest='pool_name', required=True)
-        argument = subcommand.add_argument('--pool-max', help='Pool maximum size: 20M, 20G, 0(default)', type=str, default='0', dest='pool-max', required=False)
-        argument = subcommand.add_argument('--snapshot', help='Make logical volume with snapshot capability, default: false', dest='snapshot', required=False, action='store_true')
-        argument = subcommand.add_argument('--max-volume-size', help='Logical volume max size', type=str, default='', dest='max_size', required=False)
-        argument = subcommand.add_argument('--host-id', help='Primary storage node id or hostname', type=str, dest='host_id', required=True)
-        argument = subcommand.add_argument('--encrypt', help='Use inline data encryption and decryption on the logical volume', dest='encrypt', required=False, action='store_true')
-        argument = subcommand.add_argument('--crypto-key1', help='Hex value of key1 to be used for logical volume encryption', type=str, dest='crypto_key1', required=True)
-        argument = subcommand.add_argument('--crypto-key2', help='Hex value of key2 to be used for logical volume encryption', type=str, dest='crypto_key2', required=True)
-        argument = subcommand.add_argument('--max-rw-iops', help='Maximum Read Write IO Per Second', type=int, dest='max-rw-iops', required=True)
-        argument = subcommand.add_argument('--max-rw-mbytes', help='Maximum Read Write Megabytes Per Second', type=int, dest='max-rw-mbytes', required=True)
-        argument = subcommand.add_argument('--max-r-mbytes', help='Maximum Read Megabytes Per Second', type=int, dest='max-r-mbytes', required=True)
-        argument = subcommand.add_argument('--max-w-mbytes', help='Maximum Write Megabytes Per Second', type=int, dest='max-w-mbytes', required=True)
         if self.developer_mode:
-            argument = subcommand.add_argument('--distr-vuid', help='(Dev) set vuid manually, default: random (1-99999)', type=str, default='0', dest='distr-vuid', required=False)
+            argument = subcommand.add_argument('--lvol-name', help='Logical volume name or id', type=str, default='lvol01', dest='lvol_name', required=False)
+        if self.developer_mode:
+            argument = subcommand.add_argument('--lvol-size', help='Logical volume size: 10M, 10G, 10(bytes)', type=str, default='10G', dest='lvol_size', required=False)
+        if self.developer_mode:
+            argument = subcommand.add_argument('--pool-name', help='Pool id or name', type=str, default='pool01', dest='pool_name', required=False)
+        if self.developer_mode:
+            argument = subcommand.add_argument('--pool-max', help='Pool maximum size: 20M, 20G, 0(default)', type=str, default='25G', dest='pool_max', required=False)
+        if self.developer_mode:
+            argument = subcommand.add_argument('--snapshot', help='Make logical volume with snapshot capability, default: false', dest='snapshot', required=False, action='store_true')
+        if self.developer_mode:
+            argument = subcommand.add_argument('--max-volume-size', help='Logical volume max size', type=str, default='1000G', dest='max_size', required=False)
+        argument = subcommand.add_argument('--host-id', help='Primary storage node id or hostname', type=str, dest='host_id', required=False)
+        if self.developer_mode:
+            argument = subcommand.add_argument('--encrypt', help='Use inline data encryption and decryption on the logical volume', dest='encrypt', required=False, action='store_true')
+        if self.developer_mode:
+            argument = subcommand.add_argument('--crypto-key1', help='Hex value of key1 to be used for logical volume encryption', type=str, dest='crypto_key1', required=False)
+        if self.developer_mode:
+            argument = subcommand.add_argument('--crypto-key2', help='Hex value of key2 to be used for logical volume encryption', type=str, dest='crypto_key2', required=False)
+        if self.developer_mode:
+            argument = subcommand.add_argument('--max-rw-iops', help='Maximum Read Write IO Per Second', type=int, dest='max_rw_iops', required=False)
+        if self.developer_mode:
+            argument = subcommand.add_argument('--max-rw-mbytes', help='Maximum Read Write Megabytes Per Second', type=int, dest='max_rw_mbytes', required=False)
+        if self.developer_mode:
+            argument = subcommand.add_argument('--max-r-mbytes', help='Maximum Read Megabytes Per Second', type=int, dest='max_r_mbytes', required=False)
+        if self.developer_mode:
+            argument = subcommand.add_argument('--max-w-mbytes', help='Maximum Write Megabytes Per Second', type=int, dest='max_w_mbytes', required=False)
+        if self.developer_mode:
+            argument = subcommand.add_argument('--distr-vuid', help='(Dev) set vuid manually, default: random (1-99999)', type=str, default='0', dest='distr_vuid', required=False)
         if self.developer_mode:
             argument = subcommand.add_argument('--lvol-ha-type', help='Logical volume HA type (single, ha), default is cluster HA type', type=str, default='default', dest='lvol_ha_type', required=False, choices=['single','default','ha',])
-        argument = subcommand.add_argument('--lvol-priority-class', help='Logical volume priority class', type=int, default=0, dest='lvol-priority-class', required=False)
-        argument = subcommand.add_argument('--fstype', help='Filesystem type for testing (ext4, xfs)', type=str, default='xfs', dest='fstype', required=False, choices=['ext4','xfs',])
+        argument = subcommand.add_argument('--lvol-priority-class', help='Logical volume priority class', type=int, default=0, dest='lvol_priority_class', required=False)
+        if self.developer_mode:
+            argument = subcommand.add_argument('--fstype', help='Filesystem type for testing (ext4, xfs)', type=str, default='xfs', dest='fstype', required=False, choices=['ext4','xfs',])
 
     def init_cluster__create(self, subparser):
         subcommand = self.add_sub_command(subparser, 'create', 'Creates a new cluster')
         if self.developer_mode:
             argument = subcommand.add_argument('--page_size', help='The size of a data page in bytes', type=str, default='2097152', dest='page_size', required=False)
         if self.developer_mode:
-            argument = subcommand.add_argument('--CLI_PASS', help='Password for CLI SSH connection', type=str, dest='CLI_PASS', required=True)
+            argument = subcommand.add_argument('--CLI_PASS', help='Password for CLI SSH connection', type=str, dest='CLI_PASS', required=False)
         argument = subcommand.add_argument('--cap-warn', help='Capacity warning level in percent, default: 89', type=int, default=89, dest='cap_warn', required=False)
         argument = subcommand.add_argument('--cap-crit', help='Capacity critical level in percent, default: 99', type=int, default=99, dest='cap_crit', required=False)
         argument = subcommand.add_argument('--prov-cap-warn', help='Capacity warning level in percent, default: 250', type=int, default=250, dest='prov_cap_warn', required=False)
         argument = subcommand.add_argument('--prov-cap-crit', help='Capacity critical level in percent, default: 500', type=int, default=500, dest='prov_cap_crit', required=False)
-        argument = subcommand.add_argument('--ifname', help='Management interface name, e.g. eth0', type=str, dest='ifname', required=True)
+        argument = subcommand.add_argument('--ifname', help='Management interface name, e.g. eth0', type=str, dest='ifname', required=False)
         argument = subcommand.add_argument('--log-del-interval', help='Logging retention policy, default: 3d', type=str, default='3d', dest='log_del_interval', required=False)
         argument = subcommand.add_argument('--metrics-retention-period', help='Retention period for I/O statistics (Prometheus), default: 7d', type=str, default='7d', dest='metrics_retention_period', required=False)
-        argument = subcommand.add_argument('--contact-point', help='Email or slack webhook url to be used for alerting', type=str, default='None', dest='contact_point', required=False)
-        argument = subcommand.add_argument('--grafana-endpoint', help='Endpoint url for Grafana', type=str, default='None', dest='grafana_endpoint', required=False)
-        argument = subcommand.add_argument('--data-chunks-per-stripe', help='Erasure coding schema parameter k (distributed raid), default: 1', type=int, default=1, dest='distr-ndcs', required=False)
-        argument = subcommand.add_argument('--parity-chunks-per-stripe', help='Erasure coding schema parameter n (distributed raid), default: 1', type=int, default=1, dest='distr-npcs', required=False)
+        argument = subcommand.add_argument('--contact-point', help='Email or slack webhook url to be used for alerting', type=str, dest='contact_point', required=False)
+        argument = subcommand.add_argument('--grafana-endpoint', help='Endpoint url for Grafana', type=str, dest='grafana_endpoint', required=False)
+        argument = subcommand.add_argument('--data-chunks-per-stripe', help='Erasure coding schema parameter k (distributed raid), default: 1', type=int, default=1, dest='distr_ndcs', required=False)
+        argument = subcommand.add_argument('--parity-chunks-per-stripe', help='Erasure coding schema parameter n (distributed raid), default: 1', type=int, default=1, dest='distr_npcs', required=False)
         if self.developer_mode:
-            argument = subcommand.add_argument('--distr-bs', help='(Dev) distrb bdev block size, default: 4096', type=str, default='4096', dest='distr-bs', required=False)
+            argument = subcommand.add_argument('--distr-bs', help='(Dev) distrb bdev block size, default: 4096', type=str, default='4096', dest='distr_bs', required=False)
         if self.developer_mode:
-            argument = subcommand.add_argument('--distr-chunk-bs', help='(Dev) distrb bdev chunk block size, default: 4096', type=str, default='4096', dest='distr-chunk-bs', required=False)
+            argument = subcommand.add_argument('--distr-chunk-bs', help='(Dev) distrb bdev chunk block size, default: 4096', type=str, default='4096', dest='distr_chunk_bs', required=False)
         if self.developer_mode:
             argument = subcommand.add_argument('--ha-type', help='Logical volume HA type (single, ha), default is cluster single type', type=str, default='single', dest='ha_type', required=False, choices=['single','ha',])
-        argument = subcommand.add_argument('--enable-node-affinity', help='Enable node affinity for storage nodes', dest='enable-node-affinity', required=False, action='store_true')
+        argument = subcommand.add_argument('--enable-node-affinity', help='Enable node affinity for storage nodes', dest='enable_node_affinity', required=False, action='store_true')
         argument = subcommand.add_argument('--qpair-count', help='NVMe/TCP transport qpair count per logical volume', type=int, default=0, dest='qpair_count', required=False, choices=range(0, 128))
         if self.developer_mode:
-            argument = subcommand.add_argument('--max-queue-size', help='The max size the queue will grow', type=str, default='128', dest='max-queue-size', required=False)
+            argument = subcommand.add_argument('--max-queue-size', help='The max size the queue will grow', type=str, default='128', dest='max_queue_size', required=False)
         if self.developer_mode:
-            argument = subcommand.add_argument('--inflight-io-threshold', help='The number of inflight IOs allowed before the IO queuing starts', type=str, default='4', dest='inflight-io-threshold', required=False)
-        argument = subcommand.add_argument('--enable-qos', help='Enable qos bdev for storage nodes, true by default', type=bool, default=False, dest='enable_qos', required=False)
-        argument = subcommand.add_argument('--strict-node-anti-affinity', help='Enable strict node anti affinity for storage nodes. Never more than one chunk is placed on a node. This requires a minimum of _data-chunks-in-stripe + parity-chunks-in-stripe + 1_ nodes in the cluster.', dest='strict-node-anti-affinity', required=False, action='store_true')
+            argument = subcommand.add_argument('--inflight-io-threshold', help='The number of inflight IOs allowed before the IO queuing starts', type=str, default='4', dest='inflight_io_threshold', required=False)
+        if self.developer_mode:
+            argument = subcommand.add_argument('--enable-qos', help='Enable qos bdev for storage nodes, true by default', type=bool, default=False, dest='enable_qos', required=False)
+        argument = subcommand.add_argument('--strict-node-anti-affinity', help='Enable strict node anti affinity for storage nodes. Never more than one chunk is placed on a node. This requires a minimum of _data-chunks-in-stripe + parity-chunks-in-stripe + 1_ nodes in the cluster.', dest='strict_node_anti_affinity', required=False, action='store_true')
 
     def init_cluster__add(self, subparser):
         subcommand = self.add_sub_command(subparser, 'add', 'Adds a new cluster')
@@ -428,22 +445,23 @@ class CLIWrapper(CLIWrapperBase):
         argument = subcommand.add_argument('--cap-crit', help='Capacity critical level in percent, default: 99', type=int, default=99, dest='cap_crit', required=False)
         argument = subcommand.add_argument('--prov-cap-warn', help='Capacity warning level in percent, default: 250', type=int, default=250, dest='prov_cap_warn', required=False)
         argument = subcommand.add_argument('--prov-cap-crit', help='Capacity critical level in percent, default: 500', type=int, default=500, dest='prov_cap_crit', required=False)
-        argument = subcommand.add_argument('--data-chunks-per-stripe', help='Erasure coding schema parameter k (distributed raid), default: 1', type=int, default=0, dest='distr-ndcs', required=False)
-        argument = subcommand.add_argument('--parity-chunks-per-stripe', help='Erasure coding schema parameter n (distributed raid), default: 1', type=int, default=0, dest='distr-npcs', required=False)
+        argument = subcommand.add_argument('--data-chunks-per-stripe', help='Erasure coding schema parameter k (distributed raid), default: 1', type=int, default=0, dest='distr_ndcs', required=False)
+        argument = subcommand.add_argument('--parity-chunks-per-stripe', help='Erasure coding schema parameter n (distributed raid), default: 1', type=int, default=0, dest='distr_npcs', required=False)
         if self.developer_mode:
-            argument = subcommand.add_argument('--distr-bs', help='(Dev) distrb bdev block size, default: 4096', type=str, default='4096', dest='distr-bs', required=False)
+            argument = subcommand.add_argument('--distr-bs', help='(Dev) distrb bdev block size, default: 4096', type=str, default='4096', dest='distr_bs', required=False)
         if self.developer_mode:
-            argument = subcommand.add_argument('--distr-chunk-bs', help='(Dev) distrb bdev chunk block size, default: 4096', type=str, default='4096', dest='distr-chunk-bs', required=False)
+            argument = subcommand.add_argument('--distr-chunk-bs', help='(Dev) distrb bdev chunk block size, default: 4096', type=str, default='4096', dest='distr_chunk_bs', required=False)
         if self.developer_mode:
             argument = subcommand.add_argument('--ha-type', help='Logical volume HA type (single, ha), default is cluster single type', type=str, default='single', dest='ha_type', required=False, choices=['single','ha',])
-        argument = subcommand.add_argument('--enable-node-affinity', help='Enables node affinity for storage nodes', dest='enable-node-affinity', required=False, action='store_true')
+        argument = subcommand.add_argument('--enable-node-affinity', help='Enables node affinity for storage nodes', dest='enable_node_affinity', required=False, action='store_true')
         argument = subcommand.add_argument('--qpair-count', help='NVMe/TCP transport qpair count per logical volume', type=int, default=0, dest='qpair_count', required=False, choices=range(0, 128))
         if self.developer_mode:
-            argument = subcommand.add_argument('--max-queue-size', help='The max size the queue will grow', type=str, default='128', dest='max-queue-size', required=False)
+            argument = subcommand.add_argument('--max-queue-size', help='The max size the queue will grow', type=str, default='128', dest='max_queue_size', required=False)
         if self.developer_mode:
-            argument = subcommand.add_argument('--inflight-io-threshold', help='The number of inflight IOs allowed before the IO queuing starts', type=str, default='4', dest='inflight-io-threshold', required=False)
-        argument = subcommand.add_argument('--enable-qos', help='Enable qos bdev for storage nodes, default: true', type=bool, default=False, dest='enable_qos', required=False)
-        argument = subcommand.add_argument('--strict-node-anti-affinity', help='Enable strict node anti affinity for storage nodes. Never more than one chunk is placed on a node. This requires a minimum of _data-chunks-in-stripe + parity-chunks-in-stripe + 1_ nodes in the cluster."', dest='strict-node-anti-affinity', required=False, action='store_true')
+            argument = subcommand.add_argument('--inflight-io-threshold', help='The number of inflight IOs allowed before the IO queuing starts', type=str, default='4', dest='inflight_io_threshold', required=False)
+        if self.developer_mode:
+            argument = subcommand.add_argument('--enable-qos', help='Enable qos bdev for storage nodes, default: true', type=bool, default=False, dest='enable_qos', required=False)
+        argument = subcommand.add_argument('--strict-node-anti-affinity', help='Enable strict node anti affinity for storage nodes. Never more than one chunk is placed on a node. This requires a minimum of _data-chunks-in-stripe + parity-chunks-in-stripe + 1_ nodes in the cluster."', dest='strict_node_anti_affinity', required=False, action='store_true')
 
     def init_cluster__activate(self, subparser):
         subcommand = self.add_sub_command(subparser, 'activate', 'Activates a cluster.')
@@ -469,13 +487,13 @@ class CLIWrapper(CLIWrapperBase):
         subcommand = self.add_sub_command(subparser, 'get-capacity', 'Gets a cluster\'s capacity')
         subcommand.add_argument('cluster_id', help='Cluster id', type=str).completer = self._completer_get_cluster_list
         argument = subcommand.add_argument('--json', help='Print json output', dest='json', required=False, action='store_true')
-        argument = subcommand.add_argument('--history', help='(XXdYYh), list history records (one for every 15 minutes) for XX days and YY hours (up to 10 days in total).', type=str, dest='history', required=True)
+        argument = subcommand.add_argument('--history', help='(XXdYYh), list history records (one for every 15 minutes) for XX days and YY hours (up to 10 days in total).', type=str, dest='history', required=False)
 
     def init_cluster__get_io_stats(self, subparser):
         subcommand = self.add_sub_command(subparser, 'get-io-stats', 'Gets a cluster\'s I/O statistics')
         subcommand.add_argument('cluster_id', help='Cluster id', type=str).completer = self._completer_get_cluster_list
         argument = subcommand.add_argument('--records', help='Number of records, default: 20', type=str, default='20', dest='records', required=False)
-        argument = subcommand.add_argument('--history', help='(XXdYYh), list history records (one for every 15 minutes) for XX days and YY hours (up to 10 days in total).', type=str, dest='history', required=True)
+        argument = subcommand.add_argument('--history', help='(XXdYYh), list history records (one for every 15 minutes) for XX days and YY hours (up to 10 days in total).', type=str, dest='history', required=False)
 
     def init_cluster__get_logs(self, subparser):
         subcommand = self.add_sub_command(subparser, 'get-logs', 'Returns a cluster\'s status logs')
@@ -508,7 +526,7 @@ class CLIWrapper(CLIWrapperBase):
         subcommand = self.add_sub_command(subparser, 'graceful-startup', 'Initiates a graceful startup of a cluster\'s storage nodes')
         subcommand.add_argument('cluster_id', help='Cluster id', type=str).completer = self._completer_get_cluster_list
         argument = subcommand.add_argument('--clear-data', help='clear Alceml data', dest='clear_data', required=False, action='store_true')
-        argument = subcommand.add_argument('--spdk-image', help='SPDK image uri', type=str, dest='spdk_image', required=True)
+        argument = subcommand.add_argument('--spdk-image', help='SPDK image uri', type=str, dest='spdk_image', required=False)
 
     def init_cluster__list_tasks(self, subparser):
         subcommand = self.add_sub_command(subparser, 'list-tasks', 'Lists tasks of a cluster')
@@ -550,37 +568,37 @@ class CLIWrapper(CLIWrapperBase):
         subcommand.add_argument('size', help='Logical volume size: 10M, 10G, 10(bytes)', type=str)
         subcommand.add_argument('pool', help='Pool id or name', type=str)
         argument = subcommand.add_argument('--snapshot', help='Make logical volume with snapshot capability, default: false', dest='snapshot', required=False, action='store_true')
-        argument = subcommand.add_argument('--max-size', help='Logical volume max size', type=str, default='', dest='max_size', required=False)
-        argument = subcommand.add_argument('--host-id', help='Primary storage node id or Hostname', type=str, dest='host_id', required=True)
+        argument = subcommand.add_argument('--max-size', help='Logical volume max size', type=str, dest='max_size', required=False)
+        argument = subcommand.add_argument('--host-id', help='Primary storage node id or Hostname', type=str, dest='host_id', required=False)
         argument = subcommand.add_argument('--encrypt', help='Use inline data encryption and decryption on the logical volume', dest='encrypt', required=False, action='store_true')
-        argument = subcommand.add_argument('--crypto-key1', help='Hex value of key1 to be used for logical volume encryption', type=str, dest='crypto_key1', required=True)
-        argument = subcommand.add_argument('--crypto-key2', help='Hex value of key2 to be used for logical volume encryption', type=str, dest='crypto_key2', required=True)
-        argument = subcommand.add_argument('--max-rw-iops', help='Maximum Read Write IO Per Second', type=int, dest='max-rw-iops', required=True)
-        argument = subcommand.add_argument('--max-rw-mbytes', help='Maximum Read Write Megabytes Per Second', type=int, dest='max-rw-mbytes', required=True)
-        argument = subcommand.add_argument('--max-r-mbytes', help='Maximum Read Megabytes Per Second', type=int, dest='max-r-mbytes', required=True)
-        argument = subcommand.add_argument('--max-w-mbytes', help='Maximum Write Megabytes Per Second', type=int, dest='max-w-mbytes', required=True)
+        argument = subcommand.add_argument('--crypto-key1', help='Hex value of key1 to be used for logical volume encryption', type=str, dest='crypto_key1', required=False)
+        argument = subcommand.add_argument('--crypto-key2', help='Hex value of key2 to be used for logical volume encryption', type=str, dest='crypto_key2', required=False)
+        argument = subcommand.add_argument('--max-rw-iops', help='Maximum Read Write IO Per Second', type=int, dest='max_rw_iops', required=False)
+        argument = subcommand.add_argument('--max-rw-mbytes', help='Maximum Read Write Megabytes Per Second', type=int, dest='max_rw_mbytes', required=False)
+        argument = subcommand.add_argument('--max-r-mbytes', help='Maximum Read Megabytes Per Second', type=int, dest='max_r_mbytes', required=False)
+        argument = subcommand.add_argument('--max-w-mbytes', help='Maximum Write Megabytes Per Second', type=int, dest='max_w_mbytes', required=False)
         if self.developer_mode:
-            argument = subcommand.add_argument('--distr-vuid', help='(Dev) set vuid manually, default: random (1-99999)', type=str, default='0', dest='distr-vuid', required=False)
+            argument = subcommand.add_argument('--distr-vuid', help='(Dev) set vuid manually, default: random (1-99999)', type=str, default='0', dest='distr_vuid', required=False)
         if self.developer_mode:
             argument = subcommand.add_argument('--ha-type', help='Logical volume HA type (single, ha), default is cluster HA type', type=str, default='default', dest='ha_type', required=False, choices=['single','default','ha',])
-        argument = subcommand.add_argument('--lvol-priority-class', help='Logical volume priority class', type=int, default=0, dest='lvol-priority-class', required=False)
-        argument = subcommand.add_argument('--namespace', help='Set logical volume namespace for k8s clients', type=str, dest='namespace', required=True)
+        argument = subcommand.add_argument('--lvol-priority-class', help='Logical volume priority class', type=int, default=0, dest='lvol_priority_class', required=False)
+        argument = subcommand.add_argument('--namespace', help='Set logical volume namespace for k8s clients', type=str, dest='namespace', required=False)
         if self.developer_mode:
-            argument = subcommand.add_argument('--uid', help='Set logical volume id', type=str, dest='uid', required=True)
-        argument = subcommand.add_argument('--pvc_name', help='Set logical volume PVC name for k8s clients', type=str, dest='pvc_name', required=True)
+            argument = subcommand.add_argument('--uid', help='Set logical volume id', type=str, dest='uid', required=False)
+        argument = subcommand.add_argument('--pvc_name', help='Set logical volume PVC name for k8s clients', type=str, dest='pvc_name', required=False)
 
     def init_volume__qos_set(self, subparser):
         subcommand = self.add_sub_command(subparser, 'qos-set', 'Changes QoS settings for an active logical volume')
         subcommand.add_argument('volume_id', help='Logical volume id', type=str)
-        argument = subcommand.add_argument('--max-rw-iops', help='Maximum Read Write IO Per Second', type=int, dest='max-rw-iops', required=True)
-        argument = subcommand.add_argument('--max-rw-mbytes', help='Maximum Read Write Megabytes Per Second', type=int, dest='max-rw-mbytes', required=True)
-        argument = subcommand.add_argument('--max-r-mbytes', help='Maximum Read Megabytes Per Second', type=int, dest='max-r-mbytes', required=True)
-        argument = subcommand.add_argument('--max-w-mbytes', help='Maximum Write Megabytes Per Second', type=int, dest='max-w-mbytes', required=True)
+        argument = subcommand.add_argument('--max-rw-iops', help='Maximum Read Write IO Per Second', type=int, dest='max_rw_iops', required=False)
+        argument = subcommand.add_argument('--max-rw-mbytes', help='Maximum Read Write Megabytes Per Second', type=int, dest='max_rw_mbytes', required=False)
+        argument = subcommand.add_argument('--max-r-mbytes', help='Maximum Read Megabytes Per Second', type=int, dest='max_r_mbytes', required=False)
+        argument = subcommand.add_argument('--max-w-mbytes', help='Maximum Write Megabytes Per Second', type=int, dest='max_w_mbytes', required=False)
 
     def init_volume__list(self, subparser):
         subcommand = self.add_sub_command(subparser, 'list', 'Lists logical volumes')
-        argument = subcommand.add_argument('--cluster-id', help='List logical volumes in particular cluster', type=str, dest='cluster_id', required=True)
-        argument = subcommand.add_argument('--pool', help='List logical volumes in particular pool id or name', type=str, dest='pool', required=True)
+        argument = subcommand.add_argument('--cluster-id', help='List logical volumes in particular cluster', type=str, dest='cluster_id', required=False)
+        argument = subcommand.add_argument('--pool', help='List logical volumes in particular pool id or name', type=str, dest='pool', required=False)
         argument = subcommand.add_argument('--json', help='Print outputs in json format', dest='json', required=False, action='store_true')
         argument = subcommand.add_argument('--all', help='List soft deleted logical volumes', dest='all', required=False, action='store_true')
 
@@ -617,7 +635,7 @@ class CLIWrapper(CLIWrapperBase):
         subcommand = self.add_sub_command(subparser, 'clone', 'Provisions a logical volumes from an existing snapshot')
         subcommand.add_argument('snapshot_id', help='Snapshot id', type=str)
         subcommand.add_argument('clone_name', help='Clone name', type=str)
-        argument = subcommand.add_argument('--resize', help='New logical volume size: 10M, 10G, 10(bytes). Can only increase.', type=str, dest='resize', required=True)
+        argument = subcommand.add_argument('--resize', help='New logical volume size: 10M, 10G, 10(bytes). Can only increase.', type=str, dest='resize', required=False)
 
     def init_volume__move(self, subparser):
         subcommand = self.add_sub_command(subparser, 'move', 'Moves a full copy of the logical volume between nodes')
@@ -628,12 +646,12 @@ class CLIWrapper(CLIWrapperBase):
     def init_volume__get_capacity(self, subparser):
         subcommand = self.add_sub_command(subparser, 'get-capacity', 'Gets a logical volume\'s capacity')
         subcommand.add_argument('volume_id', help='Logical volume id', type=str)
-        argument = subcommand.add_argument('--history', help='(XXdYYh), list history records (one for every 15 minutes) for XX days and YY hours (up to 10 days in total).', type=str, dest='history', required=True)
+        argument = subcommand.add_argument('--history', help='(XXdYYh), list history records (one for every 15 minutes) for XX days and YY hours (up to 10 days in total).', type=str, dest='history', required=False)
 
     def init_volume__get_io_stats(self, subparser):
         subcommand = self.add_sub_command(subparser, 'get-io-stats', 'Gets a logical volume\'s I/O statistics')
         subcommand.add_argument('volume_id', help='Logical volume id', type=str)
-        argument = subcommand.add_argument('--history', help='(XXdYYh), list history records (one for every 15 minutes) for XX days and YY hours (up to 10 days in total).', type=str, dest='history', required=True)
+        argument = subcommand.add_argument('--history', help='(XXdYYh), list history records (one for every 15 minutes) for XX days and YY hours (up to 10 days in total).', type=str, dest='history', required=False)
         argument = subcommand.add_argument('--records', help='Number of records, default: 20', type=int, default=20, dest='records', required=False)
 
     def init_volume__check(self, subparser):
@@ -677,9 +695,6 @@ class CLIWrapper(CLIWrapperBase):
         self.init_storage_pool__delete(subparser)
         self.init_storage_pool__enable(subparser)
         self.init_storage_pool__disable(subparser)
-        self.init_storage_pool__get_secret(subparser)
-        if self.developer_mode:
-            self.init_storage_pool__update_secret(subparser)
         self.init_storage_pool__get_capacity(subparser)
         self.init_storage_pool__get_io_stats(subparser)
 
@@ -688,29 +703,29 @@ class CLIWrapper(CLIWrapperBase):
         subcommand = self.add_sub_command(subparser, 'add', 'Adds a new storage pool')
         subcommand.add_argument('name', help='New pool name', type=str)
         subcommand.add_argument('cluster_id', help='Cluster id', type=str)
-        argument = subcommand.add_argument('--pool-max', help='Pool maximum size: 20M, 20G, 0. Default: 0', type=str, default='0', dest='pool-max', required=False)
-        argument = subcommand.add_argument('--lvol-max', help='Logical volume maximum size: 20M, 20G, 0. Default: 0', type=str, default='0', dest='lvol-max', required=False)
-        argument = subcommand.add_argument('--max-rw-iops', help='Maximum Read Write IO Per Second', type=int, dest='max-rw-iops', required=True)
-        argument = subcommand.add_argument('--max-rw-mbytes', help='Maximum Read Write Megabytes Per Second', type=int, dest='max-rw-mbytes', required=True)
-        argument = subcommand.add_argument('--max-r-mbytes', help='Maximum Read Megabytes Per Second', type=int, dest='max-r-mbytes', required=True)
-        argument = subcommand.add_argument('--max-w-mbytes', help='Maximum Write Megabytes Per Second', type=int, dest='max-w-mbytes', required=True)
+        argument = subcommand.add_argument('--pool-max', help='Pool maximum size: 20M, 20G, 0. Default: 0', type=str, default='0', dest='pool_max', required=False)
+        argument = subcommand.add_argument('--lvol-max', help='Logical volume maximum size: 20M, 20G, 0. Default: 0', type=str, default='0', dest='lvol_max', required=False)
+        argument = subcommand.add_argument('--max-rw-iops', help='Maximum Read Write IO Per Second', type=int, dest='max_rw_iops', required=False)
+        argument = subcommand.add_argument('--max-rw-mbytes', help='Maximum Read Write Megabytes Per Second', type=int, dest='max_rw_mbytes', required=False)
+        argument = subcommand.add_argument('--max-r-mbytes', help='Maximum Read Megabytes Per Second', type=int, dest='max_r_mbytes', required=False)
+        argument = subcommand.add_argument('--max-w-mbytes', help='Maximum Write Megabytes Per Second', type=int, dest='max_w_mbytes', required=False)
         if self.developer_mode:
-            argument = subcommand.add_argument('--has-secret', help='Pool is created with a secret (all further API interactions with the pool and logical volumes in the pool require this secret)', dest='has-secret', required=False, action='store_true')
+            argument = subcommand.add_argument('--has-secret', help='Pool is created with a secret (all further API interactions with the pool and logical volumes in the pool require this secret)', dest='has_secret', required=False, action='store_true')
 
     def init_storage_pool__set(self, subparser):
         subcommand = self.add_sub_command(subparser, 'set', 'Sets a storage pool\'s attributes')
         subcommand.add_argument('pool_id', help='Pool id', type=str)
-        argument = subcommand.add_argument('--pool-max', help='Pool maximum size: 20M, 20G', type=str, dest='pool-max', required=True)
-        argument = subcommand.add_argument('--lvol-max', help='Logical volume maximum size: 20M, 20G', type=str, dest='lvol-max', required=True)
-        argument = subcommand.add_argument('--max-rw-iops', help='Maximum Read Write IO Per Second', type=int, dest='max-rw-iops', required=True)
-        argument = subcommand.add_argument('--max-rw-mbytes', help='Maximum Read Write Megabytes Per Second', type=int, dest='max-rw-mbytes', required=True)
-        argument = subcommand.add_argument('--max-r-mbytes', help='Maximum Read Megabytes Per Second', type=int, dest='max-r-mbytes', required=True)
-        argument = subcommand.add_argument('--max-w-mbytes', help='Maximum Write Megabytes Per Second', type=int, dest='max-w-mbytes', required=True)
+        argument = subcommand.add_argument('--pool-max', help='Pool maximum size: 20M, 20G', type=str, dest='pool_max', required=False)
+        argument = subcommand.add_argument('--lvol-max', help='Logical volume maximum size: 20M, 20G', type=str, dest='lvol_max', required=False)
+        argument = subcommand.add_argument('--max-rw-iops', help='Maximum Read Write IO Per Second', type=int, dest='max_rw_iops', required=False)
+        argument = subcommand.add_argument('--max-rw-mbytes', help='Maximum Read Write Megabytes Per Second', type=int, dest='max_rw_mbytes', required=False)
+        argument = subcommand.add_argument('--max-r-mbytes', help='Maximum Read Megabytes Per Second', type=int, dest='max_r_mbytes', required=False)
+        argument = subcommand.add_argument('--max-w-mbytes', help='Maximum Write Megabytes Per Second', type=int, dest='max_w_mbytes', required=False)
 
     def init_storage_pool__list(self, subparser):
         subcommand = self.add_sub_command(subparser, 'list', 'Lists all storage pools')
         argument = subcommand.add_argument('--json', help='Print outputs in json format', dest='json', required=False, action='store_true')
-        argument = subcommand.add_argument('--cluster-id', help='Cluster id', type=str, dest='cluster_id', required=True)
+        argument = subcommand.add_argument('--cluster-id', help='Cluster id', type=str, dest='cluster_id', required=False)
 
     def init_storage_pool__get(self, subparser):
         subcommand = self.add_sub_command(subparser, 'get', 'Gets a storage pool\'s details')
@@ -729,15 +744,6 @@ class CLIWrapper(CLIWrapperBase):
         subcommand = self.add_sub_command(subparser, 'disable', 'Sets a storage pool\'s status to Inactive.')
         subcommand.add_argument('pool_id', help='Pool id', type=str)
 
-    def init_storage_pool__get_secret(self, subparser):
-        subcommand = self.add_sub_command(subparser, 'get-secret', 'Gets a storage pool\'s secret')
-        subcommand.add_argument('pool_id', help='Pool id', type=str)
-
-    def init_storage_pool__update_secret(self, subparser):
-        subcommand = self.add_sub_command(subparser, 'update-secret', 'Updates a storage pool\'s secret')
-        subcommand.add_argument('pool_id', help='Pool id', type=str)
-        subcommand.add_argument('secret', help='New 20 characters password', type=str)
-
     def init_storage_pool__get_capacity(self, subparser):
         subcommand = self.add_sub_command(subparser, 'get-capacity', 'Gets a storage pool\'s capacity')
         subcommand.add_argument('pool_id', help='Pool id', type=str)
@@ -745,7 +751,7 @@ class CLIWrapper(CLIWrapperBase):
     def init_storage_pool__get_io_stats(self, subparser):
         subcommand = self.add_sub_command(subparser, 'get-io-stats', 'Gets a storage pool\'s I/O statistics')
         subcommand.add_argument('pool_id', help='Pool id', type=str)
-        argument = subcommand.add_argument('--history', help='(XXdYYh), list history records (one for every 15 minutes) for XX days and YY hours (up to 10 days in total).', type=str, dest='history', required=True)
+        argument = subcommand.add_argument('--history', help='(XXdYYh), list history records (one for every 15 minutes) for XX days and YY hours (up to 10 days in total).', type=str, dest='history', required=False)
         argument = subcommand.add_argument('--records', help='Number of records, default: 20', type=str, default='20', dest='records', required=False)
 
 
@@ -775,7 +781,7 @@ class CLIWrapper(CLIWrapperBase):
         subcommand = self.add_sub_command(subparser, 'clone', 'Provisions a new logical volume from an existing snapshot')
         subcommand.add_argument('snapshot_id', help='Snapshot id', type=str)
         subcommand.add_argument('lvol_name', help='Logical volume name', type=str)
-        argument = subcommand.add_argument('--resize', help='New logical volume size: 10M, 10G, 10(bytes)', type=str, dest='resize', required=True)
+        argument = subcommand.add_argument('--resize', help='New logical volume size: 10M, 10G, 10(bytes)', type=str, dest='resize', required=False)
 
 
     def init_caching_node(self):
@@ -793,20 +799,21 @@ class CLIWrapper(CLIWrapperBase):
 
     def init_caching_node__deploy(self, subparser):
         subcommand = self.add_sub_command(subparser, 'deploy', 'Deploys a caching node on this machine (local run)')
-        argument = subcommand.add_argument('--ifname', help='Management interface name, e.g. eth0', type=str, dest='ifname', required=True)
+        argument = subcommand.add_argument('--ifname', help='Management interface name, e.g. eth0', type=str, dest='ifname', required=False)
 
     def init_caching_node__add_node(self, subparser):
         subcommand = self.add_sub_command(subparser, 'add-node', 'Adds a new caching node to the cluster')
         subcommand.add_argument('cluster_id', help='Cluster id', type=str)
         subcommand.add_argument('node_ip', help='Node IP address', type=str)
         subcommand.add_argument('ifname', help='Management interface name', type=str)
-        argument = subcommand.add_argument('--number-of-vcpus', help='Number of vCPUs used for SPDK. Remaining CPUs will be used for Linux system, TCP/IP processing, and other workloads. The default on non-Kubernetes hosts is 80%.', type=int, dest='vcpu_count', required=True)
+        argument = subcommand.add_argument('--vcpu-count', help='Number of vCPUs used for SPDK. Remaining CPUs will be used for Linux system, TCP/IP processing, and other workloads. The default on non-Kubernetes hosts is 80%.', type=int, dest='vcpu_count', required=False)
         if self.developer_mode:
-            argument = subcommand.add_argument('--cpu-mask', help='SPDK app CPU mask, default is all cores found', type=str, dest='spdk_cpu_mask', required=True)
-        argument = subcommand.add_argument('--memory', help='SPDK huge memory allocation. By default it will acquire all available huge pages.', type=int, dest='spdk_mem', required=True)
+            argument = subcommand.add_argument('--cpu-mask', help='SPDK app CPU mask, default is all cores found', type=str, dest='spdk_cpu_mask', required=False)
         if self.developer_mode:
-            argument = subcommand.add_argument('--spdk-image', help='SPDK image uri', type=str, dest='spdk_image', required=True)
-        argument = subcommand.add_argument('--namespace', help='k8s namespace to deploy on', type=str, dest='namespace', required=True)
+            argument = subcommand.add_argument('--memory', help='SPDK huge memory allocation. By default it will acquire all available huge pages.', type=int, dest='spdk_mem', required=False)
+        if self.developer_mode:
+            argument = subcommand.add_argument('--spdk-image', help='SPDK image uri', type=str, dest='spdk_image', required=False)
+        argument = subcommand.add_argument('--namespace', help='k8s namespace to deploy on', type=str, dest='namespace', required=False)
         argument = subcommand.add_argument('--multipathing', help='Enable multipathing for logical volume connection, default: on', type=str, default='True', dest='multipathing', required=False, choices=['on','off',])
 
     def init_caching_node__list(self, subparser):
@@ -838,7 +845,7 @@ class CLIWrapper(CLIWrapperBase):
     def init_caching_node__get_lvol_stats(self, subparser):
         subcommand = self.add_sub_command(subparser, 'get-lvol-stats', 'Gets a logical volume\'s statistics')
         subcommand.add_argument('lvol_id', help='Logical volume id', type=str)
-        argument = subcommand.add_argument('--history', help='(XXdYYh), list history records (one for every 15 minutes) for XX days and YY hours (up to 10 days in total).', type=str, dest='history', required=True)
+        argument = subcommand.add_argument('--history', help='(XXdYYh), list history records (one for every 15 minutes) for XX days and YY hours (up to 10 days in total).', type=str, dest='history', required=False)
 
 
     def run(self):
@@ -1080,14 +1087,6 @@ class CLIWrapper(CLIWrapperBase):
                 ret = self.storage_pool__enable(sub_command, args)
             if sub_command in ['disable']:
                 ret = self.storage_pool__disable(sub_command, args)
-            if sub_command in ['get-secret']:
-                ret = self.storage_pool__get_secret(sub_command, args)
-            if sub_command in ['update-secret']:
-                if not developer_mode:
-                    print("This command is private.")
-                    ret = False
-                else:
-                    ret = self.storage_pool__update_secret(sub_command, args)
             if sub_command in ['get-capacity']:
                 ret = self.storage_pool__get_capacity(sub_command, args)
             if sub_command in ['get-io-stats']:

--- a/simplyblock_cli/cli.py
+++ b/simplyblock_cli/cli.py
@@ -857,8 +857,6 @@ class CLIWrapper(CLIWrapperBase):
 
         logging.getLogger("urllib3.connectionpool").setLevel(logging.WARNING)
 
-        developer_mode = True if args.dev else False
-
         ret = ""
         args_dict = args.__dict__
         if args.command in ['storage-node', 'sn']:
@@ -892,7 +890,7 @@ class CLIWrapper(CLIWrapperBase):
             if sub_command in ['list-devices']:
                 ret = self.storage_node__list_devices(sub_command, args)
             if sub_command in ['device-testing-mode']:
-                if not developer_mode:
+                if not self.developer_mode:
                     print("This command is private.")
                     ret = False
                 else:
@@ -924,13 +922,13 @@ class CLIWrapper(CLIWrapperBase):
             if sub_command in ['info']:
                 ret = self.storage_node__info(sub_command, args)
             if sub_command in ['info-spdk']:
-                if not developer_mode:
+                if not self.developer_mode:
                     print("This command is private.")
                     ret = False
                 else:
                     ret = self.storage_node__info_spdk(sub_command, args)
             if sub_command in ['remove-jm-device']:
-                if not developer_mode:
+                if not self.developer_mode:
                     print("This command is private.")
                     ret = False
                 else:
@@ -938,25 +936,25 @@ class CLIWrapper(CLIWrapperBase):
             if sub_command in ['restart-jm-device']:
                 ret = self.storage_node__restart_jm_device(sub_command, args)
             if sub_command in ['send-cluster-map']:
-                if not developer_mode:
+                if not self.developer_mode:
                     print("This command is private.")
                     ret = False
                 else:
                     ret = self.storage_node__send_cluster_map(sub_command, args)
             if sub_command in ['get-cluster-map']:
-                if not developer_mode:
+                if not self.developer_mode:
                     print("This command is private.")
                     ret = False
                 else:
                     ret = self.storage_node__get_cluster_map(sub_command, args)
             if sub_command in ['make-primary']:
-                if not developer_mode:
+                if not self.developer_mode:
                     print("This command is private.")
                     ret = False
                 else:
                     ret = self.storage_node__make_primary(sub_command, args)
             if sub_command in ['dump-lvstore']:
-                if not developer_mode:
+                if not self.developer_mode:
                     print("This command is private.")
                     ret = False
                 else:
@@ -997,13 +995,13 @@ class CLIWrapper(CLIWrapperBase):
             if sub_command in ['update']:
                 ret = self.cluster__update(sub_command, args)
             if sub_command in ['graceful-shutdown']:
-                if not developer_mode:
+                if not self.developer_mode:
                     print("This command is private.")
                     ret = False
                 else:
                     ret = self.cluster__graceful_shutdown(sub_command, args)
             if sub_command in ['graceful-startup']:
-                if not developer_mode:
+                if not self.developer_mode:
                     print("This command is private.")
                     ret = False
                 else:
@@ -1026,7 +1024,7 @@ class CLIWrapper(CLIWrapperBase):
             if sub_command in ['list']:
                 ret = self.volume__list(sub_command, args)
             if sub_command in ['list-mem']:
-                if not developer_mode:
+                if not self.developer_mode:
                     print("This command is private.")
                     ret = False
                 else:
@@ -1044,7 +1042,7 @@ class CLIWrapper(CLIWrapperBase):
             if sub_command in ['clone']:
                 ret = self.volume__clone(sub_command, args)
             if sub_command in ['move']:
-                if not developer_mode:
+                if not self.developer_mode:
                     print("This command is private.")
                     ret = False
                 else:


### PR DESCRIPTION
Fixed the generation of the required argument. Now everything is non-required except positional arguments and specifically marked parameters with `required: true`.

Also, added to rename positional arguments. While argsparse doesn't support the dest parameter for positional arguments, the generator will generate an automatic assignment from the positional argument name to its according dest parameter.

```
args.{{dest_name}} = args.{{argument_name}}
```

Last, cleaned up cli-reference.yaml based on the above changes. Removed all `required: ...` arguments.