### PR TITLE
Return internal API errors as JSON

### DIFF
--- a/simplyblock_core/snode_client.py
+++ b/simplyblock_core/snode_client.py
@@ -44,8 +44,11 @@ class SNodeClient:
         except Exception as e:
             raise e
 
-        logger.debug("Response: status_code: %s, content: %s",
-                     response.status_code, response.content)
+        logger.debug(
+            "Response: status_code: %s, content: %s",
+             response.status_code,
+             response.json() if response.headers.get('Content-type') == 'application/json' else response.content
+        )
         ret_code = response.status_code
 
         result = None


### PR DESCRIPTION
This will format errors on the internal API as JSON, for nicer interaction with our logging.