### PR TITLE
Convert non-serializable types to strings

### DIFF
--- a/simplyblock_web/blueprints/swagger_ui_blueprint.py
+++ b/simplyblock_web/blueprints/swagger_ui_blueprint.py
@@ -1,6 +1,7 @@
 import os
 
 import yaml
+import json
 from flask_swagger_ui import get_swaggerui_blueprint
 
 SWAGGER_URL="/swagger"
@@ -12,6 +13,9 @@ cnf = {}
 with open(API_URL) as f:
     cnf = f.read()
     cnf = yaml.load(cnf, Loader=yaml.SafeLoader)
+
+# # Convert non-serializable types to strings
+cnf = json.loads(json.dumps(cnf, default=str))
 
 bp = get_swaggerui_blueprint(
     SWAGGER_URL,


### PR DESCRIPTION
## Summary of changes

`python simplyblock_web/app.py` is failing with this error

```
Traceback (most recent call last):
  File "/app/simplyblock_web/app.py", line 8, in <module>
    from blueprints import web_api_cluster, web_api_mgmt_node, web_api_device, \
  File "/app/simplyblock_web/blueprints/swagger_ui_blueprint.py", line 16, in <module>
    bp = get_swaggerui_blueprint(
  File "/usr/local/lib/python3.9/site-packages/flask_swagger_ui/flask_swagger_ui.py", line 34, in get_swaggerui_blueprint
    "config_json": json.dumps(default_config),
  File "/usr/local/lib/python3.9/json/__init__.py", line 231, in dumps
    return _default_encoder.encode(obj)
  File "/usr/local/lib/python3.9/json/encoder.py", line 199, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/usr/local/lib/python3.9/json/encoder.py", line 257, in iterencode
    return _iterencode(o, 0)
  File "/usr/local/lib/python3.9/json/encoder.py", line 179, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type datetime is not JSON serializable
```

Fixed this by converting non serialisable types to str

## Additional Info

<img width="1002" alt="Screenshot 2025-04-03 at 12 45 22" src="https://github.com/user-attachments/assets/f6cdaa4e-4b0b-4176-b527-2305ab42b937" />
<img width="737" alt="Screenshot 2025-04-03 at 12 44 27" src="https://github.com/user-attachments/assets/63001fa3-8174-4ade-bf1c-ab53162ebbe7" />


