### PR TITLE
Fix snapshot creation error handling

### DIFF
--- a/simplyblock_cli/clibase.py
+++ b/simplyblock_cli/clibase.py
@@ -424,7 +424,9 @@ class CLIWrapperBase:
         new_size = 0
         if args.resize:
             new_size = self.parse_size(args.resize)
-        return snapshot_controller.clone(args.snapshot_id, args.clone_name, new_size)
+
+        clone_id, error = snapshot_controller.clone(args.snapshot_id, args.clone_name, new_size)
+        return clone_id if not error else error
 
     def volume__move(self, sub_command, args):
         return lvol_controller.move(args.volume_id, args.node_id, args.force)
@@ -541,7 +543,9 @@ class CLIWrapperBase:
         new_size = 0
         if args.resize:
             new_size = self.parse_size(args.resize)
-        return snapshot_controller.clone(args.snapshot_id, args.lvol_name, new_size)
+
+        success, details = snapshot_controller.clone(args.snapshot_id, args.lvol_name, new_size)
+        return details
 
     def caching_node__deploy(self, sub_command, args):
         return caching_node_controller.deploy(args.ifname)

--- a/simplyblock_cli/clibase.py
+++ b/simplyblock_cli/clibase.py
@@ -417,7 +417,8 @@ class CLIWrapperBase:
     def volume__create_snapshot(self, sub_command, args):
         volume_id = args.volume_id
         name = args.name
-        return lvol_controller.create_snapshot(volume_id, name)
+        snapshot_id, error = lvol_controller.create_snapshot(volume_id, name)
+        return snapshot_id if not error else error
 
     def volume__clone(self, sub_command, args):
         new_size = 0
@@ -527,7 +528,8 @@ class CLIWrapperBase:
         return pool_controller.get_io_stats(args.pool_id, args.history, args.records)
 
     def snapshot__add(self, sub_command, args):
-        return snapshot_controller.add(args.volume_id, args.name)
+        snapshot_id, error = snapshot_controller.add(args.volume_id, args.name)
+        return snapshot_id if not error else error
 
     def snapshot__list(self, sub_command, args):
         return snapshot_controller.list(args.all)

--- a/simplyblock_core/controllers/snapshot_controller.py
+++ b/simplyblock_core/controllers/snapshot_controller.py
@@ -25,13 +25,15 @@ db_controller = DBController()
 def add(lvol_id, snapshot_name):
     lvol = db_controller.get_lvol_by_id(lvol_id)
     if not lvol:
-        logger.error(f"LVol not found: {lvol_id}")
-        return False
+        msg = f"LVol not found: {lvol_id}"
+        logger.error(msg)
+        return False, msg
 
     pool = db_controller.get_pool_by_id(lvol.pool_uuid)
     if pool.status == Pool.STATUS_INACTIVE:
-        logger.error(f"Pool is disabled")
-        return False
+        msg = f"Pool is disabled"
+        logger.error(msg)
+        return False, msg
 
     if lvol.cloned_from_snap:
         snap = db_controller.get_snapshot_by_id(lvol.cloned_from_snap)
@@ -60,15 +62,16 @@ def add(lvol_id, snapshot_name):
         size = lvol.size
 
     if 0 < pool.lvol_max_size < size:
-        logger.error(f"Pool Max LVol size is: {utils.humanbytes(pool.lvol_max_size)}, LVol size: {utils.humanbytes(size)} must be below this limit")
-        return False
+        msg = f"Pool Max LVol size is: {utils.humanbytes(pool.lvol_max_size)}, LVol size: {utils.humanbytes(size)} must be below this limit"
+        logger.error(msg)
+        return False, msg
 
     if pool.pool_max_size > 0:
         total = pool_controller.get_pool_total_capacity(pool.get_id())
         if total + size > pool.pool_max_size:
