### PR TITLE
use psutils for to identify used ports

### DIFF
--- a/simplyblock_core/utils.py
+++ b/simplyblock_core/utils.py
@@ -10,6 +10,7 @@ import subprocess
 import sys
 import uuid
 import time
+import psutil
 from typing import Set, Union
 
 import docker
@@ -1048,16 +1049,8 @@ def pull_docker_image_with_retry(client: docker.DockerClient, image_name, retrie
                 raise
 
 
-def used_ports() -> Set[int]:
-    return {
-        int(local_address.rsplit(':', 1)[1])
-        for proto, recvq, sendq, local_address, foreign_address, state
-        in (
-            line.split()
-            for line
-            in subprocess.check_output(['netstat', '-tn'], text=True).splitlines()[2:]
-        )
-    }
+def used_ports() -> set[int]:
+    return {conn.laddr.port for conn in psutil.net_connections(kind='tcp') if conn.laddr}
 
 
 def next_free_port(port: int) -> int:


### PR DESCRIPTION
## Summary of changes

```
app_WebAppAPI.0.eznbk207ax4j@vm11.simplyblock2.localdomain    |   File "/usr/local/lib/python3.9/site-packages/sbcli_dev-17.4.64-py3.9.egg/simplyblock_core/storage_node_ops.py", line 3274, in create_lvstore
app_WebAppAPI.0.eznbk207ax4j@vm11.simplyblock2.localdomain    |     snode.create_hublvol(cluster_nqn)
app_WebAppAPI.0.eznbk207ax4j@vm11.simplyblock2.localdomain    |   File "/usr/local/lib/python3.9/site-packages/sbcli_dev-17.4.64-py3.9.egg/simplyblock_core/models/storage_node.py", line 163, in create_hublvol
app_WebAppAPI.0.eznbk207ax4j@vm11.simplyblock2.localdomain    |     'port': utils.next_free_port(9096),
app_WebAppAPI.0.eznbk207ax4j@vm11.simplyblock2.localdomain    |   File "/usr/local/lib/python3.9/site-packages/sbcli_dev-17.4.64-py3.9.egg/simplyblock_core/utils.py", line 1066, in next_free_port
app_WebAppAPI.0.eznbk207ax4j@vm11.simplyblock2.localdomain    |     return next(
app_WebAppAPI.0.eznbk207ax4j@vm11.simplyblock2.localdomain    |   File "/usr/local/lib/python3.9/site-packages/sbcli_dev-17.4.64-py3.9.egg/simplyblock_core/utils.py", line 1069, in <genexpr>
app_WebAppAPI.0.eznbk207ax4j@vm11.simplyblock2.localdomain    |     if p not in used_ports()
app_WebAppAPI.0.eznbk207ax4j@vm11.simplyblock2.localdomain    |   File "/usr/local/lib/python3.9/site-packages/sbcli_dev-17.4.64-py3.9.egg/simplyblock_core/utils.py", line 1058, in used_ports
app_WebAppAPI.0.eznbk207ax4j@vm11.simplyblock2.localdomain    |     in subprocess.check_output(['netstat', '-tn'], text=True).splitlines()[2:]
app_WebAppAPI.0.eznbk207ax4j@vm11.simplyblock2.localdomain    |   File "/usr/local/lib/python3.9/subprocess.py", line 424, in check_output
app_WebAppAPI.0.eznbk207ax4j@vm11.simplyblock2.localdomain    |     return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
app_WebAppAPI.0.eznbk207ax4j@vm11.simplyblock2.localdomain    |   File "/usr/local/lib/python3.9/subprocess.py", line 505, in run
app_WebAppAPI.0.eznbk207ax4j@vm11.simplyblock2.localdomain    |     with Popen(*popenargs, **kwargs) as process:
app_WebAppAPI.0.eznbk207ax4j@vm11.simplyblock2.localdomain    |   File "/usr/local/lib/python3.9/subprocess.py", line 951, in __init__
app_WebAppAPI.0.eznbk207ax4j@vm11.simplyblock2.localdomain    |     self._execute_child(args, executable, preexec_fn, close_fds,
app_WebAppAPI.0.eznbk207ax4j@vm11.simplyblock2.localdomain    |   File "/usr/local/lib/python3.9/subprocess.py", line 1837, in _execute_child
app_WebAppAPI.0.eznbk207ax4j@vm11.simplyblock2.localdomain    |     raise child_exception_type(errno_num, err_msg, err_filename)
app_WebAppAPI.0.eznbk207ax4j@vm11.simplyblock2.localdomain    | FileNotFoundError: [Errno 2] No such file or directory: 'netstat'
```

 it's possible that netstat is not installed on the containers. 

so using psutils library instead.

### Testing

Don't need to install any extra library. 

<img width="1414" alt="Screenshot 2025-05-08 at 16 12 29" src="https://github.com/user-attachments/assets/017fc7e7-77f7-4faf-9bd9-340e76fd57cb" />


