### PR TITLE
fix lint

### DIFF
--- a/simplyblock_core/utils.py
+++ b/simplyblock_core/utils.py
@@ -625,7 +625,7 @@ def _parse_unit(unit: str, mode: str = 'si/iec', strict: bool = True) -> tuple[i
     )
 
 
-def parse_size(size: str | int, mode: str = 'si/iec', assume_unit: str = '', strict: bool = False) -> int:
+def parse_size(size: Union[str, int], mode: str = 'si/iec', assume_unit: str = '', strict: bool = False) -> int:
     """Parse the given data size
 
     If passed and not explicitly given, 'assume_unit' will be assumed.


### PR DESCRIPTION
Stack trace:

```
Login Succeeded
Traceback (most recent call last):
  File "/usr/local/bin/sbcli-dev", line 5, in <module>
    from simplyblock_cli.cli import main
  File "/usr/local/lib/python3.9/site-packages/simplyblock_cli/cli.py", line 4, in <module>
    from simplyblock_cli.clibase import CLIWrapperBase
  File "/usr/local/lib/python3.9/site-packages/simplyblock_cli/clibase.py", line 9, in <module>
    from simplyblock_core import cluster_ops, utils, db_controller
  File "/usr/local/lib/python3.9/site-packages/simplyblock_core/cluster_ops.py", line 18, in <module>
    from simplyblock_core import utils, scripts, constants, mgmt_node_ops, storage_node_ops, distr_controller, shell_utils
  File "/usr/local/lib/python3.9/site-packages/simplyblock_core/utils.py", line 628, in <module>
    def parse_size(size: str | int, mode: str = 'si/iec', assume_unit: str = '', strict: bool = False) -> int:
TypeError: unsupported operand type(s) for |: 'type' and 'type'
Error: sbcli_cmd deploy-cleaner failed
```

This | is only supported in Python 3.10 and above. Our VMs are 3.9.19. For older version we need to use `Union`.

[8:57](https://simplyblockworkspace.slack.com/archives/C06L66G7E9H/p1745391431223609)
https://peps.python.org/pep-0604/