### PR TITLE
Added check to ensure cleanly generated cli.py

### DIFF
--- a/.github/workflows/python-generate-test.yml
+++ b/.github/workflows/python-generate-test.yml
@@ -1,9 +1,6 @@
-name: Python Unit Testing
+name: Python Package Build
 
 on:
-  push:
-    branches:
-      - '**'
   pull_request:
     branches:
       - '**'
@@ -12,20 +9,20 @@ permissions:
   contents: read
 
 jobs:
-  deploy:
+  clipy-test:
+
     runs-on: ubuntu-latest
+
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python
       uses: actions/setup-python@v3
       with:
         python-version: '3.x'
-
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip setuptools build
-        pip install -r requirements.txt
-
+        python -m pip install --upgrade pip twine setuptools
+        pip install build
     - name: Checking cli.py status
       run: |
         ./scripts/generate.sh
@@ -35,13 +32,3 @@ jobs:
           echo "${changes}"
           exit 1
         fi
-
-    - name: Install package
-      run: python setup.py install
-
-    - name: Test with pytest
-      run: |
-        pip install pytest
-        pytest -v
-
-

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -23,6 +23,15 @@ jobs:
       run: |
         python -m pip install --upgrade pip twine setuptools
         pip install build
+    - name: Checking cli.py status
+      run: |
+        ./scripts/generate.sh
+        changes="$(git diff simplyblock_cli/cli.py)"
+        if [[ "${changes}" ]]; then
+          echo "cli.py has changed after regeneration. Stopping."
+          echo "${changes}"
+          exit 1
+        fi
     - name: Build package
       run: python setup.py sdist
     - name: Publish package to pypi


### PR DESCRIPTION
This PR enhances the builders (test and deploy) to check that a freshly generated cli.py is the same as the checked in, to prevent lost changes on follow up commits which regenerate cli.py and override manual changes.