### PR TITLE
fixed aws permission error upon snode config generate

### DIFF
--- a/simplyblock_core/env_var
+++ b/simplyblock_core/env_var
@@ -1,5 +1,5 @@
 SIMPLY_BLOCK_COMMAND_NAME=sbcli-dev
-SIMPLY_BLOCK_VERSION=18.0.19
+SIMPLY_BLOCK_VERSION=18.0.20
 
 SIMPLY_BLOCK_DOCKER_IMAGE=public.ecr.aws/simply-block/simplyblock:main
 SIMPLY_BLOCK_SPDK_ULTRA_IMAGE=public.ecr.aws/simply-block/ultra:main-latest

--- a/simplyblock_core/utils.py
+++ b/simplyblock_core/utils.py
@@ -907,7 +907,12 @@ def load_core_distribution_from_file(file_path, number_of_cores):
 
 def store_config_file(data_config, file_path, create_read_only_file=False):
     # Ensure the directory exists
-    os.makedirs(os.path.dirname(file_path), exist_ok=True)
+    subprocess.run(
+        ["sudo", "mkdir", "-p", os.path.dirname(file_path)],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
+        check=True)
+
     cores_config_json = json.dumps(data_config, indent=4)
 
     # Write the dictionary to the JSON file


### PR DESCRIPTION
## Summary of changes

1.  Fixed permission error during snode configure
```
  File "/usr/lib64/python3.9/os.py", line 225, in makedirs
    mkdir(name, mode)
PermissionError: [Errno 13] Permission denied: '/etc/simplyblock'
``` 
