### PR TITLE
cleanup `max_prov` if not already cleaned up in restart_node and add_node

### DIFF
--- a/simplyblock_core/storage_node_ops.py
+++ b/simplyblock_core/storage_node_ops.py
@@ -1046,6 +1046,14 @@ def add_node(cluster_id, node_ip, iface_name, data_nics_list,
             logger.error("Unsupported instance type please specify --number-of-devices.")
             return False
 
+    if not isinstance(max_prov, int):
+        try:
+            max_prov = int(max_prov)
+            max_prov = f"{max_prov}g"
+        except Exception:
+            pass
+        max_prov = int(utils.parse_size(max_prov))
+    
     if max_prov <= 0:
         logger.error(f"Incorrect max-prov value {max_prov}")
         return False
@@ -1626,6 +1634,15 @@ def restart_storage_node(
         snode.max_lvol = max_lvol
     if max_snap:
         snode.max_snap = max_snap
+
+    if not isinstance(max_prov, int):
+        try:
+            max_prov = int(max_prov)
+            max_prov = f"{max_prov}g"
+            max_prov = int(utils.parse_size(max_prov))
+        except Exception:
+            logger.error(f"Invalid max_prov value: {max_prov}")
+            return False
 
     snode.max_prov = max_prov
     if snode.max_prov <= 0:


### PR DESCRIPTION
## Summary of changes

We've started to observe in the logs that there are a lot of instances of the error: 

<img width="514" alt="Screenshot 2025-04-04 at 19 13 45" src="https://github.com/user-attachments/assets/3ef55b34-759d-4071-b6a8-700261cf6ae6" />


As a part of https://github.com/simplyblock-io/sbcli/pull/235 we've added unit conversion. Where we do the cleanup as a part of cli and then pass on the the function (add_node & restart_node). 

But these functions are used not only by CLI but also by the internal task where the cleanup don't happen. So added an additional block to cleanup if `max_prov` is not int.

