### PR TITLE
Cluster deployment workflow

### DIFF
--- a/.github/workflows/api-test.yml
+++ b/.github/workflows/api-test.yml
@@ -1,0 +1,33 @@
+name: API Test
+
+on:
+  workflow_call:
+    inputs:
+      runs_on:  # Has to be an input
+        description: Platform to execute on
+        type: string
+        default: ubuntu-latest
+      cluster_ip:
+        required: true
+        type: string
+      cluster_id:
+        required: true
+        type: string
+      cluster_secret:
+        required: true
+        type: string
+
+jobs:
+  api_test:
+    runs-on: ${{ inputs.runs_on }}
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Run tests
+      run: |
+        pytest simplyblock_web \
+          --entrypoint=${{ inputs.cluster_ip }} \
+          --cluster=${{ inputs.cluster_id }} \
+          --secret=${{ inputs.cluster_secret }}

--- a/.github/workflows/bare-metal-deploy.yml
+++ b/.github/workflows/bare-metal-deploy.yml
@@ -1,0 +1,86 @@
+name: Deploy cluster
+
+on:
+  workflow_call:
+    inputs:
+      runs_on:  # Has to be an input
+        description: Platform to execute on
+        type: string
+        default: ubuntu-latest
+      cluster:
+        required: true
+        type: string
+      docker_image:
+        required: true
+        type: string
+      sbcli_source:
+        required: true
+        type: string
+      ndcs:
+        required: false
+        type: number
+        default: 1
+      npcs:
+        required: false
+        type: number
+        default: 1
+      bs:
+        required: false
+        type: number
+        default: 4096
+      chunk_bs:
+        required: false
+        type: number
+        default: 4096
+      nr_hugepages:
+        required: false
+        type: number
+        default: 2048
+
+    outputs:
+      cluster_ip:
+        description: "The cluster's IP"
+        value: ${{ jobs.deploy.outputs.cluster_ip }}
+      cluster_id:
+        description: "The cluster's ID"
+        value: ${{ jobs.deploy.outputs.cluster_id }}
+      cluster_secret:
+        description: "The cluster secret"
+        value: ${{ jobs.deploy.outputs.cluster_secret }}
+
+jobs:
+  deploy:
+    runs-on: ${{ inputs.runs_on }}
+
+    outputs:
+      cluster_id: ${{ steps.deployment.outputs.cluster_id }}
+      cluster_ip: ${{ steps.deployment.outputs.cluster_ip }}
+      cluster_secret: ${{ steps.deployment.outputs.cluster_secret }}
+
+    steps:
+    - name: Checkout sbcli
+      uses: actions/checkout@v4
+      with:
+        path: sbcli
+
+    - name: Checkout deployment tooling
+      uses: actions/checkout@v4
+      with:
+        repository: simplyblock-io/simplyBlockDeploy
+        path: deploy
+        ref: vmware
+
+    - name: Deploy cluster
+      id: deployment
+      run: |
+        cd deploy
+        eval $(python3 inventory.py inventory/${{ inputs.cluster }}.yml)
+        ./bootstrap-cluster.sh --max-lvol 10 --max-snap 10 --max-size 400G --number-of-devices 1 --sbcli-cmd sbcli-dev --spdk-debug
+      env:
+        NDCS: ${{ inputs.ndcs }}
+        NPCS: ${{ inputs.npcs }}
+        BS: ${{ inputs.bs }}
+        CHUNK_BS: ${{ inputs.chunk_bs }}
+        NR_HUGEPAGES: ${{ inputs.nr_hugepages }}
+        SBCLI_INSTALL_SOURCE: ${{ inputs.sbcli_source }}
+        SIMPLY_BLOCK_DOCKER_IMAGE: ${{ inputs.docker_image }}

--- a/.github/workflows/cluster-deployment.yml
+++ b/.github/workflows/cluster-deployment.yml
@@ -1,0 +1,33 @@
+name: Deploy and test cluster
+
+on:
+  workflow_dispatch:
+    inputs:
+      cluster:
+        description: 'Cluster identifier'
+        required: true
+      docker_image:
+        description: 'Docker image'
+        default: 'public.ecr.aws/simply-block/simplyblock:main'
+        required: false
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    uses: ./.github/workflows/bare-metal-deploy.yml
+    with:
+      runs_on: self-hosted
+      cluster: ${{ github.event.inputs.cluster }}
+      docker_image: ${{ github.event.inputs.docker_image }}
+      sbcli_source: ${{ github.repositoryUrl }}@${{ github.sha }}
+
+  test:
+    needs: deploy
+    uses: ./.github/workflows/api-test.yml
+    with:
+      runs_on: self-hosted
+      cluster_id: ${{ needs.deploy.outputs.cluster_id }}
+      cluster_ip: ${{ needs.deploy.outputs.cluster_ip }}
+      cluster_secret: ${{ needs.deploy.outputs.cluster_secret }}

--- a/simplyblock_web/test/util.py
+++ b/simplyblock_web/test/util.py
@@ -10,7 +10,7 @@ uuid_regex = re.compile(r'[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-
 def api_call(entrypoint, cluster, secret, method, path, *, fail=True, data=None, log_func=lambda msg: None):
     response = requests.request(
         method,
-        f'http://{entrypoint}{path}',
+        f'{entrypoint}{path}',
         headers={'Authorization': f'{cluster} {secret}'},
         json=data,
     )


### PR DESCRIPTION
The API test and bare metal deploy workflows are reusable, i.e. they cane be easily reused, e.g. to apply the tests to different deployment methods, or to have different triggers for the deployment. For now, the deployment and test is triggered manually, but this can be extended to deploy against a dedicated cluster on pull requests.

Note that this requires an additional workflow, as well as a decision on labels for self-hosted runners, as the e2e workflows also use this mechanism.

An example execution is not possible in this repository before merging, as the workflow file needs to be present in the default branch to be executed. You can have a look at an execution at my fork: https://github.com/mxsrc/sbcli/actions/runs/14960014202.