### PR TITLE
use tee instead to write to file

### DIFF
--- a/simplyblock_core/env_var
+++ b/simplyblock_core/env_var
@@ -1,5 +1,5 @@
 SIMPLY_BLOCK_COMMAND_NAME=sbcli-dev
-SIMPLY_BLOCK_VERSION=18.0.15
+SIMPLY_BLOCK_VERSION=18.0.16
 
 SIMPLY_BLOCK_DOCKER_IMAGE=public.ecr.aws/simply-block/simplyblock:main
 SIMPLY_BLOCK_SPDK_ULTRA_IMAGE=public.ecr.aws/simply-block/ultra:main-latest

--- a/simplyblock_core/scripts/config_docker.sh
+++ b/simplyblock_core/scripts/config_docker.sh
@@ -3,7 +3,7 @@
 function create_override() {
 override_dir=/etc/systemd/system/docker.service.d
 sudo mkdir -p ${override_dir}
-/bin/cat <<EOM > ${override_dir}/override.conf
+sudo tee ${override_dir}/override.conf > /dev/null <<EOM
 [Service]
 ExecStart=
 ExecStart=-/usr/bin/dockerd --containerd=/run/containerd/containerd.sock -H tcp://${1}:2375 -H unix:///var/run/docker.sock -H fd://


### PR DESCRIPTION
## Summary of changes

1.  write to file `/etc/systemd/system/docker.service.d/override.conf` using `tee`
