### PR TITLE
use sbcli-pre instead of sbcli

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Update simplyblock_core/env_var
         run: |
-          sed -i 's/sbcli-dev/sbcli/g' simplyblock_core/env_var
+          sed -i 's/sbcli-dev/sbcli-pre/g' simplyblock_core/env_var
           version="${{ github.event.release.tag_name }}"
           echo "Replacing SIMPLY_BLOCK_VERSION with $version"
           sed -i "s/^SIMPLY_BLOCK_VERSION=.*/SIMPLY_BLOCK_VERSION=${version}/" simplyblock_core/env_var


### PR DESCRIPTION
## Summary of changes

<img width="528" alt="Screenshot 2025-04-07 at 10 34 20" src="https://github.com/user-attachments/assets/3c0f3df1-991c-4ba1-bc31-08840e087bfb" />

 to prevent typosquatting and malicious uploads, PYPI has rejected uploads to `sbcli`


## Additional Info

Currently there are a lot of test repositories. https://pypi.org/search/?q=sbcli we should move all of them to test.pypi.org.

