### PR TITLE
Added schema check of the cli-reference.yaml

### DIFF
--- a/scripts/cli-wrapper-gen.py
+++ b/scripts/cli-wrapper-gen.py
@@ -3,6 +3,10 @@ import yaml
 import sys
 import re
 
+from jsonschema import validators
+from jsonschema.exceptions import ValidationError
+
+
 def is_parameter(item):
     return item["name"].startswith("--") or item["name"].startswith("-")
 
@@ -126,6 +130,19 @@ base_path = sys.argv[1]
 with open("%s/cli-reference.yaml" % base_path) as stream:
     try:
         reference = yaml.safe_load(stream)
+        # validate reference file against schema
+        with open("%s/cli-reference-schema.yaml" % base_path) as schema:
+            schema = yaml.safe_load(schema)
+            validator_type = validators.validator_for(schema)
+            validator = validator_type(schema)
+            iterator = iter(validator.iter_errors(reference))
+            error = next(iterator, None)
+            if error:
+                print("Generator failed on schema validation. Found the following errors:", file=sys.stderr)
+                while error:
+                    print(f" - {error.json_path}: {error.message}", file=sys.stderr)
+                    error = next(iterator, None)
+                sys.exit(1)
 
         for command in reference["commands"]:
             for subcommand in command["subcommands"]:

--- a/scripts/generate.sh
+++ b/scripts/generate.sh
@@ -5,6 +5,6 @@ if [[ "${PYTHON}" == "" ]]; then
   PYTHON="$(command -v python3)"
 fi
 
-${PYTHON} -m pip install jinja2 PyYAML
+${PYTHON} -m pip --quiet install jinja2 PyYAML jsonschema
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 ${PYTHON} "${SCRIPT_DIR}/cli-wrapper-gen.py" "${SCRIPT_DIR}/.."


### PR DESCRIPTION
This PR introduces schema validation against the `cli-reference.yaml` to prevent illegal or misused properties.

If errors are found, the validation errors are listed on stderr for easy analysis of the schema validation failure and fixing.

Example output:
```
(.venv) demo@demo ~/s/sbcli > scripts/generate.sh
Generator failed on schema validation. Found the following errors:
 - $.commands[1].subcommands[0].arguments[33].type: 1 is not of type 'string'
 - $.commands[1].subcommands[0].arguments[33].type: 1 is not one of ['str', 'bool', 'int']
```