### PR TITLE
Deduplicate helpers

### DIFF
--- a/simplyblock_core/shell_utils.py
+++ b/simplyblock_core/shell_utils.py
@@ -3,7 +3,10 @@ import subprocess
 
 
 def run_command(cmd):
-    process = subprocess.Popen(
-        cmd.split(), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    stdout, stderr = process.communicate()
-    return stdout.strip().decode("utf-8"), stderr.strip(), process.returncode
+    try:
+        process = subprocess.Popen(
+            cmd.split(), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        stdout, stderr = process.communicate()
+        return stdout.strip().decode("utf-8"), stderr.strip(), process.returncode
+    except Exception as e:
+        return "", str(e), 1

--- a/simplyblock_core/utils.py
+++ b/simplyblock_core/utils.py
@@ -67,30 +67,30 @@ def get_ips():
 
 
 def get_nics_data():
-    try:
-        out, _, _ = shell_utils.run_command("ip -j address show")
-        data = json.loads(out)
-        def _get_ip4_address(list_of_addr):
-            if list_of_addr:
-                for data in list_of_addr:
-                    if data['family'] == 'inet':
-                        return data['local']
-            return ""
+    out, err, rc = shell_utils.run_command("ip -j address show")
+    if rc != 0:
+        logger.error(err)
+        return []
+    data = json.loads(out)
 
-        devices = {i["ifname"]: i for i in data}
-        iface_list = {}
-        for nic in devices:
-            device = devices[nic]
-            iface = {
-                'name': device['ifname'],
-                'ip': _get_ip4_address(device['addr_info']),
-                'status': device['operstate'],
-                'net_type': device['link_type']}
-            iface_list[nic] = iface
-        return iface_list
-    except Exception as e:
-        logger.error(e)
-        return False
+    def _get_ip4_address(list_of_addr):
+        if list_of_addr:
+            for data in list_of_addr:
+                if data['family'] == 'inet':
+                    return data['local']
+        return ""
+
+    devices = {i["ifname"]: i for i in data}
+    iface_list = {}
+    for nic in devices:
+        device = devices[nic]
+        iface = {
+            'name': device['ifname'],
+            'ip': _get_ip4_address(device['addr_info']),
+            'status': device['operstate'],
+            'net_type': device['link_type']}
+        iface_list[nic] = iface
+    return iface_list
 
 
 def get_iface_ip(ifname):

--- a/simplyblock_web/blueprints/caching_node_ops.py
+++ b/simplyblock_web/blueprints/caching_node_ops.py
@@ -24,9 +24,9 @@ bp = Blueprint("caching_node", __name__, url_prefix="/cnode")
 def get_docker_client():
     ip = os.getenv("DOCKER_IP")
     if not ip:
-        for ifname in node_utils.get_nics_data():
+        for ifname in core_utils.get_nics_data():
             if ifname in ["eth0", "ens0"]:
-                ip = node_utils.get_nics_data()[ifname]['ip']
+                ip = core_utils.get_nics_data()[ifname]['ip']
                 break
     return docker.DockerClient(base_url=f"tcp://{ip}:2375", version="auto", timeout=60 * 5)
 
@@ -196,7 +196,7 @@ def get_info():
         "spdk_devices": node_utils.get_spdk_devices(),
         "spdk_pcie_list": node_utils.get_spdk_pcie_list(),
 
-        "network_interface": node_utils.get_nics_data()
+        "network_interface": core_utils.get_nics_data()
     }
     return utils.get_response(out)
 

--- a/simplyblock_web/blueprints/caching_node_ops.py
+++ b/simplyblock_web/blueprints/caching_node_ops.py
@@ -31,101 +31,14 @@ def get_docker_client():
     return docker.DockerClient(base_url=f"tcp://{ip}:2375", version="auto", timeout=60 * 5)
 
 
-def _get_spdk_pcie_list():  # return: ['0000:00:1e.0', '0000:00:1f.0']
-    out, err, _ = run_command("ls /sys/bus/pci/drivers/uio_pci_generic")
-    spdk_pcie_list = [line for line in out.split() if line.startswith("0000")]
-    logger.debug(spdk_pcie_list)
-    return spdk_pcie_list
-
-
-def _get_nvme_pcie_list():  # return: ['0000:00:1e.0', '0000:00:1f.0']
-    out, err, _ = run_command("ls /sys/bus/pci/drivers/nvme")
-    spdk_pcie_list = [line for line in out.split() if line.startswith("0000")]
-    logger.debug(spdk_pcie_list)
-    return spdk_pcie_list
-
-
-def get_nvme_pcie():
-    # Returns a list of nvme pci address and vendor IDs,
-    # each list item is a tuple [("PCI_ADDRESS", "VENDOR_ID:DEVICE_ID")]
-    stream = os.popen("lspci -Dnn | grep -i nvme")
-    ret = stream.readlines()
-    devs = []
-    for line in ret:
-        line_array = line.split()
-        devs.append((line_array[0], line_array[-1][1:-1]))
-    return devs
-
-
-def _get_nvme_devices():
-    out, err, _ = run_command("nvme list -v -o json")
-    data = json.loads(out)
-    logger.debug("nvme list:")
-    logger.debug(data)
-
-    devices = []
-    if data and 'Devices' in data:
-        for dev in data['Devices'][0]['Subsystems']:
-            if 'Controllers' in dev and dev['Controllers']:
-                controller = dev['Controllers'][0]
-                namespace = None
-                if "Namespaces" in dev and dev['Namespaces']:
-                    namespace = dev['Namespaces'][0]
-                elif controller and controller["Namespaces"]:
-                    namespace = controller['Namespaces'][0]
-                if namespace:
-                    devices.append({
-                        'nqn': dev['SubsystemNQN'],
-                        'size': namespace['PhysicalSize'],
-                        'sector_size': namespace['SectorSize'],
-                        'device_name': namespace['NameSpace'],
-                        'device_path': "/dev/"+namespace['NameSpace'],
-                        'controller_name': controller['Controller'],
-                        'address': controller['Address'],
-                        'transport': controller['Transport'],
-                        'model_id': controller['ModelNumber'],
-                        'serial_number': controller['SerialNumber']})
-    return devices
-
-
-def get_nics_data():
-    out, _, _ = run_command("ip -j address show")
-    data = json.loads(out)
-    logger.debug("ifaces")
-    logger.debug(data)
-
-    def _get_ip4_address(list_of_addr):
-        if list_of_addr:
-            for data in list_of_addr:
-                if data['family'] == 'inet':
-                    return data['local']
-        return ""
-
-    devices = {i["ifname"]: i for i in data}
-    iface_list = {}
-    for nic in devices:
-        device = devices[nic]
-        iface = {
-            'name': device['ifname'],
-            'ip': _get_ip4_address(device['addr_info']),
-            'status': device['operstate'],
-            'net_type': device['link_type']}
-        iface_list[nic] = iface
-    return iface_list
-
-
-def _get_spdk_devices():
-    return []
-
-
 @bp.route('/scan_devices', methods=['GET'])
 def scan_devices():
     run_health_check = request.args.get('run_health_check', default=False, type=bool)
     out = {
-        "nvme_devices": _get_nvme_devices(),
-        "nvme_pcie_list": _get_nvme_pcie_list(),
-        "spdk_devices": _get_spdk_devices(),
-        "spdk_pcie_list": _get_spdk_pcie_list(),
+        "nvme_devices": node_utils.get_nvme_devices(),
+        "nvme_pcie_list": node_utils.get_nvme_pcie_list(),
+        "spdk_devices": node_utils.get_spdk_devices(),
+        "spdk_pcie_list": node_utils.get_spdk_pcie_list(),
     }
     return utils.get_response(out)
 
@@ -277,13 +190,13 @@ def get_info():
         "hugepages": node_utils.get_huge_memory(),
         "memory_details": node_utils.get_memory_details(),
 
-        "nvme_devices": _get_nvme_devices(),
-        "nvme_pcie_list": _get_nvme_pcie_list(),
+        "nvme_devices": node_utils.get_nvme_devices(),
+        "nvme_pcie_list": node_utils.get_nvme_pcie_list(),
 
-        "spdk_devices": _get_spdk_devices(),
-        "spdk_pcie_list": _get_spdk_pcie_list(),
+        "spdk_devices": node_utils.get_spdk_devices(),
+        "spdk_pcie_list": node_utils.get_spdk_pcie_list(),
 
-        "network_interface": get_nics_data()
+        "network_interface": node_utils.get_nics_data()
     }
     return utils.get_response(out)
 

