### PR TITLE
Bump workflow action versions

### DIFF
--- a/.github/workflows/docker-base-image.yml
+++ b/.github/workflows/docker-base-image.yml
@@ -13,13 +13,13 @@ jobs:
     - uses: actions/checkout@master
 
     - name: Login to Docker Hub
-      uses: docker/login-action@v1
+      uses: docker/login-action@v3
       with:
         username: hamdysimplyblock
         password: ${{ secrets.DOCKER_PASS }}
 
     - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@v1
+      uses: aws-actions/configure-aws-credentials@v4
       with:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_HAMDI }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_HAMDI }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -29,13 +29,13 @@ jobs:
         echo "SHA=$([ -z '${{ github.event.pull_request.head.sha }}' ] && echo $GITHUB_SHA || echo '${{ github.event.pull_request.head.sha }}')" >> $GITHUB_ENV
 
     - name: Login to Docker Hub
-      uses: docker/login-action@v1
+      uses: docker/login-action@v3
       with:
         username: hamdysimplyblock
         password: ${{ secrets.DOCKER_PASS }}
 
     - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@v1
+      uses: aws-actions/configure-aws-credentials@v4
       with:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_HAMDI }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_HAMDI }}

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -44,7 +44,7 @@ jobs:
       run: echo "::notice title=PIP Package::$(ls dist)"
 
     - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@v1
+      uses: aws-actions/configure-aws-credentials@v4
       with:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_HAMDI }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_HAMDI }}


### PR DESCRIPTION
The current versions still use the old way of setting workflow outputs. See also: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/.