### PR TITLE
Fix missing requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ argcomplete
 jc
 sentry-sdk
 prometheus_client
+ec2_metadata


### PR DESCRIPTION
`ec2_metadata` is used but not listed in requirements.txt.