### PR TITLE
Fix python publish workflow

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -7,6 +7,8 @@ on:
       - main
     paths:
       - 'simplyblock_core/env_var'
+    tags-ignore:
+      - '*'
 
 permissions:
   contents: read


### PR DESCRIPTION
According to [this](https://github.com/orgs/community/discussions/25615) discussion, this will prevent executing the workflow in question when tags are pushed. Tags are handled by the `release` workflow, so the `python-publish` one is not needed. This PR (hopefully) avoids false-negatives since the `env_var` file will often have conflicting versions.