### PR TITLE
use branch source

### DIFF
--- a/.github/workflows/bare-metal-deploy.yml
+++ b/.github/workflows/bare-metal-deploy.yml
@@ -83,5 +83,5 @@ jobs:
         BS: ${{ inputs.bs }}
         CHUNK_BS: ${{ inputs.chunk_bs }}
         NR_HUGEPAGES: ${{ inputs.nr_hugepages }}
-        SBCLI_INSTALL_SOURCE: ${{ inputs.sbcli_source }}
+        SBCLI_BRANCH: ${{ inputs.sbcli_source }}
         SIMPLY_BLOCK_DOCKER_IMAGE: ${{ inputs.docker_image }}

--- a/.github/workflows/cluster-deployment.yml
+++ b/.github/workflows/cluster-deployment.yml
@@ -21,7 +21,7 @@ jobs:
       runs_on: self-hosted
       cluster: ${{ github.event.inputs.cluster }}
       docker_image: ${{ github.event.inputs.docker_image }}
-      sbcli_source: ${{ github.repositoryUrl }}@${{ github.sha }}
+      sbcli_source: ${{ github.ref_name }}
 
   test:
     needs: deploy


### PR DESCRIPTION
## Summary of changes

the value of `SBCLI_INSTALL_SOURCE` is always over written so using `SBCLI_BRANCH` to a specific branch

