### PR TITLE
Add missing id to cluster activation

### DIFF
--- a/cli-reference.yaml
+++ b/cli-reference.yaml
@@ -1231,6 +1231,11 @@ commands:
         usage: Once a cluster has sufficient nodes added, it needs to be activated. Can also be used to
           re-activate a suspended cluster.
         arguments:
+          - name: "cluster_id"
+            help: "Cluster id"
+            dest: cluster_id
+            type: str
+            completer: _completer_get_cluster_list
           - name: "--force"
             help: "Force recreate distr and lv stores"
             dest: force

--- a/simplyblock_cli/cli.py
+++ b/simplyblock_cli/cli.py
@@ -471,6 +471,7 @@ class CLIWrapper(CLIWrapperBase):
 
     def init_cluster__activate(self, subparser):
         subcommand = self.add_sub_command(subparser, 'activate', 'Activates a cluster.')
+        subcommand.add_argument('cluster_id', help='Cluster id', type=str).completer = self._completer_get_cluster_list
         argument = subcommand.add_argument('--force', help='Force recreate distr and lv stores', dest='force', required=False, action='store_true')
         argument = subcommand.add_argument('--force-lvstore-create', help='Force recreate lv stores', dest='force_lvstore_create', required=False, action='store_true').completer = self._completer_get_cluster_list
 


### PR DESCRIPTION
## Summary of changes
This adds the missing cluster ID argument to the cluster activation CLI.