--- a/simplyblock_web/blueprints/caching_node_ops.py
+++ b/simplyblock_web/blueprints/caching_node_ops.py
@@ -32,13 +32,6 @@ def get_docker_client():
     return docker.DockerClient(base_url=f"tcp://{ip}:2375", version="auto", timeout=60 * 5)
 
 
-def run_command(cmd):
-    process = subprocess.Popen(
-        cmd.split(), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    stdout, stderr = process.communicate()
-    return stdout.strip().decode("utf-8"), stderr.strip().decode("utf-8"), process.returncode
-
-
 def _get_spdk_pcie_list():  # return: ['0000:00:1e.0', '0000:00:1f.0']
     out, err, _ = run_command("ls /sys/bus/pci/drivers/uio_pci_generic")
     spdk_pcie_list = [line for line in out.split() if line.startswith("0000")]
@@ -267,8 +260,8 @@ def spdk_process_is_up():
 
 
 CPU_INFO = cpuinfo.get_cpu_info()
-HOSTNAME, _, _ = node_utils.run_command("hostname -s")
-SYSTEM_ID, _, _ = node_utils.run_command("dmidecode -s system-uuid")
+HOSTNAME, _, _ = shell_utils.run_command("hostname -s")
+SYSTEM_ID, _, _ = shell_utils.run_command("dmidecode -s system-uuid")
 
 
 @bp.route('/info', methods=['GET'])
@@ -327,7 +320,7 @@ def connect_to_nvme():
     nqn = data['nqn']
     st = f"nvme connect --transport=tcp --traddr={ip} --trsvcid={port} --nqn={nqn}"
     logger.debug(st)
-    out, err, ret_code = run_command(st)
+    out, err, ret_code = shell_utils.run_command(st)
     logger.debug(ret_code)
     logger.debug(out)
     logger.debug(err)
@@ -342,7 +335,7 @@ def disconnect_device():
     data = request.get_json()
     dev_path = data['dev_path']
     st = f"nvme disconnect --device={dev_path}"
-    out, err, ret_code = run_command(st)
+    out, err, ret_code = shell_utils.run_command(st)
     logger.debug(ret_code)
     logger.debug(out)
     logger.debug(err)
@@ -354,7 +347,7 @@ def disconnect_nqn():
     data = request.get_json()
     nqn = data['nqn']
     st = f"nvme disconnect --nqn={nqn}"
-    out, err, ret_code = run_command(st)
+    out, err, ret_code = shell_utils.run_command(st)
     logger.debug(ret_code)
     logger.debug(out)
     logger.debug(err)
@@ -364,7 +357,7 @@ def disconnect_nqn():
 @bp.route('/disconnect_all', methods=['POST'])
 def disconnect_all():
     st = "nvme disconnect-all"
-    out, err, ret_code = run_command(st)
+    out, err, ret_code = shell_utils.run_command(st)
     logger.debug(ret_code)
     logger.debug(out)
     logger.debug(err)

--- a/simplyblock_web/blueprints/caching_node_ops.py
+++ b/simplyblock_web/blueprints/caching_node_ops.py
@@ -13,9 +13,8 @@ from docker.types import LogConfig
 from flask import Blueprint
 from flask import request
 
-from simplyblock_web import utils, node_utils
 from simplyblock_core import scripts, constants, shell_utils, utils as core_utils
-from simplyblock_core.utils import pull_docker_image_with_retry
+from simplyblock_web import utils, node_utils
 
 logger = logging.getLogger(__name__)
 
@@ -177,7 +176,7 @@ def spdk_process_start():
 
     if 'spdk_image' in data and data['spdk_image']:
         spdk_image = data['spdk_image']
-        pull_docker_image_with_retry(node_docker, spdk_image)
+        core_utils.pull_docker_image_with_retry(node_docker, spdk_image)
 
     container = node_docker.containers.run(
         spdk_image,

--- a/simplyblock_web/blueprints/caching_node_ops_k8s.py
+++ b/simplyblock_web/blueprints/caching_node_ops_k8s.py
@@ -15,7 +15,6 @@ from kubernetes.client import ApiException
 from jinja2 import Environment, FileSystemLoader
 
 from simplyblock_core import constants, shell_utils, utils as core_utils
-
 from simplyblock_web import utils, node_utils
 
 logger = logging.getLogger(__name__)
@@ -70,10 +69,10 @@ def set_namespace(namespace):
 def scan_devices():
     run_health_check = request.args.get('run_health_check', default=False, type=bool)
     out = {
-        "nvme_devices": node_utils._get_nvme_devices(),
-        "nvme_pcie_list": node_utils._get_nvme_pcie_list(),
-        "spdk_devices": node_utils._get_spdk_devices(),
-        "spdk_pcie_list": node_utils._get_spdk_pcie_list(),
+        "nvme_devices": node_utils.get_nvme_devices(),
+        "nvme_pcie_list": node_utils.get_nvme_pcie_list(),
+        "spdk_devices": node_utils.get_spdk_devices(),
+        "spdk_pcie_list": node_utils.get_spdk_pcie_list(),
     }
     return utils.get_response(out)
 
@@ -204,11 +203,11 @@ def get_info():
         "hugepages": node_utils.get_huge_memory(),
         "memory_details": node_utils.get_memory_details(),
 
-        "nvme_devices": node_utils._get_nvme_devices(),
-        "nvme_pcie_list": node_utils._get_nvme_pcie_list(),
+        "nvme_devices": node_utils.get_nvme_devices(),
+        "nvme_pcie_list": node_utils.get_nvme_pcie_list(),
 
-        "spdk_devices": node_utils._get_spdk_devices(),
-        "spdk_pcie_list": node_utils._get_spdk_pcie_list(),
+        "spdk_devices": node_utils.get_spdk_devices(),
+        "spdk_pcie_list": node_utils.get_spdk_pcie_list(),
 
         "network_interface": node_utils.get_nics_data()
     }

--- a/simplyblock_web/blueprints/caching_node_ops_k8s.py
+++ b/simplyblock_web/blueprints/caching_node_ops_k8s.py
@@ -38,10 +38,10 @@ TOP_DIR = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 
 
 cpu_info = cpuinfo.get_cpu_info()
-hostname, _, _ = node_utils.run_command("hostname -s")
+hostname, _, _ = shell_utils.run_command("hostname -s")
 system_id = ""
 try:
-    system_id, _, _ = node_utils.run_command("dmidecode -s system-uuid")
+    system_id, _, _ = shell_utils.run_command("dmidecode -s system-uuid")
 except:
     pass
 
@@ -228,7 +228,7 @@ def connect_to_nvme():
     nqn = data['nqn']
     st = f"nvme connect --transport=tcp --traddr={ip} --trsvcid={port} --nqn={nqn}"
     logger.debug(st)
-    out, err, ret_code = node_utils.run_command(st)
+    out, err, ret_code = shell_utils.run_command(st)
     logger.debug(ret_code)
     logger.debug(out)
     logger.debug(err)
@@ -243,7 +243,7 @@ def disconnect_device():
     data = request.get_json()
     dev_path = data['dev_path']
     st = f"nvme disconnect --device={dev_path}"
-    out, err, ret_code = node_utils.run_command(st)
+    out, err, ret_code = shell_utils.run_command(st)
     logger.debug(ret_code)
     logger.debug(out)
     logger.debug(err)
@@ -255,7 +255,7 @@ def disconnect_nqn():
     data = request.get_json()
     nqn = data['nqn']
     st = f"nvme disconnect --nqn={nqn}"
-    out, err, ret_code = node_utils.run_command(st)
+    out, err, ret_code = shell_utils.run_command(st)
     logger.debug(ret_code)
     logger.debug(out)
     logger.debug(err)
@@ -265,7 +265,7 @@ def disconnect_nqn():
 @bp.route('/disconnect_all', methods=['POST'])
 def disconnect_all():
     st = "nvme disconnect-all"
-    out, err, ret_code = node_utils.run_command(st)
+    out, err, ret_code = shell_utils.run_command(st)
     logger.debug(ret_code)
     logger.debug(out)
     logger.debug(err)

--- a/simplyblock_web/blueprints/caching_node_ops_k8s.py
+++ b/simplyblock_web/blueprints/caching_node_ops_k8s.py
@@ -209,7 +209,7 @@ def get_info():
         "spdk_devices": node_utils.get_spdk_devices(),
         "spdk_pcie_list": node_utils.get_spdk_pcie_list(),
 
-        "network_interface": node_utils.get_nics_data()
+        "network_interface": core_utils.get_nics_data()
     }
     return utils.get_response(out)
 

