### PR TITLE
catch exception if k8s library fails

### DIFF
--- a/simplyblock_core/env_var
+++ b/simplyblock_core/env_var
@@ -1,5 +1,5 @@
 SIMPLY_BLOCK_COMMAND_NAME=sbcli-dev
-SIMPLY_BLOCK_VERSION=14.0.96
+SIMPLY_BLOCK_VERSION=14.0.97
 
 SIMPLY_BLOCK_DOCKER_IMAGE=public.ecr.aws/simply-block/simplyblock:main
 DOCKER_USER=hamdysimplyblock

--- a/simplyblock_web/blueprints/snode_ops_k8s.py
+++ b/simplyblock_web/blueprints/snode_ops_k8s.py
@@ -445,11 +445,7 @@ def _is_pod_up():
         resp = k8s_core_v1.list_namespaced_pod(get_namespace())
         for pod in resp.items:
             if pod.metadata.name.startswith(pod_name):
-                status = pod.status.phase
-                if status == "Running":
-                    return True
-                else:
-                    return False
+                return pod.status.phase == "Running"
     except ApiException as e:
         logger.error(f"API error: {e}")
         return False

--- a/simplyblock_web/blueprints/snode_ops_k8s.py
+++ b/simplyblock_web/blueprints/snode_ops_k8s.py
@@ -441,14 +441,21 @@ def spdk_process_kill():
 
 
 def _is_pod_up():
-    resp = k8s_core_v1.list_namespaced_pod(get_namespace())
-    for pod in resp.items:
-        if pod.metadata.name.startswith(pod_name):
-            status = pod.status.phase
-            if status == "Running":
-                return True
-            else:
-                return False
+    try:
+        resp = k8s_core_v1.list_namespaced_pod(get_namespace())
+        for pod in resp.items:
+            if pod.metadata.name.startswith(pod_name):
+                status = pod.status.phase
+                if status == "Running":
+                    return True
+                else:
+                    return False
+    except ApiException as e:
+        logger.error(f"API error: {e}")
+        return False
+    except Exception as e:
+        logger.error(f"Unexpected error: {e}")
+        return False
     return False
 
 


### PR DESCRIPTION
When I call the `/snode/spdk_process_start` API. I got this error: 

```
<!doctype html>
<html lang=en>
<title>500 Internal Server Error</title>
<h1>Internal Server Error</h1>
<p>The server encountered an internal error and was unable to complete your request. Either the server is overloaded or
    there is an error in the application.</p>
```

and the error on the SNODE API side
```
2025-04-02 13:34:09,186: ERROR: Exception on /snode/spdk_process_start [POST]
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/kubernetes/stream/ws_client.py", line 533, in websocket_call
    client = WSClient(configuration, url, headers, capture_all, binary=binary)
  File "/usr/local/lib/python3.9/site-packages/kubernetes/stream/ws_client.py", line 68, in __init__
    self.sock = create_websocket(configuration, url, headers)
  File "/usr/local/lib/python3.9/site-packages/kubernetes/stream/ws_client.py", line 499, in create_websocket
    websocket.connect(url, **connect_opt)
  File "/usr/local/lib/python3.9/site-packages/websocket/_core.py", line 261, in connect
    self.handshake_response = handshake(self.sock, url, *addrs, **options)
  File "/usr/local/lib/python3.9/site-packages/websocket/_handshake.py", line 65, in handshake
    status, resp = _get_resp_headers(sock)
  File "/usr/local/lib/python3.9/site-packages/websocket/_handshake.py", line 150, in _get_resp_headers
    raise WebSocketBadStatusException(
websocket._exceptions.WebSocketBadStatusException: Handshake status 200 OK -+-+- {'audit-id': 'c74380d8-c0f9-45ec-b14b-a73973a538e7', 'cache-control': 'no-cache, private', 'content-type': 'application/json', 'x-kubernetes-pf-flowschema-uid': '0c3cf8a3-8def-4d6d-becf-fa0162906ce6', 'x-kubernetes-pf-prioritylevel-uid': '40276749-16c1-427f-901d-c8462d115178', 'date': 'Wed, 02 Apr 2025 13:34:09 GMT', 'transfer-encoding': 'chunked'} -+-+- None

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/flask/app.py", line 1511, in wsgi_app
    response = self.full_dispatch_request()
  File "/usr/local/lib/python3.9/site-packages/flask/app.py", line 919, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/usr/local/lib/python3.9/site-packages/flask/app.py", line 917, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/local/lib/python3.9/site-packages/flask/app.py", line 902, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)  # type: ignore[no-any-return]
  File "/app/simplyblock_web/blueprints/snode_ops_k8s.py", line 379, in spdk_process_start
    if _is_pod_up():
  File "/app/simplyblock_web/blueprints/snode_ops_k8s.py", line 444, in _is_pod_up
    resp = k8s_core_v1.list_namespaced_pod(get_namespace())
  File "/usr/local/lib/python3.9/site-packages/kubernetes/client/api/core_v1_api.py", line 15968, in list_namespaced_pod
    return self.list_namespaced_pod_with_http_info(namespace, **kwargs)  # noqa: E501
  File "/usr/local/lib/python3.9/site-packages/kubernetes/client/api/core_v1_api.py", line 16087, in list_namespaced_pod_with_http_info
    return self.api_client.call_api(
  File "/usr/local/lib/python3.9/site-packages/kubernetes/client/api_client.py", line 348, in call_api
    return self.__call_api(resource_path, method,
  File "/usr/local/lib/python3.9/site-packages/kubernetes/client/api_client.py", line 180, in __call_api
    response_data = self.request(
  File "/usr/local/lib/python3.9/site-packages/kubernetes/stream/ws_client.py", line 543, in websocket_call
    raise ApiException(status=0, reason=str(e))
kubernetes.client.exceptions.ApiException: (0)
Reason: Handshake status 200 OK -+-+- {'audit-id': 'c74380d8-c0f9-45ec-b14b-a73973a538e7', 'cache-control': 'no-cache, private', 'content-type': 'application/json', 'x-kubernetes-pf-flowschema-uid': '0c3cf8a3-8def-4d6d-becf-fa0162906ce6', 'x-kubernetes-pf-prioritylevel-uid': '40276749-16c1-427f-901d-c8462d115178', 'date': 'Wed, 02 Apr 2025 13:34:09 GMT', 'transfer-encoding': 'chunked'} -+-+- None

2025-04-02 13:34:09,187: INFO: 192.168.10.1 - - [02/Apr/2025 13:34:09] "POST /snode/spdk_process_start HTTP/1.1" 500 -
```


This looks like a broken socket when trying to connect with Kubernetes. Probably because we are using an older version of python?? 

So fixing this by adding catching the exception. 