### PR TITLE
use ECR public image rather than docker hub

### DIFF
--- a/simplyblock_core/constants.py
+++ b/simplyblock_core/constants.py
@@ -77,7 +77,7 @@ TASK_EXEC_RETRY_COUNT = 8
 SIMPLY_BLOCK_SPDK_CORE_IMAGE = "simplyblock/spdk-core:v24.05-tag-latest"
 
 
-SIMPLY_BLOCK_SPDK_ULTRA_IMAGE = "simplyblock/spdk:main-latest"
+SIMPLY_BLOCK_SPDK_ULTRA_IMAGE = " public.ecr.aws/simply-block/ultra:main-latest"
 
 GELF_PORT = 12202
 


### PR DESCRIPTION
## Summary of changes

Currently all the images are using public ECR repos. So let's also use the same with SPDK images too. 
So that when we are rate limited, we can send an authenticated request to pull the images without rate limiting. 

