### PR TITLE
fixed permission denied error in aws environment

### DIFF
--- a/simplyblock_core/env_var
+++ b/simplyblock_core/env_var
@@ -1,5 +1,5 @@
 SIMPLY_BLOCK_COMMAND_NAME=sbcli-dev
-SIMPLY_BLOCK_VERSION=18.0.14
+SIMPLY_BLOCK_VERSION=18.0.15
 
 SIMPLY_BLOCK_DOCKER_IMAGE=public.ecr.aws/simply-block/simplyblock:main
 SIMPLY_BLOCK_SPDK_ULTRA_IMAGE=public.ecr.aws/simply-block/ultra:main-latest

--- a/simplyblock_core/scripts/config_docker.sh
+++ b/simplyblock_core/scripts/config_docker.sh
@@ -2,7 +2,7 @@
 
 function create_override() {
 override_dir=/etc/systemd/system/docker.service.d
-mkdir -p ${override_dir}
+sudo mkdir -p ${override_dir}
 /bin/cat <<EOM > ${override_dir}/override.conf
 [Service]
 ExecStart=


### PR DESCRIPTION
## Summary of changes

1.  Fixed permission denied error on aws environment during cluster create 

```
2025-05-12 10:12:47,576: DEBUG: + override_dir=/etc/systemd/system/docker.service.d
2025-05-12 10:12:47,576: DEBUG: + mkdir -p /etc/systemd/system/docker.service.d
2025-05-12 10:12:47,579: DEBUG: mkdir: cannot create directory ‘/etc/systemd/system/docker.service.d’: Permission denied
2025-05-12 10:12:47,579: DEBUG: + /bin/cat
2025-05-12 10:12:47,580: DEBUG: /usr/local/lib/python3.9/site-packages/simplyblock_core/scripts/config_docker.sh: line 6: /etc/systemd/system/docker.service.d/override.conf: No such file or directory
2025-05-12 10:12:47,580: DEBUG: + sudo systemctl daemon-reload
2025-05-12 10:12:48,304: DEBUG: + sudo systemctl restart docker
```