--- a/simplyblock_web/blueprints/node_api_basic.py
+++ b/simplyblock_web/blueprints/node_api_basic.py
@@ -6,7 +6,7 @@ import cpuinfo
 from flask import Blueprint
 from flask import request
 
-from simplyblock_core import shell_utils
+from simplyblock_core import shell_utils, utils as core_utils
 from simplyblock_web import utils, node_utils
 
 logger = logging.getLogger(__name__)
@@ -54,7 +54,7 @@ def get_info():
         "spdk_devices": node_utils.get_spdk_devices(),
         "spdk_pcie_list": node_utils.get_spdk_pcie_list(),
 
-        "network_interface": node_utils.get_nics_data()
+        "network_interface": core_utils.get_nics_data()
     }
     return utils.get_response(out)
 

--- a/simplyblock_web/blueprints/node_api_basic.py
+++ b/simplyblock_web/blueprints/node_api_basic.py
@@ -26,10 +26,10 @@ except:
 def scan_devices():
     run_health_check = request.args.get('run_health_check', default=False, type=bool)
     out = {
-        "nvme_devices": node_utils._get_nvme_devices(),
-        "nvme_pcie_list": node_utils._get_nvme_pcie_list(),
-        "spdk_devices": node_utils._get_spdk_devices(),
-        "spdk_pcie_list": node_utils._get_spdk_pcie_list(),
+        "nvme_devices": node_utils.get_nvme_devices(),
+        "nvme_pcie_list": node_utils.get_nvme_pcie_list(),
+        "spdk_devices": node_utils.get_spdk_devices(),
+        "spdk_pcie_list": node_utils.get_spdk_pcie_list(),
     }
     return utils.get_response(out)
 
