### PR TITLE
Add API tests

### DIFF
--- a/simplyblock_web/test/api/test_lvol.py
+++ b/simplyblock_web/test/api/test_lvol.py
@@ -1,0 +1,91 @@
+import re
+
+import pytest
+from requests.exceptions import HTTPError
+
+import util
+
+
+@pytest.mark.timeout(120)
+def test_lvol(call, cluster, pool):
+    pool_name = call('GET', f'/pool/{pool}')[0]['pool_name']
+    lvol_uuid = call('POST', '/lvol', data={
+        'name': 'lvolX',
+        'size': '1G',
+        'pool': pool_name}
+    )
+    assert re.match(util.uuid_regex, lvol_uuid)
+
+    assert call('GET', f'/lvol/{lvol_uuid}')[0]['uuid'] == lvol_uuid
+    assert lvol_uuid in util.list(call, 'lvol')
+
+    call('DELETE', f'/lvol/{lvol_uuid}')
+
+    util.await_deletion(call, f'/lvol/{lvol_uuid}')
+
+    assert lvol_uuid not in util.list(call, 'lvol')
+
+    with pytest.raises(HTTPError):
+        call('GET', f'/lvol/{lvol_uuid}')
+
+
+def test_lvol_get(call, cluster, pool, lvol):
+    pool_name = call('GET', f'/pool/{pool}')[0]['pool_name']
+    lvol_details = call('GET', f'/lvol/{lvol}')
+
+    assert len(lvol_details) == 1
+    assert lvol_details[0]['lvol_name'] == 'lvolX'
+    assert lvol_details[0]['lvol_type'] == 'lvol'
+    assert lvol_details[0]['uuid'] == lvol
+    assert lvol_details[0]['pool_name'] == pool_name
+    assert lvol_details[0]['pool_uuid'] == pool
+    assert lvol_details[0]['size'] == 10 ** 9
+    # TODO assert schema
+
+
+def test_lvol_update(call, cluster, pool, lvol):
+    call('PUT', f'/lvol/{lvol}', data={
+        'name': 'lvol2',
+        'max-rw-iops': 1,
+        'max-rw-mbytes': 1,
+        'max-r-mbytes': 1,
+        'max-w-mbytes': 1
+    })
+    lvol_details = call('GET', f'/lvol/{lvol}')
+    assert lvol_details[0]['rw_ios_per_sec'] == 1
+    assert lvol_details[0]['rw_mbytes_per_sec'] == 1
+    assert lvol_details[0]['r_mbytes_per_sec'] == 1
+    assert lvol_details[0]['w_mbytes_per_sec'] == 1
+
+
+def test_resize(call, cluster, pool, lvol):
+    call('PUT', f'/lvol/resize/{lvol}', data={'size': '2G'})
+    call('GET', f'/lvol/{lvol}')[0]['size'] == (2 * 2 ** 30)
+
+    with pytest.raises(ValueError):
+        call('PUT', f'/lvol/resize/{lvol}', data={'size': '1G'})
+
+
+def test_iostats(call, cluster, pool, lvol):
+    call('GET', f'/lvol/iostats/{lvol}')
+    # TODO check schema
+
+
+def test_iostats_history(call, cluster, pool, lvol):
+    call('GET', f'/lvol/iostats/{lvol}/history/1h')
+    # TODO check schema
+
+
+def test_capacity(call, cluster, pool, lvol):
+    call('GET', f'/lvol/capacity/{lvol}')
+    # TODO check schema
+
+
+def test_capacity_history(call, cluster, pool, lvol):
+    call('GET', f'/lvol/capacity/{lvol}/history/1h')
+    # TODO check schema
+
+
+def test_get_connection_strings(call, cluster, pool, lvol):
+    call('GET', f'/lvol/connect/{lvol}')
+    # TODO check schema

