### PR TITLE
Use flask_openapi3 for internal API

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ prometheus-client
 ec2-metadata
 flask-swagger-ui
 sentry-sdk[flask]
+flask-openapi3

--- a/simplyblock_core/utils.py
+++ b/simplyblock_core/utils.py
@@ -36,6 +36,7 @@ CONFIG_KEYS = [
     "jc_singleton_core",
 ]
 
+
 UUID_PATTERN = re.compile(r'^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$')
 
 

--- a/simplyblock_web/blueprints/node_api_basic.py
+++ b/simplyblock_web/blueprints/node_api_basic.py
@@ -24,19 +24,24 @@ except:
     pass
 
 
-@api.get('/scan_devices', responses={
-    200: {'content': {'application/json': {'schema': utils.response_schema({
-        'type': 'object',
-        'required': ['nvme_devices', 'nvme_pcie_list', 'spdk_devices', 'spdk_pcie_list'],
-        'properties': {
-            'nvme_devices': {'type': 'array', 'items': {'type': 'string'}},
-            'nvme_pcie_list': {'type': 'array', 'items': {'type': 'string'}},
-            'spdk_devices': {'type': 'array', 'items': {'type': 'string'}},
-            'spdk_pcie_list': {'type': 'array', 'items': {'type': 'string'}},
-        },
-    })}}},
+@api.get('/scan_devices',
+    summary='Enumerate connected devices',
+    responses={
+        200: {'content': {'application/json': {'schema': utils.response_schema({
+            'type': 'object',
+            'required': ['nvme_devices', 'nvme_pcie_list', 'spdk_devices', 'spdk_pcie_list'],
+            'properties': {
+                'nvme_devices': {'type': 'array', 'items': {'type': 'string'}},
+                'nvme_pcie_list': {'type': 'array', 'items': {'type': 'string'}},
+                'spdk_devices': {'type': 'array', 'items': {'type': 'string'}},
+                'spdk_pcie_list': {'type': 'array', 'items': {'type': 'string'}},
+            },
+        })}},
+    },
 })
 def scan_devices():
+    """Query lists of connected NVMe and SPDK devices
+    """
     return utils.get_response({
         "nvme_devices": node_utils.get_nvme_devices(),
         "nvme_pcie_list": node_utils.get_nvme_pcie_list(),
@@ -45,14 +50,18 @@ def scan_devices():
     })
 
 
-@api.get('/info', responses={
-    200: {'content': {'application/json': {'schema': utils.response_schema({
-        'type': 'object',
-        'additionalProperties': True,
-    })}}},
+@api.get('/info',
+    summary='Get node info',
+    responses={
+        200: {'content': {'application/json': {'schema': utils.response_schema({
+            'type': 'object',
+            'additionalProperties': True,
+        })}},
+    },
 })
 def get_info():
-
+    """Retrieve information about the node's configuration and hardware
+    """
     out = {
         "hostname": hostname,
         "system_id": system_id,
@@ -81,12 +90,17 @@ class _NVMeParams(BaseModel):
     nqn: str
 
 
-@api.post('/nvme_connect', responses={
-    200: {'content': {'application/json': {'schema': utils.response_schema({
-        'type': 'boolean',
-    })}}},
+@api.post('/nvme_connect',
+    summary='Connect NVMe-oF target',
+    responses={
+        200: {'content': {'application/json': {'schema': utils.response_schema({
+            'type': 'boolean',
+        })}},
+    },
 })
 def connect_to_nvme(body: _NVMeParams):
+    """Connect to the indicated NVMe-oF target.
+    """
     st = f"nvme connect --transport=tcp --traddr={body.ip} --trsvcid={body.port} --nqn={body.nqn}"
     logger.debug(st)
     out, err, ret_code = shell_utils.run_command(st)
@@ -103,12 +117,17 @@ class _DisconnectParams(BaseModel):
     dev_path: str
 
 
-@api.post('/disconnect_device', responses={
-    200: {'content': {'application/json': {'schema': utils.response_schema({
-        'type': 'integer',
-    })}}},
+@api.post('/disconnect_device',
+    summary='Disconnect NVMe-oF device by name',
+    responses={
+        200: {'content': {'application/json': {'schema': utils.response_schema({
+            'type': 'integer',
+        })}},
+    },
 })
 def disconnect_device(body: _DisconnectParams):
+    """Disconnect from indicated NVMe-oF target
+    """
     st = f"nvme disconnect --device={body.dev_path}"
     out, err, ret_code = shell_utils.run_command(st)
     logger.debug(ret_code)
@@ -121,12 +140,16 @@ class _DisconnectNQNParams(BaseModel):
     nqn: str
 
 
-@api.post('/disconnect_nqn', responses={
+@api.post('/disconnect_nqn',
+    summary='Disconnect NVMe-oF device by NQN',
+    responses={
     200: {'content': {'application/json': {'schema': utils.response_schema({
         'type': 'integer',
     })}}},
 })
 def disconnect_nqn(body: _DisconnectNQNParams):
+    """Disconnect from indicated NVMe-oF target
+    """
     st = f"nvme disconnect --nqn={body.nqn}"
     out, err, ret_code = shell_utils.run_command(st)
     logger.debug(ret_code)
@@ -135,12 +158,17 @@ def disconnect_nqn(body: _DisconnectNQNParams):
     return utils.get_response(ret_code)
 
 
-@api.post('/disconnect_all', responses={
-    200: {'content': {'application/json': {'schema': utils.response_schema({
-        'type': 'integer',
-    })}}},
+@api.post('/disconnect_all',
+    summary='Disconnect all NVMe-oF devices',
+    responses={
+        200: {'content': {'application/json': {'schema': utils.response_schema({
+            'type': 'integer',
+        })}},
+    },
 })
 def disconnect_all():
+    """Disconnect from all NVMe-oF devices
+    """
     st = "nvme disconnect-all"
     out, err, ret_code = shell_utils.run_command(st)
     logger.debug(ret_code)

--- a/simplyblock_web/blueprints/snode_ops.py
+++ b/simplyblock_web/blueprints/snode_ops.py
@@ -589,7 +589,7 @@ def get_firewall(query: _RPCPortQuery):
 
 @api.post('/set_hugepages', responses={
     200: {'content': {'application/json': {'schema': utils.response_schema({
-        'type': 'bool'
+        'type': 'boolean'
     })}}},
 })
 def set_hugepages():

--- a/simplyblock_web/blueprints/snode_ops.py
+++ b/simplyblock_web/blueprints/snode_ops.py
@@ -587,7 +587,11 @@ def get_firewall(query: _RPCPortQuery):
     return utils.get_response(ret)
 
 
-@bp.route('/set_hugepages', methods=['POST'])
+@api.post('/set_hugepages', responses={
+    200: {'content': {'application/json': {'schema': utils.response_schema({
+        'type': 'bool'
+    })}}},
+})
 def set_hugepages():
     node_info = core_utils.load_config(constants.NODES_CONFIG_FILE)
     if node_info.get("nodes"):

--- a/simplyblock_web/node_webapp.py
+++ b/simplyblock_web/node_webapp.py
@@ -5,13 +5,13 @@ logger = core_utils.get_logger(__name__)
 
 import argparse
 
-from flask import Flask
+from flask_openapi3 import OpenAPI
 
 from simplyblock_web import utils
 from simplyblock_core import constants
 
 
-app = Flask(__name__)
+app = OpenAPI(__name__)
 app.url_map.strict_slashes = False
 app.config['JSONIFY_PRETTYPRINT_REGULAR'] = True
 
@@ -38,20 +38,20 @@ if __name__ == '__main__':
     mode = args.mode
     if mode == "caching_docker_node":
         from simplyblock_web.blueprints import node_api_basic, node_api_caching_docker
-        app.register_blueprint(node_api_basic.bp)
-        app.register_blueprint(node_api_caching_docker.bp)
+        app.register_api(node_api_basic.api)
+        app.register_api(node_api_caching_docker.api)
 
     if mode == "caching_kubernetes_node":
         from simplyblock_web.blueprints import node_api_basic, node_api_caching_ks
-        app.register_blueprint(node_api_basic.bp)
-        app.register_blueprint(node_api_caching_ks.bp)
+        app.register_api(node_api_basic.api)
+        app.register_api(node_api_caching_ks.api)
 
     if mode == "storage_node":
         from simplyblock_web.blueprints import snode_ops
-        app.register_blueprint(snode_ops.bp)
+        app.register_api(snode_ops.api)
 
     if mode == "storage_node_k8s":
         from simplyblock_web.blueprints import snode_ops_k8s
-        app.register_blueprint(snode_ops_k8s.bp)
+        app.register_api(snode_ops_k8s.api)
 
     app.run(host='0.0.0.0', debug=constants.LOG_WEB_DEBUG)

--- a/simplyblock_web/utils.py
+++ b/simplyblock_web/utils.py
@@ -6,6 +6,21 @@ import string
 from flask import jsonify
 
 
+IP_PATTERN = re.compile(r'^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$')
+
+
+def response_schema(result_schema: dict) -> dict:
+    return {
+        'type': 'object',
+        'required': ['status', 'results'],
+        'properties': {
+            'status': {'type': 'boolean'},
+            'results': result_schema,
+            'error': {'type': 'string'},
+        },
+    }
+
+
 def get_response(data, error=None, http_code=None):
     resp = {
         "status": True,


### PR DESCRIPTION
As discussed, this PR proposes to use flask_openapi3 for our internal API. The annotations are more elaborate, but enable automated validation of passed parameters, and provide generated documentation/specification of our API. This may be used to automatically confirm consistency of our clients with the servers, and reduces the effort spent on manual validation.

For now the PR is a draft, I did some preliminary tests that confirm basic functionality. All of our internal APIs are transcribed in this, I only added documentation beyond semantics for the basic node API to showcase how that would look. The functions' docstrings are used for the endpoint's `description`, the `summary` is passed to the annotation.

What do you think @Hamdy-khader , @noctarius 

P.S.: The PR is based on #237 , that may be removed as well but it makes sense to address in one go.