### PR TITLE
Add failure output on invalid request

### DIFF
--- a/simplyblock_core/snode_client.py
+++ b/simplyblock_core/snode_client.py
@@ -67,6 +67,10 @@ class SNodeClient:
 
         if ret_code in [500, 400]:
             raise SNodeClientException("Invalid http status: %s" % ret_code)
+
+        if ret_code == 422:
+            raise SNodeClientException(f"Request validation failed: '{response.text}'")
+
         logger.error("Unknown http status: %s", ret_code)
         return None, None
 


### PR DESCRIPTION
This adds the details of failed requests due to validation errors to the raises exception.