### PR TITLE
python-publish only for main branch

### DIFF
--- a/.github/workflows/python-generate-test.yml
+++ b/.github/workflows/python-generate-test.yml
@@ -1,4 +1,4 @@
-name: Python Package Build
+name: Verify Python Package Build
 
 on:
   pull_request:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -4,6 +4,9 @@ on:
   push:
     paths:
       - 'simplyblock_core/env_var'
+  pull_request:
+    paths:
+      - 'simplyblock_core/env_var'
 
 permissions:
   contents: read

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -2,9 +2,8 @@ name: Python Package Build
 
 on:
   push:
-    paths:
-      - 'simplyblock_core/env_var'
-  pull_request:
+    branches:
+      - main
     paths:
       - 'simplyblock_core/env_var'
 


### PR DESCRIPTION
## Summary of changes


This stage is failing for all PRs. So adding a condition to python publish only for `main` branch

<img width="480" alt="Screenshot 2025-04-07 at 14 39 32" src="https://github.com/user-attachments/assets/37484802-787a-44f5-a9a9-231b8131ba54" />



1.  [ Provide some key summary of changes to give context as to why these changes have been made ]


