### PR TITLE
Renamed --node-ip to --node-addr

### DIFF
--- a/cli-reference.yaml
+++ b/cli-reference.yaml
@@ -262,12 +262,15 @@ commands:
             type: str
             default: "0"
             private: true
-          - name: "--node-ip"
+          - name: "--node-addr"
+            aliases:
+              - "--node-ip"
             help: "Restart Node on new node"
             description: >
               Allows to restart an existing storage node on new host or hardware. Devices attached to storage nodes
               have to be attached to new hosts. Otherwise, they have to be marked as failed and removed from cluster.
-              Triggers a pro-active migration of data from those devices onto other storage nodes.
+              Triggers a pro-active migration of data from those devices onto other storage nodes.<br><br>
+              The provided value must be presented in the form of _IP:PORT_. Be default the port number is _5000_.
             dest: node_ip
             type: str
           - name: "--number-of-devices"

--- a/simplyblock_cli/cli.py
+++ b/simplyblock_cli/cli.py
@@ -150,7 +150,7 @@ class CLIWrapper(CLIWrapperBase):
             argument = subcommand.add_argument('--max-snap', help='Max snapshot per storage node', type=int, default=5000, dest='max_snap', required=False)
         if self.developer_mode:
             argument = subcommand.add_argument('--max-size', help='Maximum amount of GB to be utilized on this storage node', type=str, default='0', dest='max_prov', required=False)
-        argument = subcommand.add_argument('--node-ip', help='Restart Node on new node', type=str, dest='node_ip', required=False)
+        argument = subcommand.add_argument('--node-addr', '--node-ip', help='Restart Node on new node', type=str, dest='node_ip', required=False)
         argument = subcommand.add_argument('--number-of-devices', help='Number of devices per storage node if it\'s not supported EC2 instance', type=int, dest='number_of_devices', required=False)
         if self.developer_mode:
             argument = subcommand.add_argument('--spdk-image', help='SPDK image uri', type=str, dest='spdk_image', required=False)


### PR DESCRIPTION
This PR renamed the `storage-node restart --node-ip` parameter to `--node-addr` as it requires the port number to be given as value (e.g. `192.168.0.1:5000`).

The `--node-ip` parameter name still works as it is added as an alias. It should be marked as deprecated and eventually removed.

This PR is related to: https://github.com/simplyblock-io/documentation/issues/32