@@ -48,11 +48,11 @@ def get_info():
         "hugepages": node_utils.get_huge_memory(),
         "memory_details": node_utils.get_memory_details(),
 
-        "nvme_devices": node_utils._get_nvme_devices(),
-        "nvme_pcie_list": node_utils._get_nvme_pcie_list(),
+        "nvme_devices": node_utils.get_nvme_devices(),
+        "nvme_pcie_list": node_utils.get_nvme_pcie_list(),
 
-        "spdk_devices": node_utils._get_spdk_devices(),
-        "spdk_pcie_list": node_utils._get_spdk_pcie_list(),
+        "spdk_devices": node_utils.get_spdk_devices(),
+        "spdk_pcie_list": node_utils.get_spdk_pcie_list(),
 
         "network_interface": node_utils.get_nics_data()
     }

--- a/simplyblock_web/blueprints/node_api_basic.py
+++ b/simplyblock_web/blueprints/node_api_basic.py
@@ -6,6 +6,7 @@ import cpuinfo
 from flask import Blueprint
 from flask import request
 
+from simplyblock_core import shell_utils
 from simplyblock_web import utils, node_utils
 
 logger = logging.getLogger(__name__)
@@ -13,10 +14,10 @@ logger = logging.getLogger(__name__)
 bp = Blueprint("node_api_basic", __name__, url_prefix="/")
 
 cpu_info = cpuinfo.get_cpu_info()
