### PR TITLE
updated spdk kubernetes deployment

### DIFF
--- a/simplyblock_core/cluster_ops.py
+++ b/simplyblock_core/cluster_ops.py
@@ -1258,12 +1258,13 @@ def update_cluster(cluster_id, mgmt_only=False, restart=False, spdk_image=None, 
         logger.info(f"Pulling image {constants.SIMPLY_BLOCK_DOCKER_IMAGE}")
         cluster_docker.images.pull(constants.SIMPLY_BLOCK_DOCKER_IMAGE)
         image_without_tag = constants.SIMPLY_BLOCK_DOCKER_IMAGE.split(":")[0]
-        image_without_tag = image_without_tag.split("/")[-1]
+        image_without_tag = image_without_tag.split("/")
+        image_parts = "/".join(image_without_tag[-2:])
         service_image = constants.SIMPLY_BLOCK_DOCKER_IMAGE
         if mgmt_image:
             service_image = mgmt_image
         for service in cluster_docker.services.list():
-            if image_without_tag in service.attrs['Spec']['Labels']['com.docker.stack.image']:
+            if image_parts in service.attrs['Spec']['Labels']['com.docker.stack.image']:
                 logger.info(f"Updating service {service.name}")
                 service.update(image=service_image, force_update=True)
         logger.info("Done updating mgmt cluster")

--- a/simplyblock_core/env_var
+++ b/simplyblock_core/env_var
@@ -1,5 +1,5 @@
 SIMPLY_BLOCK_COMMAND_NAME=sbcli-dev
-SIMPLY_BLOCK_VERSION=17.4.34
+SIMPLY_BLOCK_VERSION=17.4.35
 
 SIMPLY_BLOCK_DOCKER_IMAGE=public.ecr.aws/simply-block/simplyblock:main
 SIMPLY_BLOCK_SPDK_ULTRA_IMAGE=public.ecr.aws/simply-block/ultra:main-latest

--- a/simplyblock_web/templates/caching_deploy_spdk.yaml.j2
+++ b/simplyblock_web/templates/caching_deploy_spdk.yaml.j2
@@ -1,4 +1,3 @@
-
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/simplyblock_web/templates/caching_deploy_spdk.yaml.j2
+++ b/simplyblock_web/templates/caching_deploy_spdk.yaml.j2
@@ -1,3 +1,4 @@
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -64,13 +65,17 @@ spec:
           - name: SPDKCSI_SECRET
             valueFrom:
               secretKeyRef:
-                name: spdkcsi-secret
+                name: simplyblock-csi-secret
                 key: secret.json
           - name: CLUSTER_CONFIG
             valueFrom:
               configMapKeyRef:
-                name: spdkcsi-cm
+                name: simplyblock-csi-cm
                 key: config.json
+        lifecycle:
+          postStart:
+            exec:
+              command: ["/bin/sh", "-c", "sudo modprobe nbd || echo failed to modprobe nbd"]
         securityContext:
           privileged: true
         volumeMounts:

--- a/simplyblock_web/templates/storage_deploy_spdk.yaml.j2
+++ b/simplyblock_web/templates/storage_deploy_spdk.yaml.j2
@@ -13,7 +13,7 @@ spec:
       labels:
         app: spdk-app-{{ HOSTNAME }}
     spec:
-      serviceAccountName: storage-node-sa
+      serviceAccountName: simplyblock-storage-node-sa
       nodeSelector:
         kubernetes.io/hostname: {{ HOSTNAME }}
       hostNetwork: true
@@ -84,13 +84,17 @@ spec:
           - name: SPDKCSI_SECRET
             valueFrom:
               secretKeyRef:
-                name: spdkcsi-secret
+                name: simplyblock-csi-secret
                 key: secret.json
           - name: CLUSTER_CONFIG
             valueFrom:
               configMapKeyRef:
-                name: spdkcsi-cm
+                name: simplyblock-csi-cm
                 key: config.json
+        lifecycle:
+          postStart:
+            exec:
+              command: ["/bin/sh", "-c", "sudo modprobe nbd || echo failed to modprobe nbd"]
         securityContext:
           privileged: true
         volumeMounts:
@@ -166,3 +170,4 @@ spec:
         - name: dockercontainerlogdirectory
           mountPath: /var/log/pods
           readOnly: true
+          


### PR DESCRIPTION
## JIRA ticket link/s

-   [SFAM-1958](https://simplyblock.atlassian.net/browse/SFAM-1958)
-   [SFAM-1959](https://simplyblock.atlassian.net/browse/SFAM-1959)


## Summary of changes
- Fix issue with image update during cluster update

Updated spdk deployment to reference
1. new serviceAccountName
2. new secret and configmapMap name 
3. use pod Lifecycle  to load nbd module

## Awaiting PR
[simplyblock-csi](https://github.com/simplyblock-io/simplyblock-csi/pull/141)