--- a/simplyblock_web/test/api/test_pool.py
+++ b/simplyblock_web/test/api/test_pool.py
@@ -1,0 +1,80 @@
+import re
+
+import pytest
+from requests.exceptions import HTTPError
+
+import util
+
+
+def test_api(call):
+    assert call('GET', '/') == "Live"
+
+
+def test_pool(call, cluster):
+    pool_uuid = call('POST', '/pool', data={'name': 'poolX', 'cluster_id': cluster, 'no_secret': True})
+    assert re.match(util.uuid_regex, pool_uuid)
+
+    assert call('GET', f'/pool/{pool_uuid}')[0]['uuid'] == pool_uuid
+    assert pool_uuid in util.list(call, 'pool')
+
+    call('DELETE', f'/pool/{pool_uuid}')
+
+    assert pool_uuid not in util.list(call, 'pool')
+
+    with pytest.raises(HTTPError):
+        call('GET', f'/pool/{pool_uuid}')
+
+
+def test_pool_duplicate(call, cluster, pool):
+    with pytest.raises(HTTPError):
+        call('POST', '/pool', data={'name': 'poolX', 'cluster_id': cluster, 'no_secret': True})
+
+
+def test_pool_delete_missing(call):
+    with pytest.raises(HTTPError):
+        call('DELETE', '/pool/invalid_uuid')
+
+
+def test_pool_update(call, cluster, pool):
+    values = [
+        ('name', 'pool_name', 'poolY'),
+        ('pool_max', 'pool_max_size', 1),
+        ('lvol_max', 'lvol_max_size', 1),
+        ('max_rw_iops', 'max_rw_ios_per_sec', 1),
+        ('max_rw_mbytes', 'max_rw_mbytes_per_sec', 1),
+        ('max_r_mbytes', 'max_r_mbytes_per_sec', 1),
+        ('max_w_mbytes', 'max_w_mbytes_per_sec', 1),
+    ]
+
+    call('PUT', f'/pool/{pool}', data={
+        parameter: value
+        for parameter, _, value
+        in values
+    })
+
+    pool = call('GET', f'/pool/{pool}')[0]
+    for _, field, value in values:
+        assert pool[field] == value
+
+
+def test_pool_io_stats(call, pool):
+    io_stats = call('GET', f'/pool/iostats/{pool}')
+    assert io_stats['object_data']['uuid'] == pool
+    # TODO match expected schema
+
+
+def test_pool_io_stats_history(call, pool):
+    io_stats = call('GET', f'/pool/iostats/{pool}/history/10m')
+    assert io_stats['object_data']['uuid'] == pool
+    # TODO match expected schema
+
+
+def test_pool_capacity(call, pool):
+    call('GET', f'/pool/capacity/{pool}')
+    # TODO match expected schema
+
+
+@pytest.mark.skip(reason="Known faulty")
+def test_pool_capacity_history(call, pool):
+    call('GET', f'/pool/capacity/{pool}/history/10m')
+    # TODO match expected schema

--- a/simplyblock_web/test/api/test_snapshot.py
+++ b/simplyblock_web/test/api/test_snapshot.py
@@ -1,0 +1,46 @@
+import util
+
+import pytest
+
+
+@pytest.mark.timeout(120)
+def test_snapshot_delete(call, cluster, pool):
+    pool_name = call('GET', f'/pool/{pool}')[0]['pool_name']
+    lvol_uuid = call('POST', '/lvol', data={'name': 'lvolX', 'size': '1G', 'pool': pool_name})
+
+    snapshot_uuid = call('POST', '/snapshot', data={'lvol_id': lvol_uuid, 'snapshot_name': 'snapX'})
+
+    call('DELETE', f'/lvol/{lvol_uuid}')
+    util.await_deletion(call, f'/lvol/{lvol_uuid}')
+    assert lvol_uuid not in util.list(call, 'lvol')
+
+    clone_uuid = call('POST', '/snapshot/clone', data={'snapshot_id': snapshot_uuid, 'clone_name': 'cloneX'})
+
+    call('DELETE', f'/lvol/{clone_uuid}')
+    util.await_deletion(call, f'/lvol/{clone_uuid}')
+    assert clone_uuid not in util.list(call, 'lvol')
+
+    call('DELETE', f'/snapshot/{snapshot_uuid}')
+    assert snapshot_uuid not in util.list(call, 'snapshot')
+
+
+@pytest.mark.timeout(120)
+def test_snapshot_softdelete(call, cluster, pool):
+    pool_name = call('GET', f'/pool/{pool}')[0]['pool_name']
+    lvol_uuid = call('POST', '/lvol', data={'name': 'lvolX', 'size': '1G', 'pool': pool_name})
+
+    snapshot_uuid = call('POST', '/snapshot', data={'lvol_id': lvol_uuid, 'snapshot_name': 'snapX'})
+
+    call('DELETE', f'/lvol/{lvol_uuid}')
+    util.await_deletion(call, f'/lvol/{lvol_uuid}')
+    assert lvol_uuid not in util.list(call, 'lvol')
+
+    clone_uuid = call('POST', '/snapshot/clone', data={'snapshot_id': snapshot_uuid, 'clone_name': 'cloneX'})
+
+    call('DELETE', f'/snapshot/{snapshot_uuid}')
+    # Snapshot still present due to existing clone
+
+    call('DELETE', f'/lvol/{clone_uuid}')
+    util.await_deletion(call, f'/lvol/{clone_uuid}')
+    assert clone_uuid not in util.list(call, 'lvol')
+    assert snapshot_uuid not in util.list(call, 'snapshot')