-            logger.error( f"Invalid LVol size: {utils.humanbytes(size)} " 
-                          f"Pool max size has reached {utils.humanbytes(total+size)} of {utils.humanbytes(pool.pool_max_size)}")
-            return False
+            msg =  f"Invalid LVol size: {utils.humanbytes(size)}. pool max size has reached {utils.humanbytes(total+size)} of {utils.humanbytes(pool.pool_max_size)}"
+            logger.error(msg)
+            return False, msg
 
     if pool.pool_max_size > 0:
         total = pool_controller.get_pool_total_capacity(pool.get_id())

--- a/simplyblock_core/controllers/snapshot_controller.py
+++ b/simplyblock_core/controllers/snapshot_controller.py
@@ -426,15 +426,16 @@ def clone(snapshot_id, clone_name, new_size=0):
 
     size = snap.size
     if 0 < pool.lvol_max_size < size:
-        logger.error(f"Pool Max LVol size is: {utils.humanbytes(pool.lvol_max_size)}, LVol size: {utils.humanbytes(size)} must be below this limit")
-        return False
+        msg = f"Pool Max LVol size is: {utils.humanbytes(pool.lvol_max_size)}, LVol size: {utils.humanbytes(size)} must be below this limit"
+        logger.error(msg)
+        return False, msg
 
     if pool.pool_max_size > 0:
         total = pool_controller.get_pool_total_capacity(pool.get_id())
         if total + size > pool.pool_max_size:
-            logger.error( f"Invalid LVol size: {utils.humanbytes(size)} " 
-                          f"Pool max size has reached {utils.humanbytes(total+size)} of {utils.humanbytes(pool.pool_max_size)}")
-            return False
+            msg =  f"Invalid LVol size: {utils.humanbytes(size)}. Pool max size has reached {utils.humanbytes(total+size)} of {utils.humanbytes(pool.pool_max_size)}"
+            logger.error(msg)
+            return False, msg
 
     lvol_count = len(db_controller.get_lvols_by_node_id(snode.get_id()))
     if lvol_count >= snode.max_lvol:
@@ -603,4 +604,4 @@ def clone(snapshot_id, clone_name, new_size=0):
     snapshot_events.snapshot_clone(snap, lvol)
     if new_size:
         lvol_controller.resize_lvol(lvol.get_id(), new_size)
-    return True, lvol.uuid
+    return lvol.uuid, False

--- a/simplyblock_web/blueprints/web_api_lvol.py
+++ b/simplyblock_web/blueprints/web_api_lvol.py
@@ -288,10 +288,10 @@ def create_snapshot():
     if 'snapshot_name' not in cl_data:
         return utils.get_response(None, "missing required param: snapshot_name", 400)
 
-    snapID = snapshot_controller.add(
+    snapID, err = snapshot_controller.add(
         cl_data['lvol_id'],
         cl_data['snapshot_name'])
-    return utils.get_response(snapID)
+    return utils.get_response(snapID, err, http_code=400)
 
 
 @bp.route('/lvol/inflate_lvol/<string:uuid>', methods=['PUT'])

--- a/simplyblock_web/blueprints/web_api_snapshot.py
+++ b/simplyblock_web/blueprints/web_api_snapshot.py
@@ -61,8 +61,6 @@ def clone_snapshot():
     if 'new_size' in cl_data:
         new_size = utils.parse_size(cl_data['new_size'])
 
-    res, msg = snapshot_controller.clone(
+    clone_id, error = snapshot_controller.clone(
         cl_data['snapshot_id'], cl_data['clone_name'], new_size)
-    if res:
-        return utils.get_response(msg)
-    return utils.get_response(None, msg)
+    return utils.get_response(clone_id, error, http_code=400)


### PR DESCRIPTION
The signature of `snapshot_controller.add` was inconsistent, returning either a tuple or a value. At the call-sites, this was not handled adequately.

This change consistently returns a tuple and process it adequately when calling the function.

## JIRA ticket link/s

-   [SFAM-1836](https://simplyblock.atlassian.net/browse/SFAM-1836)

## Summary of changes

1.  Make the signature of `snapshot_controller.add` consistent, always returning a tuple
2. Adapt call-sites to infer an error accordingly