### PR TITLE
Fix CLI parameter naming for snapshot creation

### DIFF
--- a/cli-reference.yaml
+++ b/cli-reference.yaml
@@ -1901,9 +1901,9 @@ commands:
       - name: add
         help: "Creates a new snapshot"
         arguments:
-          - name: "snapshot_id"
+          - name: "volume_id"
             help: "Logical volume id"
-            dest: snapshot_id
+            dest: volume_id
             type: str
           - name: "name"
             help: "New snapshot name"

--- a/simplyblock_cli/cli.py
+++ b/simplyblock_cli/cli.py
@@ -768,7 +768,7 @@ class CLIWrapper(CLIWrapperBase):
 
     def init_snapshot__add(self, subparser):
         subcommand = self.add_sub_command(subparser, 'add', 'Creates a new snapshot')
-        subcommand.add_argument('snapshot_id', help='Logical volume id', type=str)
+        subcommand.add_argument('volume_id', help='Logical volume id', type=str)
         subcommand.add_argument('name', help='New snapshot name', type=str)
 
     def init_snapshot__list(self, subparser):

--- a/simplyblock_cli/clibase.py
+++ b/simplyblock_cli/clibase.py
@@ -520,7 +520,7 @@ class CLIWrapperBase:
         return pool_controller.get_io_stats(args.pool_id, args.history, args.records)
 
     def snapshot__add(self, sub_command, args):
-        return snapshot_controller.add(args.snapshot_id, args.name)
+        return snapshot_controller.add(args.volume_id, args.name)
 
     def snapshot__list(self, sub_command, args):
         return snapshot_controller.list(args.all)


### PR DESCRIPTION
The ID parameter for snapshot creation is named `snapshot_id`, instead of `volume_id`. The resulting snapshot ID is autogenerated and to set by the user.