--- a/simplyblock_web/test/conftest.py
+++ b/simplyblock_web/test/conftest.py
@@ -1,0 +1,59 @@
+import functools
+
+import pytest
+
+import util
+
+
+_OPTIONS = ['entrypoint', 'cluster', 'secret']
+
+
+def pytest_addoption(parser):
+    for opt in _OPTIONS:
+        parser.addoption(f"--{opt}", action="store", required=True)
+
+
+def pytest_generate_tests(metafunc):
+    for opt in _OPTIONS:
+        if opt in metafunc.fixturenames:
+            metafunc.parametrize(
+                opt,
+                [metafunc.config.getoption(opt)] if hasattr(metafunc.config.option, opt) else [],
+                scope='session',
+            )
+
+
+@pytest.fixture(scope='session')
+def call(request):
+    options = request.config.option
+
+    if (missing_options := {opt for opt in _OPTIONS if not hasattr(options, opt)}):
+        pytest.skip('Missing options: ' + ','.join(missing_options))
+
+    return functools.partial(
+            util.api_call,
+            options.entrypoint,
+            options.cluster,
+            options.secret,
+            log_func=print,
+    )
+
+
+@pytest.fixture(scope='module')
+def pool(call, cluster):
+    pool_uuid = call('POST', '/pool', data={'name': 'poolX', 'cluster_id': cluster, 'no_secret': True})
+    yield pool_uuid
+    call('DELETE', f'/pool/{pool_uuid}')
+
+
+@pytest.fixture(scope='module')
+def lvol(call, cluster, pool):
+    pool_name = call('GET', f'/pool/{pool}')[0]['pool_name']
+    lvol_uuid = call('POST', '/lvol', data={
+        'name': 'lvolX',
+        'size': '1G',
+        'pool': pool_name}
+    )
+    yield lvol_uuid
+    call('DELETE', f'/lvol/{lvol_uuid}')
+    util.await_deletion(call, f'/lvol/{lvol_uuid}')

--- a/simplyblock_web/test/pytest.ini
+++ b/simplyblock_web/test/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+timeout = 10
+timeout_func_only = true

--- a/simplyblock_web/test/requirements.txt
+++ b/simplyblock_web/test/requirements.txt
@@ -1,0 +1,3 @@
+pytest
+pytest-timeout
+requests

--- a/simplyblock_web/test/util.py
+++ b/simplyblock_web/test/util.py
@@ -1,0 +1,55 @@
+import re
+import time
+
+import requests
+
+
+uuid_regex = re.compile(r'[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}')
+
+
+def api_call(entrypoint, cluster, secret, method, path, *, fail=True, data=None, log_func=lambda msg: None):
+    response = requests.request(
+        method,
+        f'http://{entrypoint}{path}',
+        headers={'Authorization': f'{cluster} {secret}'},
+        json=data,
+    )
+
+    if fail:
+        response.raise_for_status() 
+
+    try:
+        result = response.json()
+    except requests.exceptions.JSONDecodeError:
+        log_func("Failed to decode content as JSON:")
+        log_func(response.text)
+        if fail:
+            raise
+
+    if not result['status']:
+        raise ValueError(result.get('error', 'Request failed'))
+
+    log_func(f'{method} {path}' + (f" -> {result['results']}" if method == 'POST' else ''))
+
+    return result['results']
+
+
+def await_deletion(call, resource, timeout=120):
+    for i in range(timeout):
+        try:
+            call('GET', resource)
+            time.sleep(1)
+        except ValueError:
+            return
+        except requests.exceptions.HTTPError:
+            return
+
+    raise TimeoutError('Failed to await deletion')
+
+
+def list(call, type):
+    return [
+        obj['uuid']
+        for obj
+        in call('GET', f'/{type}/')
+    ]


### PR DESCRIPTION
This adds the API tests that previously were developed out-of-tree at `sb-ansible`. The tests are placed in the `simplyblock_web` directory, as they are testing the API, even if the tests also trigger the underlying functionality. To use the tests, `pytest` needs to be called explicitly on `simplyblock_web` and the `entrypoint`, `cluster`, and `secret` arguments need to be provided.