### PR TITLE
Patched handling of default ndcs + npcs for `cluster add` and `cluster create`

### DIFF
--- a/cli-reference.yaml
+++ b/cli-reference.yaml
@@ -1199,12 +1199,12 @@ commands:
             help: "Erasure coding schema parameter k (distributed raid), default: 1"
             dest: distr_ndcs
             type: int
-            default: 0
+            default: 1
           - name: "--parity-chunks-per-stripe"
             help: "Erasure coding schema parameter n (distributed raid), default: 1"
             dest: distr_npcs
             type: int
-            default: 0
+            default: 1
           - name: "--distr-bs"
             help: "(Dev) distrb bdev block size, default: 4096"
             dest: distr_bs

--- a/simplyblock_cli/cli.py
+++ b/simplyblock_cli/cli.py
@@ -465,8 +465,8 @@ class CLIWrapper(CLIWrapperBase):
         argument = subcommand.add_argument('--cap-crit', help='Capacity critical level in percent, default: 99', type=int, default=99, dest='cap_crit', required=False)
         argument = subcommand.add_argument('--prov-cap-warn', help='Capacity warning level in percent, default: 250', type=int, default=250, dest='prov_cap_warn', required=False)
         argument = subcommand.add_argument('--prov-cap-crit', help='Capacity critical level in percent, default: 500', type=int, default=500, dest='prov_cap_crit', required=False)
-        argument = subcommand.add_argument('--data-chunks-per-stripe', help='Erasure coding schema parameter k (distributed raid), default: 1', type=int, default=0, dest='distr_ndcs', required=False)
-        argument = subcommand.add_argument('--parity-chunks-per-stripe', help='Erasure coding schema parameter n (distributed raid), default: 1', type=int, default=0, dest='distr_npcs', required=False)
+        argument = subcommand.add_argument('--data-chunks-per-stripe', help='Erasure coding schema parameter k (distributed raid), default: 1', type=int, default=1, dest='distr_ndcs', required=False)
+        argument = subcommand.add_argument('--parity-chunks-per-stripe', help='Erasure coding schema parameter n (distributed raid), default: 1', type=int, default=1, dest='distr_npcs', required=False)
         if self.developer_mode:
             argument = subcommand.add_argument('--distr-bs', help='(Dev) distrb bdev block size, default: 4096', type=int, default=4096, dest='distr_bs', required=False)
         if self.developer_mode:

--- a/simplyblock_core/cluster_ops.py
+++ b/simplyblock_core/cluster_ops.py
@@ -203,8 +203,8 @@ def create_cluster(blk_size, page_size_in_blocks, cli_pass,
     if prov_cap_crit and prov_cap_crit > 0:
         c.prov_cap_crit = prov_cap_crit
     if distr_ndcs == 0 and distr_npcs == 0:
-        c.distr_ndcs = 1
-        c.distr_npcs = 1
+        logger.error("both distr_ndcs and distr_npcs cannot be 0")
+        return False
     else:
         c.distr_ndcs = distr_ndcs
         c.distr_npcs = distr_npcs
@@ -537,11 +537,11 @@ def add_cluster(blk_size, page_size_in_blocks, cap_warn, cap_crit, prov_cap_warn
     _create_update_user(cluster.uuid, cluster.grafana_endpoint, cluster.grafana_secret, cluster.secret)
 
     if distr_ndcs == 0 and distr_npcs == 0:
-        cluster.distr_ndcs = 2
-        cluster.distr_npcs = 1
-    else:
-        cluster.distr_ndcs = distr_ndcs
-        cluster.distr_npcs = distr_npcs
+        logger.error("both distr_ndcs and distr_npcs cannot be 0")
+        return False
+
+    cluster.distr_ndcs = distr_ndcs
+    cluster.distr_npcs = distr_npcs
     cluster.distr_bs = distr_bs
     cluster.distr_chunk_bs = distr_chunk_bs
     cluster.ha_type = ha_type


### PR DESCRIPTION
Our internal deploy tooling got stung by this. I made a fix to the default parameters, and changed behavior for when 0x0 is provided. Previously, it then converted this to a 2x1, I've made this error instead. My thinking is that if a user provides 0x0, it's probably an error.

In cluster add:
- set defaults to 1x1
- error if the user sets these both to 0 (previously: it would default to 2x1)

In cluster create:
- change to error if the user provides 0x0 (prev: it would default to 2x1)

I split this out into two commits in case you only want the first change.
