### PR TITLE
initialise k8s conn object only when needed

### DIFF
--- a/simplyblock_core/env_var
+++ b/simplyblock_core/env_var
@@ -1,5 +1,5 @@
 SIMPLY_BLOCK_COMMAND_NAME=sbcli-dev
 SIMPLY_BLOCK_VERSION=18.0.19
 
-SIMPLY_BLOCK_DOCKER_IMAGE=public.ecr.aws/simply-block/simplyblock:main
+SIMPLY_BLOCK_DOCKER_IMAGE=public.ecr.aws/simply-block/simplyblock:k8s-conn-issue
 SIMPLY_BLOCK_SPDK_ULTRA_IMAGE=public.ecr.aws/simply-block/ultra:main-latest

--- a/simplyblock_core/env_var
+++ b/simplyblock_core/env_var
@@ -1,5 +1,5 @@
 SIMPLY_BLOCK_COMMAND_NAME=sbcli-dev
 SIMPLY_BLOCK_VERSION=18.0.19
 
-SIMPLY_BLOCK_DOCKER_IMAGE=public.ecr.aws/simply-block/simplyblock:k8s-conn-issue
+SIMPLY_BLOCK_DOCKER_IMAGE=public.ecr.aws/simply-block/simplyblock:main
 SIMPLY_BLOCK_SPDK_ULTRA_IMAGE=public.ecr.aws/simply-block/ultra:main-latest

--- a/simplyblock_core/utils.py
+++ b/simplyblock_core/utils.py
@@ -13,7 +13,7 @@ import uuid
 import time
 import psutil
 from typing import Set, Union
-
+from kubernetes import client, config
 import docker
 from prettytable import PrettyTable
 from graypy import GELFTCPHandler
@@ -1714,3 +1714,12 @@ def validate_config(config, upgrade=False):
     if upgrade:
         return True
     return all_isolated_cores
+
+
+def get_k8s_apps_client():
+    config.load_incluster_config()
+    return client.AppsV1Api()
+
+def get_k8s_core_client():
+    config.load_incluster_config()
+    return client.CoreV1Api()

--- a/simplyblock_web/node_utils_k8s.py
+++ b/simplyblock_web/node_utils_k8s.py
@@ -6,6 +6,7 @@ import os
 import jc
 from kubernetes.stream import stream
 from kubernetes import client, config
+from simplyblock_core.utils import get_k8s_core_client
 
 
 node_name = os.environ.get("HOSTNAME")
@@ -13,9 +14,6 @@ deployment_name = f"snode-spdk-deployment-{node_name}"
 pod_name = deployment_name[:50]
 namespace_id_file = '/etc/simplyblock/namespace'
 default_namespace = 'default'
-
-config.load_incluster_config()
-k8s_core_v1 = client.CoreV1Api()
 
 logger = logging.getLogger(__name__)
 
@@ -61,6 +59,7 @@ def firewall_port_k8s(port_id=9090, port_type="tcp", block=True, k8s_core_v1=Non
 
 
 def firewall_get_k8s():
+    k8s_core_v1 = get_k8s_core_client()
     ret = ""
     resp = k8s_core_v1.list_namespaced_pod(get_namespace())
     for pod in resp.items:


### PR DESCRIPTION
## Summary of changes

When the a connection breaks maintained by kubernetes client breaks we start we have issues with broken connection. So made changes to initialise k8s client only during usage. 

## Testing

Observed for 20 mins and no restarts. 
<img width="753" alt="Screenshot 2025-05-13 at 11 18 57" src="https://github.com/user-attachments/assets/581bca5b-d133-4b70-a2a9-57d825fda898" />


