### PR TITLE
Fixed nargs on positional arguments which were ignored

### DIFF
--- a/scripts/cli-wrapper-gen.py
+++ b/scripts/cli-wrapper-gen.py
@@ -115,7 +115,8 @@ def get_description(item):
         return "<missing documentation>"
 
 
-def nargs(value):
+def nargs(item):
+    value = item["nargs"]
     if not isinstance(value, int) and value not in ('?', '*', '+'):
         raise ValueError(f"Invalid nargs parameters: '{value}'")
     return value if isinstance(value, int) else f"'{value}'"

--- a/scripts/cli-wrapper.jinja2
+++ b/scripts/cli-wrapper.jinja2
@@ -1,3 +1,6 @@
+#!/usr/bin/env python
+# PYTHON_ARGCOMPLETE_OK
+
 from simplyblock_cli.clibase import CLIWrapperBase
 from simplyblock_core import utils
 import logging

--- a/scripts/cli-wrapper.jinja2
+++ b/scripts/cli-wrapper.jinja2
@@ -43,6 +43,7 @@ class CLIWrapper(CLIWrapperBase):
 {%- for argument in subcommand.arguments %}
         subcommand.add_argument('{{ argument.name }}', help='{{ argument.help | escape_strings | escape_python_string }}', type={{ argument.type }}
 {%- if argument.default is defined and argument.action is undefined %}, default={{ argument | default_value }}{% endif %}
+{%- if argument.nargs is defined %}, nargs={{ argument | nargs }}{% endif %}
 {%- if argument.action is defined %}, dest='{{ argument.action }}'{% endif %})
 {%- if argument.completer is defined %}.completer = self.{{ argument.completer }}{% endif %}
 {%- endfor -%}
@@ -60,7 +61,7 @@ class CLIWrapper(CLIWrapperBase):
 {%- if parameter.default is defined and parameter.action is undefined %}, default={{ parameter | default_value }}{% endif %}
 {%- if parameter.dest is defined %}, dest='{{ parameter.dest }}'{% endif %}
 {%- if parameter.required is defined %}, required={{ parameter | required }}{% endif %}
-{%- if parameter.nargs is defined %}, nargs={{ parameter.nargs | nargs }}{% endif %}
+{%- if parameter.nargs is defined %}, nargs={{ parameter | nargs }}{% endif %}
 {%- if parameter.choices %}, choices=[{% for choice in parameter.choices %}'{{ choice }}',{% endfor %}]{% endif %}
 {%- if parameter.value_range %}, choices=range({{ parameter.value_range | split_value_range }}){% endif %}
 {%- if parameter.action is defined %}, action='{{ parameter.action }}'{% endif %})
@@ -77,7 +78,7 @@ class CLIWrapper(CLIWrapperBase):
 {%- if parameter.default is defined %}, default={{ parameter | default_value }}{% endif %}
 {%- if parameter.dest is defined %}, dest='{{ parameter.dest }}'{% endif %}
 {%- if parameter.required is defined %}, required={{ parameter | required }}{% endif %}
-{%- if parameter.nargs is defined %}, nargs={{ parameter.nargs | nargs }}{% endif %}
+{%- if parameter.nargs is defined %}, nargs={{ parameter | nargs }}{% endif %}
 {%- if parameter.choices %}, choices=[{% for choice in parameter.choices %}'{{ choice }}',{% endfor %}]{% endif %}
 {%- if parameter.value_range %}, choices=range({{ parameter.value_range | split_value_range }}){% endif %}
 {%- if parameter.action is defined %}, action='{{ parameter.action }}'{% endif %})

--- a/simplyblock_cli/cli.py
+++ b/simplyblock_cli/cli.py
@@ -1,3 +1,6 @@
+#!/usr/bin/env python
+# PYTHON_ARGCOMPLETE_OK
+
 from simplyblock_cli.clibase import CLIWrapperBase
 from simplyblock_core import utils
 import logging

--- a/simplyblock_cli/cli.py
+++ b/simplyblock_cli/cli.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# PYTHON_ARGCOMPLETE_OK
-
 from simplyblock_cli.clibase import CLIWrapperBase
 from simplyblock_core import utils
 import logging
@@ -621,7 +618,7 @@ class CLIWrapper(CLIWrapperBase):
 
     def init_volume__delete(self, subparser):
         subcommand = self.add_sub_command(subparser, 'delete', 'Deletes a logical volume')
-        subcommand.add_argument('volume_id', help='Logical volumes id or ids', type=str,  nargs='+')
+        subcommand.add_argument('volume_id', help='Logical volumes id or ids', type=str, nargs='+')
         argument = subcommand.add_argument('--force', help='Force delete logical volume from the cluster', dest='force', required=False, action='store_true')
 
     def init_volume__connect(self, subparser):


### PR DESCRIPTION
Positional arguments (such as `volume_id` on `volume delete`) were ignored during generating cli.py. This PR fixes the problem and reintroduces the option to provide multiple volume ids.