-hostname, _, _ = node_utils.run_command("hostname -s")
+hostname, _, _ = shell_utils.run_command("hostname -s")
 system_id = ""
 try:
-    system_id, _, _ = node_utils.run_command("dmidecode -s system-uuid")
+    system_id, _, _ = shell_utils.run_command("dmidecode -s system-uuid")
 except:
     pass
 
@@ -66,7 +67,7 @@ def connect_to_nvme():
     nqn = data['nqn']
     st = f"nvme connect --transport=tcp --traddr={ip} --trsvcid={port} --nqn={nqn}"
     logger.debug(st)
-    out, err, ret_code = node_utils.run_command(st)
+    out, err, ret_code = shell_utils.run_command(st)
     logger.debug(ret_code)
     logger.debug(out)
     logger.debug(err)
@@ -81,7 +82,7 @@ def disconnect_device():
     data = request.get_json()
     dev_path = data['dev_path']
     st = f"nvme disconnect --device={dev_path}"
-    out, err, ret_code = node_utils.run_command(st)
+    out, err, ret_code = shell_utils.run_command(st)
     logger.debug(ret_code)
     logger.debug(out)
     logger.debug(err)
@@ -93,7 +94,7 @@ def disconnect_nqn():
     data = request.get_json()
     nqn = data['nqn']
     st = f"nvme disconnect --nqn={nqn}"
-    out, err, ret_code = node_utils.run_command(st)
+    out, err, ret_code = shell_utils.run_command(st)
     logger.debug(ret_code)
     logger.debug(out)
     logger.debug(err)
@@ -103,7 +104,7 @@ def disconnect_nqn():
 @bp.route('/disconnect_all', methods=['POST'])
 def disconnect_all():
     st = "nvme disconnect-all"
-    out, err, ret_code = node_utils.run_command(st)
+    out, err, ret_code = shell_utils.run_command(st)
     logger.debug(ret_code)
     logger.debug(out)
     logger.debug(err)

--- a/simplyblock_web/blueprints/node_api_caching_docker.py
+++ b/simplyblock_web/blueprints/node_api_caching_docker.py
@@ -22,9 +22,9 @@ bp = Blueprint("node_api_caching_docker", __name__, url_prefix="/cnode")
 def get_docker_client():
     ip = os.getenv("DOCKER_IP")
     if not ip:
-        for ifname in node_utils.get_nics_data():
+        for ifname in core_utils.get_nics_data():
             if ifname in ["eth0", "ens0"]:
-                ip = node_utils.get_nics_data()[ifname]['ip']
+                ip = core_utils.get_nics_data()[ifname]['ip']
                 break
     return docker.DockerClient(base_url=f"tcp://{ip}:2375", version="auto", timeout=60 * 5)
 

--- a/simplyblock_web/blueprints/snode_ops.py
+++ b/simplyblock_web/blueprints/snode_ops.py
@@ -294,12 +294,12 @@ def spdk_proxy_restart():
 
 
 def get_cluster_id():
-    out, _, _ = node_utils.run_command(f"cat {cluster_id_file}")
+    out, _, _ = shell_utils.run_command(f"cat {cluster_id_file}")
     return out
 
 @bp.route('/get_file_content/<string:file_name>', methods=['GET'])
 def get_file_content(file_name):
-    out, err, _ = node_utils.run_command(f"cat /etc/simplyblock/{file_name}")
+    out, err, _ = shell_utils.run_command(f"cat /etc/simplyblock/{file_name}")
     if out:
         return utils.get_response(out)
     elif err:
@@ -314,12 +314,12 @@ def set_cluster_id(cluster_id):
 
 
 def delete_cluster_id():
-    out, _, _ = node_utils.run_command(f"rm -f {cluster_id_file}")
+    out, _, _ = shell_utils.run_command(f"rm -f {cluster_id_file}")
     return out
 
 
 def get_node_lsblk():
-    out, err, rc = node_utils.run_command("lsblk -J")
+    out, err, rc = shell_utils.run_command("lsblk -J")
     if rc != 0:
         logger.error(err)
         return []
@@ -510,8 +510,8 @@ def delete_gpt_partitions_for_dev():
 
 
 CPU_INFO = cpuinfo.get_cpu_info()
