### PR TITLE
Use library provided-annotation access if present

### DIFF
--- a/simplyblock_core/models/base_model.py
+++ b/simplyblock_core/models/base_model.py
@@ -4,7 +4,8 @@ import logging
 
 import json
 from inspect import ismethod
-from typing import Mapping
+import sys
+from typing import Mapping, Type
 from collections import ChainMap
 
 
@@ -27,10 +28,24 @@ class BaseModel(object):
         self.name = self.__class__.__name__
         self.from_dict(data)
 
-    def all_annotations(self) -> ChainMap:
+    @classmethod
+    def all_annotations(cls) -> Mapping[str, Type]:
         """Returns a dictionary-like ChainMap that includes annotations for all
            attributes defined in cls or inherited from superclasses."""
-        return ChainMap(*(c.__annotations__ for c in self.__class__.__mro__ if '__annotations__' in c.__dict__))
+        if sys.version_info >= (3, 10):
+            from inspect import get_annotations
+            return ChainMap(*(
+                get_annotations(c)
+                for c
+                in cls.__mro__
+            ))
+        else:
+            return ChainMap(*(
+                c.__annotations__
+                for c
+                in cls.__mro__
+                if '__annotations__' in c.__dict__
+            ))
 
     def get_id(self):
         return self.uuid

--- a/simplyblock_core/test/test_models.py
+++ b/simplyblock_core/test/test_models.py
@@ -1,0 +1,47 @@
+from simplyblock_core.models.base_model import BaseModel
+
+
+class Model(BaseModel):
+    x: int = 0
+
+
+def test():
+    assert Model({}).x == 0
+    assert Model({'x': 1}).x == 1
+
+
+def test_all_annotations():
+    assert Model().all_annotations().get('x') is int
+
+
+def test_get_attrs_map():
+    print(Model().get_attrs_map())
+    assert Model().get_attrs_map().get('x') == {
+        'type': int,
+        'default': 0,
+    }
+
+
+def test_to_dict():
+    d = Model({'x': 1}).to_dict()
+    assert d.get('x') == 1
+    assert 'uuid' in d
+    assert 'name' in d
+    assert 'object_type' in d
+
+
+def test_get_clean_dict():
+    d = Model({'x': 1}).get_clean_dict()
+    assert d.get('x') == 1
+    assert 'status_code' in d
+    assert 'uuid' in d
+    assert 'name' not in d
+    assert 'object_type' not in d
+
+
+def test_to_str():
+    assert "'x': 0" in Model().to_str()
+
+
+def test_keys():
+    assert 'x' in Model().keys()


### PR DESCRIPTION
Python 3.10 introduces `inspect.get_annotations`, the idiomatic way of accessing annotations. The way annotations are handled changes in upcoming Python versions, this change is hidden by the helper. Our method of accessing annotations will break in Python 3.14 which is set to be released in late 2025.

Current behavior (Note the empty object in 3.14-dev):
```
$ for version in 3.9 3.10 3.11 3.12 3.13 3.14-dev; do \
        echo "${version}: " && \
        pyenv shell $version && \
        python3 -c 'from simplyblock_core.models.storage_node import StorageNode; print(StorageNode().from_dict({"alceml_cpu_index": 12}))' | head -n2; done
3.9: 
{'alceml_cpu_cores': [],
 'alceml_cpu_index': 12,
3.10: 
{'alceml_cpu_cores': [],
 'alceml_cpu_index': 12,
3.11: 
{'alceml_cpu_cores': [],
 'alceml_cpu_index': 12,
3.12: 
{'alceml_cpu_cores': [],
 'alceml_cpu_index': 12,
3.13: 
{'alceml_cpu_cores': [],
 'alceml_cpu_index': 12,
3.14-dev: 
{}
```

Updated behavior:
```
$ for version in 3.9 3.10 3.11 3.12 3.13 3.14-dev; do \
        echo "${version}: " && \
        pyenv shell $version && \
        python3 -c 'from simplyblock_core.models.storage_node import StorageNode; print(StorageNode().from_dict({"alceml_cpu_index": 12}))' | head -n2; done
3.9: 
{'alceml_cpu_cores': [],
 'alceml_cpu_index': 12,
3.10: 
{'alceml_cpu_cores': [],
 'alceml_cpu_index': 12,
3.11: 
{'alceml_cpu_cores': [],
 'alceml_cpu_index': 12,
3.12: 
{'alceml_cpu_cores': [],
 'alceml_cpu_index': 12,
3.13: 
{'alceml_cpu_cores': [],
 'alceml_cpu_index': 12,
3.14-dev: 
{'alceml_cpu_cores': [],
 'alceml_cpu_index': 12,
```