### PR TITLE
Fix list-caching-nodes API

### DIFF
--- a/simplyblock_web/blueprints/web_api_caching_node.py
+++ b/simplyblock_web/blueprints/web_api_caching_node.py
@@ -67,7 +67,7 @@ def list_caching_nodes(uuid):
     if uuid:
         node = db.get_caching_node_by_id(uuid)
         if not node:
-            node = db.get_storage_node_by_hostname(uuid)
+            node = db.get_caching_node_by_hostname(uuid)
 
         if node:
             nodes = [node]


### PR DESCRIPTION
The web api listing caching nodes uses the wrong type of nodes in case the node is not found.