-HOSTNAME, _, _ = node_utils.run_command("hostname -s")
-SYSTEM_ID, _, _ = node_utils.run_command("dmidecode -s system-uuid")
+HOSTNAME, _, _ = shell_utils.run_command("hostname -s")
+SYSTEM_ID, _, _ = shell_utils.run_command("dmidecode -s system-uuid")
 CLOUD_INFO = {}
 if not os.environ.get("WITHOUT_CLOUD_INFO"):
     CLOUD_INFO = get_amazon_cloud_info()

--- a/simplyblock_web/blueprints/snode_ops.py
+++ b/simplyblock_web/blueprints/snode_ops.py
@@ -89,9 +89,9 @@ def get_docker_client(timeout=60):
     except:
         ip = os.getenv("DOCKER_IP")
         if not ip:
-            for ifname in node_utils.get_nics_data():
+            for ifname in core_utils.get_nics_data():
                 if ifname in ["eth0", "ens0"]:
-                    ip = node_utils.get_nics_data()[ifname]['ip']
+                    ip = core_utils.get_nics_data()[ifname]['ip']
                     break
         cl = docker.DockerClient(base_url=f"tcp://{ip}:2375", version="auto", timeout=timeout)
         try:
@@ -369,7 +369,7 @@ def get_info():
         "spdk_devices": node_utils.get_spdk_devices(),
         "spdk_pcie_list": node_utils.get_spdk_pcie_list(),
 
-        "network_interface": node_utils.get_nics_data(),
+        "network_interface": core_utils.get_nics_data(),
 
         "cloud_instance": CLOUD_INFO,
 

--- a/simplyblock_web/blueprints/snode_ops.py
+++ b/simplyblock_web/blueprints/snode_ops.py
@@ -13,9 +13,8 @@ from docker.types import LogConfig
 from flask import Blueprint
 from flask import request
 
-from simplyblock_web import utils, node_utils
-
 from simplyblock_core import scripts, constants, shell_utils, utils as core_utils
+from simplyblock_web import utils, node_utils
 
 logger = logging.getLogger(__name__)
 
@@ -105,10 +104,10 @@ def get_docker_client(timeout=60):
 def scan_devices():
     run_health_check = request.args.get('run_health_check', default=False, type=bool)
     out = {
-        "nvme_devices": node_utils._get_nvme_devices(),
-        "nvme_pcie_list": node_utils._get_nvme_pcie_list(),
-        "spdk_devices": node_utils._get_spdk_devices(),
-        "spdk_pcie_list": node_utils._get_spdk_pcie_list(),
+        "nvme_devices": node_utils.get_nvme_devices(),
+        "nvme_pcie_list": node_utils.get_nvme_pcie_list(),
+        "spdk_devices": node_utils.get_spdk_devices(),
+        "spdk_pcie_list": node_utils.get_spdk_pcie_list(),
     }
     return utils.get_response(out)
 
@@ -364,11 +363,11 @@ def get_info():
         "hugepages": node_utils.get_huge_memory(),
         "memory_details": node_utils.get_memory_details(),
 
-        "nvme_devices": node_utils._get_nvme_devices(),
-        "nvme_pcie_list": node_utils._get_nvme_pcie_list(),
+        "nvme_devices": node_utils.get_nvme_devices(),
+        "nvme_pcie_list": node_utils.get_nvme_pcie_list(),
 
-        "spdk_devices": node_utils._get_spdk_devices(),
-        "spdk_pcie_list": node_utils._get_spdk_pcie_list(),
+        "spdk_devices": node_utils.get_spdk_devices(),
+        "spdk_pcie_list": node_utils.get_spdk_pcie_list(),
 
         "network_interface": node_utils.get_nics_data(),
 

--- a/simplyblock_web/blueprints/snode_ops_k8s.py
+++ b/simplyblock_web/blueprints/snode_ops_k8s.py
@@ -16,8 +16,8 @@ from kubernetes.client import ApiException
 from jinja2 import Environment, FileSystemLoader
 import yaml
 
-from simplyblock_web import utils, node_utils, node_utils_k8s
 from simplyblock_core import scripts, constants, shell_utils, utils as core_utils
+from simplyblock_web import utils, node_utils, node_utils_k8s
 from simplyblock_web.node_utils_k8s import deployment_name, namespace_id_file, pod_name
 
 logger = logging.getLogger(__name__)
@@ -105,10 +105,10 @@ def get_amazon_cloud_info():
 def scan_devices():
     run_health_check = request.args.get('run_health_check', default=False, type=bool)
     out = {
-        "nvme_devices": node_utils._get_nvme_devices(),
-        "nvme_pcie_list": node_utils._get_nvme_pcie_list(),
-        "spdk_devices": node_utils._get_spdk_devices(),
-        "spdk_pcie_list": node_utils._get_spdk_pcie_list(),
+        "nvme_devices": node_utils.get_nvme_devices(),
+        "nvme_pcie_list": node_utils.get_nvme_pcie_list(),
+        "spdk_devices": node_utils.get_spdk_devices(),
+        "spdk_pcie_list": node_utils.get_spdk_pcie_list(),
     }
     return utils.get_response(out)
 
