### PR TITLE
Make 'storage-node make-primary' public

### DIFF
--- a/cli-reference.yaml
+++ b/cli-reference.yaml
@@ -593,8 +593,10 @@ commands:
             type: str
             completer: _completer_get_sn_list
       - name: make-primary
-        help: "In case of HA SNode, makes the current node as primary"
-        private: true
+        help: "Forces to make the provided node id primary"
+        description: |
+          Makes the storage node the primary node. This is required after certain storage cluster operations, such
+          as a storage node migration.
         arguments:
           - name: "node_id"
             help: "Storage node id"

--- a/simplyblock_cli/cli.py
+++ b/simplyblock_cli/cli.py
@@ -68,8 +68,7 @@ class CLIWrapper(CLIWrapperBase):
             self.init_storage_node__send_cluster_map(subparser)
         if self.developer_mode:
             self.init_storage_node__get_cluster_map(subparser)
-        if self.developer_mode:
-            self.init_storage_node__make_primary(subparser)
+        self.init_storage_node__make_primary(subparser)
         if self.developer_mode:
             self.init_storage_node__dump_lvstore(subparser)
         if self.developer_mode:
@@ -277,7 +276,7 @@ class CLIWrapper(CLIWrapperBase):
         subcommand.add_argument('node_id', help='Storage node id', type=str).completer = self._completer_get_sn_list
 
     def init_storage_node__make_primary(self, subparser):
-        subcommand = self.add_sub_command(subparser, 'make-primary', 'In case of HA SNode, makes the current node as primary')
+        subcommand = self.add_sub_command(subparser, 'make-primary', 'Forces to make the provided node id primary')
         subcommand.add_argument('node_id', help='Storage node id', type=str).completer = self._completer_get_sn_list
 
     def init_storage_node__dump_lvstore(self, subparser):
@@ -983,11 +982,7 @@ class CLIWrapper(CLIWrapperBase):
                 else:
                     ret = self.storage_node__get_cluster_map(sub_command, args)
             elif sub_command in ['make-primary']:
-                if not self.developer_mode:
-                    print("This command is private.")
-                    ret = False
-                else:
-                    ret = self.storage_node__make_primary(sub_command, args)
+                ret = self.storage_node__make_primary(sub_command, args)
             elif sub_command in ['dump-lvstore']:
                 if not self.developer_mode:
                     print("This command is private.")


### PR DESCRIPTION
For a successful storage node migration, the new storage node eventually needs to be made the primary node using `sbcli storage-node make-primary`. Hence, this operation needs to be public so that the user can execute it.

This PR is related to https://github.com/simplyblock-io/documentation/issues/32