### PR TITLE
use action secret for AWS Account ID

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -54,5 +54,5 @@ jobs:
 
     - name: Publish package codeArtifact
       run: |
-        aws codeartifact login --tool twine --repository sbcli --domain simplyblock --domain-owner 565979732541 --region eu-west-1
+        aws codeartifact login --tool twine --repository sbcli --domain simplyblock --domain-owner ${{ secrets.AWS_ACCOUNT_ID }} --region eu-west-1
         twine upload dist/* -r codeartifact


### PR DESCRIPTION
## JIRA ticket link/s

-   [SFAM-1960](https://simplyblock.atlassian.net/browse/SFAM-1960)

## Summary of changes

1.  Move hardcoded aws account Id aws secret