@@ -152,11 +152,11 @@ def get_info():
         "hugepages": node_utils.get_huge_memory(),
         "memory_details": node_utils.get_memory_details(),
 
-        "nvme_devices": node_utils._get_nvme_devices(),
-        "nvme_pcie_list": node_utils._get_nvme_pcie_list(),
+        "nvme_devices": node_utils.get_nvme_devices(),
+        "nvme_pcie_list": node_utils.get_nvme_pcie_list(),
 
-        "spdk_devices": node_utils._get_spdk_devices(),
-        "spdk_pcie_list": node_utils._get_spdk_pcie_list(),
+        "spdk_devices": node_utils.get_spdk_devices(),
+        "spdk_pcie_list": node_utils.get_spdk_pcie_list(),
 
         "network_interface": node_utils.get_nics_data(),
 

--- a/simplyblock_web/blueprints/snode_ops_k8s.py
+++ b/simplyblock_web/blueprints/snode_ops_k8s.py
@@ -158,7 +158,7 @@ def get_info():
         "spdk_devices": node_utils.get_spdk_devices(),
         "spdk_pcie_list": node_utils.get_spdk_pcie_list(),
 
-        "network_interface": node_utils.get_nics_data(),
+        "network_interface": core_utils.get_nics_data(),
 
         "cloud_instance": CLOUD_INFO,
         "cores_config": get_cores_config(CPU_INFO['count']),

--- a/simplyblock_web/blueprints/snode_ops_k8s.py
+++ b/simplyblock_web/blueprints/snode_ops_k8s.py
@@ -114,17 +114,17 @@ def scan_devices():
 
 
 def get_cluster_id():
-    out, _, _ = node_utils.run_command(f"cat {cluster_id_file}")
+    out, _, _ = shell_utils.run_command(f"cat {cluster_id_file}")
     return out
 
 
 def set_cluster_id(cluster_id):
-    out, _, _ = node_utils.run_command(f"echo {cluster_id} > {cluster_id_file}")
+    out, _, _ = shell_utils.run_command(f"echo {cluster_id} > {cluster_id_file}")
     return out
 
 
 def delete_cluster_id():
-    out, _, _ = node_utils.run_command(f"rm -f {cluster_id_file}")
+    out, _, _ = shell_utils.run_command(f"rm -f {cluster_id_file}")
     return out
 
 
@@ -254,7 +254,7 @@ def delete_gpt_partitions_for_dev():
 
 
 CPU_INFO = cpuinfo.get_cpu_info()
-HOSTNAME, _, _ = node_utils.run_command("hostname -s")
+HOSTNAME, _, _ = shell_utils.run_command("hostname -s")
 SYSTEM_ID = ""
 CLOUD_INFO = get_amazon_cloud_info()
 if not CLOUD_INFO:
@@ -266,7 +266,7 @@ if not CLOUD_INFO:
 if CLOUD_INFO:
     SYSTEM_ID = CLOUD_INFO["id"]
 else:
-    SYSTEM_ID, _, _ = node_utils.run_command("dmidecode -s system-uuid")
+    SYSTEM_ID, _, _ = shell_utils.run_command("dmidecode -s system-uuid")
 
 
 @bp.route('/spdk_process_start', methods=['POST'])
@@ -395,7 +395,7 @@ def spdk_process_is_up():
 
 @bp.route('/get_file_content/<string:file_name>', methods=['GET'])
 def get_file_content(file_name):
-    out, err, _ = node_utils.run_command(f"cat /etc/simplyblock/{file_name}")
+    out, err, _ = shell_utils.run_command(f"cat /etc/simplyblock/{file_name}")
     if out:
         return utils.get_response(out)
     elif err:

--- a/simplyblock_web/node_utils.py
+++ b/simplyblock_web/node_utils.py
@@ -12,6 +12,7 @@ import jc
 from kubernetes.stream import stream
 from kubernetes import client, config
 
+from simplyblock_core import shell_utils
 from simplyblock_web import utils
 
 
@@ -19,28 +20,18 @@ from simplyblock_web import utils
 logger = logging.getLogger(__name__)
 
 
