### PR TITLE
fix: task not found error when trying to cancel task

### DIFF
--- a/simplyblock_core/storage_node_ops.py
+++ b/simplyblock_core/storage_node_ops.py
@@ -1477,7 +1477,7 @@ def remove_storage_node(node_id, force_remove=False, force_migrate=False):
         for task in tasks:
             if task.node_id == node_id:
                 if task.status != JobSchedule.STATUS_DONE and task.canceled is False:
-                    tasks_controller.cancel_task(task.get_id())
+                    tasks_controller.cancel_task(task.uuid)
 
     lvols = db_controller.get_lvols_by_node_id(node_id)
     if lvols:


### PR DESCRIPTION
## JIRA ticket link/s

-   

## Summary of changes

- Fix task not found error


## Additional Info

When trying to force remove a node, I get this error: 

<img width="1436" alt="Screenshot 2025-04-01 at 09 04 55" src="https://github.com/user-attachments/assets/f9e889a6-7fa1-4093-b47b-5961aba36979" />

```
Task not found: 8834aec2-a12f-48c7-9511-19ddea0b39c8/1743490691/a2db7430-7dab-4db5-97da-19a9cce2d950
```

The above fix is tested by making modification in sbcli-dev

`sbcli-dev storage-node remove --force` output with this change applied

<img width="1422" alt="Screenshot 2025-04-01 at 09 45 06" src="https://github.com/user-attachments/assets/d348e9cc-7834-46c9-93c4-54b1a613df03" />


