### PR TITLE
Renamed --pvc_name to --pvc-name

### DIFF
--- a/cli-reference.yaml
+++ b/cli-reference.yaml
@@ -1530,6 +1530,11 @@ commands:
             aliases:
               - "--pvc_name"
             help: "Set logical volume PVC name for k8s clients"
+            description: |
+              Set the logical volume persistent volume claim name for Kubernetes clients.<br><br>
+              !!! warning
+                  The old parameter name `--pvc_name` is deprecated and shouldn't be used anymore. It will eventually be
+                  removed. Please exchange the use of `--pvc_name` with `--pvc-name`.
             dest: pvc_name
             type: str
       - name: qos-set

--- a/cli-reference.yaml
+++ b/cli-reference.yaml
@@ -1526,7 +1526,9 @@ commands:
             dest: uid
             type: str
             private: true
-          - name: "--pvc_name"
+          - name: "--pvc-name"
+            aliases:
+              - "--pvc_name"
             help: "Set logical volume PVC name for k8s clients"
             dest: pvc_name
             type: str

--- a/simplyblock_cli/cli.py
+++ b/simplyblock_cli/cli.py
@@ -600,7 +600,7 @@ class CLIWrapper(CLIWrapperBase):
         argument = subcommand.add_argument('--namespace', help='Set logical volume namespace for k8s clients', type=str, dest='namespace', required=False)
         if self.developer_mode:
             argument = subcommand.add_argument('--uid', help='Set logical volume id', type=str, dest='uid', required=False)
-        argument = subcommand.add_argument('--pvc_name', help='Set logical volume PVC name for k8s clients', type=str, dest='pvc_name', required=False)
+        argument = subcommand.add_argument('--pvc-name', '--pvc_name', help='Set logical volume PVC name for k8s clients', type=str, dest='pvc_name', required=False)
 
     def init_volume__qos_set(self, subparser):
         subcommand = self.add_sub_command(subparser, 'qos-set', 'Changes QoS settings for an active logical volume')


### PR DESCRIPTION
Renamed `--pvc_name` to `--pvc-name` for naming consistency. The old name still works as an alias but should be deprecated and eventually removed.