-def run_command(cmd):
-    try:
-        process = subprocess.Popen(
-            cmd.split(), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        stdout, stderr = process.communicate()
-        return stdout.strip().decode("utf-8"), stderr.strip(), process.returncode
-    except Exception as e:
-        return "", str(e), 1
-
-
 def _get_spdk_pcie_list():  # return: ['0000:00:1e.0', '0000:00:1f.0']
-    out, err, _ = run_command("ls /sys/bus/pci/drivers/uio_pci_generic")
+    out, err, _ = shell_utils.run_command("ls /sys/bus/pci/drivers/uio_pci_generic")
     spdk_pcie_list = [line for line in out.split() if line.startswith("0000")]
     if not spdk_pcie_list:
-        out, err, _ = run_command("ls /sys/bus/pci/drivers/vfio-pci")
+        out, err, _ = shell_utils.run_command("ls /sys/bus/pci/drivers/vfio-pci")
         spdk_pcie_list = [line for line in out.split() if line.startswith("0000")]
     logger.debug(spdk_pcie_list)
     return spdk_pcie_list
 
 
 def _get_nvme_pcie_list():  # return: ['0000:00:1e.0', '0000:00:1f.0']
-    out, err, _ = run_command("ls /sys/bus/pci/drivers/nvme")
+    out, err, _ = shell_utils.run_command("ls /sys/bus/pci/drivers/nvme")
     spdk_pcie_list = [line for line in out.split() if line.startswith("0000")]
     logger.debug(spdk_pcie_list)
     return spdk_pcie_list
@@ -59,7 +50,7 @@ def get_nvme_pcie():
 
 
 def _get_nvme_devices():
-    out, err, rc = run_command("nvme list -v -o json")
+    out, err, rc = shell_utils.run_command("nvme list -v -o json")
     if rc != 0:
         logger.error("Error getting nvme list")
         logger.error(err)
@@ -94,7 +85,7 @@ def _get_nvme_devices():
 
 
 def get_nics_data():
-    out, err, rc = run_command("ip -j address show")
+    out, err, rc = shell_utils.run_command("ip -j address show")
     if rc != 0:
         logger.error(err)
         return []
@@ -125,7 +116,7 @@ def _get_spdk_devices():
 
 
 def _get_mem_info():
-    out, err, rc = run_command("cat /proc/meminfo")
+    out, err, rc = shell_utils.run_command("cat /proc/meminfo")
 
     if rc != 0:
         raise ValueError('Failed to get memory info')
@@ -167,7 +158,7 @@ def get_memory_details():
 
 
 def get_host_arch():
-    out, err, rc = run_command("uname -m")
+    out, err, rc = shell_utils.run_command("uname -m")
     return out
 
 def get_region():

--- a/simplyblock_web/node_utils.py
+++ b/simplyblock_web/node_utils.py
@@ -20,7 +20,7 @@ from simplyblock_web import utils
 logger = logging.getLogger(__name__)
 
 
-def _get_spdk_pcie_list():  # return: ['0000:00:1e.0', '0000:00:1f.0']
+def get_spdk_pcie_list():  # return: ['0000:00:1e.0', '0000:00:1f.0']
     out, err, _ = shell_utils.run_command("ls /sys/bus/pci/drivers/uio_pci_generic")
     spdk_pcie_list = [line for line in out.split() if line.startswith("0000")]
     if not spdk_pcie_list:
@@ -30,7 +30,7 @@ def _get_spdk_pcie_list():  # return: ['0000:00:1e.0', '0000:00:1f.0']
     return spdk_pcie_list
 
 
-def _get_nvme_pcie_list():  # return: ['0000:00:1e.0', '0000:00:1f.0']
+def get_nvme_pcie_list():  # return: ['0000:00:1e.0', '0000:00:1f.0']
     out, err, _ = shell_utils.run_command("ls /sys/bus/pci/drivers/nvme")
     spdk_pcie_list = [line for line in out.split() if line.startswith("0000")]
     logger.debug(spdk_pcie_list)
@@ -49,7 +49,7 @@ def get_nvme_pcie():
     return devs
 
 
-def _get_nvme_devices():
+def get_nvme_devices():
     out, err, rc = shell_utils.run_command("nvme list -v -o json")
     if rc != 0:
         logger.error("Error getting nvme list")
@@ -111,7 +111,7 @@ def get_nics_data():
     return iface_list
 
 
-def _get_spdk_devices():
+def get_spdk_devices():
     return []
 
 

--- a/simplyblock_web/node_utils.py
+++ b/simplyblock_web/node_utils.py
@@ -84,33 +84,6 @@ def get_nvme_devices():
     return devices
 
 
-def get_nics_data():
-    out, err, rc = shell_utils.run_command("ip -j address show")
-    if rc != 0:
-        logger.error(err)
-        return []
-    data = json.loads(out)
-
-    def _get_ip4_address(list_of_addr):
-        if list_of_addr:
-            for data in list_of_addr:
-                if data['family'] == 'inet':
-                    return data['local']
-        return ""
-
-    devices = {i["ifname"]: i for i in data}
-    iface_list = {}
-    for nic in devices:
-        device = devices[nic]
-        iface = {
-            'name': device['ifname'],
-            'ip': _get_ip4_address(device['addr_info']),
-            'status': device['operstate'],
-            'net_type': device['link_type']}
-        iface_list[nic] = iface
-    return iface_list
-
-
 def get_spdk_devices():
     return []
 


### PR DESCRIPTION
This PR unifies use of node helpers:
- the `run_command` helper in `node_utils` is removed and the one from `shell_utils` is used in its place
- names are changed to indicate them as public
- duplicate helpers in `caching_node_ops` are removed