### PR TITLE
Fix storage node lookup by host

### DIFF
--- a/simplyblock_core/controllers/lvol_controller.py
+++ b/simplyblock_core/controllers/lvol_controller.py
@@ -87,7 +87,7 @@ def validate_add_lvol_func(name, size, host_id_or_name, pool_id_or_name,
     #  host validation
     # snode = db_controller.get_storage_node_by_id(host_id_or_name)
     # if not snode:
-    #     snode = db_controller.get_storage_node_by_hostname(host_id_or_name)
+    #     snode = db_controller.get_storage_nodes_by_hostname(host_id_or_name)
     #     if not snode:
     #         return False, f"Can not find storage node: {host_id_or_name}"
 
@@ -273,8 +273,10 @@ def add_lvol_ha(name, size, host_id_or_name, ha_type, pool_id_or_name, use_comp,
     if host_id_or_name:
         host_node = db_controller.get_storage_node_by_id(host_id_or_name)
         if not host_node:
-            host_node = db_controller.get_storage_node_by_hostname(host_id_or_name)
-            if not host_node:
+            nodes = db_controller.get_storage_nodes_by_hostname(host_id_or_name)
+            if len(nodes) > 0:
+                host_node = nodes[0]
+            else:
                 return False, f"Can not find storage node: {host_id_or_name}"
 
     pool = None
@@ -964,7 +966,7 @@ def connect_lvol_to_pool(uuid):
         logger.error(f"Pool is disabled")
         return False
 
-    snode = db_controller.get_storage_node_by_hostname(lvol.hostname)
+    snode = db_controller.get_storage_node_by_id(lvol.node_id)
     # creating RPCClient instance
     rpc_client = RPCClient(
         snode.mgmt_ip,
@@ -1007,7 +1009,7 @@ def set_lvol(uuid, max_rw_iops, max_rw_mbytes, max_r_mbytes, max_w_mbytes, name=
     if name:
         lvol.lvol_name = name
 
-    snode = db_controller.get_storage_node_by_hostname(lvol.hostname)
+    snode = db_controller.get_storage_node_by_id(lvol.node_id)
     # creating RPCClient instance
     rpc_client = RPCClient(
         snode.mgmt_ip,
@@ -1327,7 +1329,7 @@ def set_read_only(id):
 
     logger.info(f"Setting LVol: {lvol.get_id()} read only")
 
-    snode = db_controller.get_storage_node_by_hostname(lvol.hostname)
+    snode = db_controller.get_storage_node_by_id(lvol.node_id)
 
     # creating RPCClient instance
     rpc_client = RPCClient(

--- a/simplyblock_core/controllers/pool_controller.py
+++ b/simplyblock_core/controllers/pool_controller.py
@@ -153,11 +153,11 @@ def set_pool(uuid, pool_max=0, lvol_max=0, max_rw_iops=0,
 
     # Apply QoS settings via RPC
     for hostname in db_controller.get_hostnames_by_pool_id(uuid):
-        sn = db_controller.get_storage_node_by_hostname(hostname)
-        client = RPCClient(sn.mgmt_ip, sn.rpc_port, sn.rpc_username, sn.rpc_password)
-        if not client.bdev_lvol_set_qos_limit(pool.numeric_id, max_rw_iops, max_rw_mbytes, max_r_mbytes, max_w_mbytes):
-            logger.error("RPC failed bdev_lvol_set_qos_limit")
-            return False, "RPC failed"
+        for sn in db_controller.get_storage_nodes_by_hostname(hostname):
+            client = RPCClient(sn.mgmt_ip, sn.rpc_port, sn.rpc_username, sn.rpc_password)
+            if not client.bdev_lvol_set_qos_limit(pool.numeric_id, max_rw_iops, max_rw_mbytes, max_r_mbytes, max_w_mbytes):
+                logger.error("RPC failed bdev_lvol_set_qos_limit")
+                return False, "RPC failed"
 
     pool.write_to_db(db_controller.kv_store)
     pool_events.pool_updated(pool)

--- a/simplyblock_core/db_controller.py
+++ b/simplyblock_core/db_controller.py
@@ -65,11 +65,19 @@ class DBController(metaclass=Singleton):
                 nodes.append(n)
         return sorted(nodes, key=lambda x: x.create_dt)
 
-    def get_storage_node_by_system_id(self, system_id) -> StorageNode:
-        nodes = StorageNode().read_from_db(self.kv_store)
-        for node in nodes:
-            if node.system_uuid == system_id:
-                return node
+    def get_storage_nodes_by_system_id(self, system_id) -> List[StorageNode]:
+        return [
+            node for node
+            in StorageNode().read_from_db(self.kv_store)
+            if node.system_uuid == system_id
+        ]
+
+    def get_storage_nodes_by_hostname(self, hostname) -> List[StorageNode]:
+        return [
+            node for node
+            in self.get_storage_nodes()
+            if node.hostname == hostname
+        ]
 
     def get_storage_node_by_id(self, id) -> StorageNode:
         ret = StorageNode().read_from_db(self.kv_store, id)
@@ -95,12 +103,6 @@ class DBController(metaclass=Singleton):
 
     def get_caching_node_by_hostname(self, hostname)  -> CachingNode:
         nodes = self.get_caching_nodes()
-        for node in nodes:
-            if node.hostname == hostname:
-                return node
-
-    def get_storage_node_by_hostname(self, hostname) -> StorageNode:
-        nodes = self.get_storage_nodes()
         for node in nodes:
             if node.hostname == hostname:
                 return node


### PR DESCRIPTION
There may be multiple storage nodes per host, the current API does not account for this. The helper for looking up a node by a host (name or id) will always return the first matching node. This is not correct in all cases and the suggestion by the function name is misleading. This PR:

- renames the helper from get storage **node** to **nodes**, and returns a list instead
- changes lookup by hostname to lookup by node ID where possible
- loops over all nodes where semantically correct
- explicitly uses the first node if found otherwise.

Note that this PR depends on #300 which removes a use of the renamed function.