### PR TITLE
Exchanged term node-ip for node-addr in storage node add

### DIFF
--- a/simplyblock_cli/cli-reference.yaml
+++ b/simplyblock_cli/cli-reference.yaml
@@ -93,9 +93,9 @@ commands:
             help: "Cluster id"
             dest: cluster_id
             type: str
-          - name: "node_ip"
-            help: "IP of storage node to add"
-            dest: node_ip
+          - name: "node_addr"
+            help: "Address of storage node api to add, like <node-ip>:5000"
+            dest: node_addr
             type: str
           - name: "ifname"
             help: "Management interface name"

--- a/simplyblock_cli/cli.py
+++ b/simplyblock_cli/cli.py
@@ -100,7 +100,7 @@ class CLIWrapper(CLIWrapperBase):
     def init_storage_node__add_node(self, subparser):
         subcommand = self.add_sub_command(subparser, 'add-node', 'Adds a storage node by its IP address')
         subcommand.add_argument('cluster_id', help='Cluster id', type=str)
-        subcommand.add_argument('node_ip', help='IP of storage node to add', type=str)
+        subcommand.add_argument('node_addr', help='Address of storage node api to add, like <node-ip>:5000', type=str)
         subcommand.add_argument('ifname', help='Management interface name', type=str)
         argument = subcommand.add_argument('--journal-partition', help='1: auto-create small partitions for journal on nvme devices. 0: use a separate (the smallest) nvme device of the node for journal. The journal needs a maximum of 3 percent of total available raw disk space.', type=int, default=1, dest='partitions')
         if self.developer_mode:

--- a/simplyblock_cli/clibase.py
+++ b/simplyblock_cli/clibase.py
@@ -115,7 +115,7 @@ class CLIWrapperBase:
 
     def storage_node__add_node(self, sub_command, args):
         cluster_id = args.cluster_id
-        node_ip = args.node_ip
+        node_addr = args.node_addr
         ifname = args.ifname
         data_nics = args.data_nics
         spdk_image = args.spdk_image
@@ -134,7 +134,7 @@ class CLIWrapperBase:
 
         out = storage_ops.add_node(
             cluster_id=cluster_id,
-            node_ip=node_ip,
+            node_addr=node_addr,
             iface_name=ifname,
             data_nics_list=data_nics,
             max_snap=max_snap,

--- a/simplyblock_core/storage_node_ops.py
+++ b/simplyblock_core/storage_node_ops.py
@@ -778,13 +778,13 @@ def _connect_to_remote_jm_devs(this_node, jm_ids=None):
     return new_devs
 
 
-def add_node(cluster_id, node_ip, iface_name, data_nics_list,
+def add_node(cluster_id, node_addr, iface_name, data_nics_list,
              max_snap, spdk_image=None, spdk_debug=False,
              small_bufsize=0, large_bufsize=0,
              num_partitions_per_dev=0, jm_percent=0, enable_test_device=False,
              namespace=None, enable_ha_jm=False, id_device_by_nqn=False,
              partition_size="", ha_jm_count=3, full_page_unmap=False):
-    snode_api = SNodeClient(node_ip)
+    snode_api = SNodeClient(node_addr)
     node_info, _ = snode_api.info()
     if node_info.get("nodes_config") and node_info["nodes_config"].get("nodes"):
         nodes = node_info["nodes_config"]["nodes"]
@@ -804,7 +804,7 @@ def add_node(cluster_id, node_ip, iface_name, data_nics_list,
             logger.error("Cluster not found: %s", cluster_id)
             return False
 
-        logger.info(f"Adding Storage node: {node_ip}")
+        logger.info(f"Adding Storage node: {node_addr}")
 
         if not node_info:
             logger.error("SNode API is not reachable")
@@ -908,7 +908,7 @@ def add_node(cluster_id, node_ip, iface_name, data_nics_list,
         if ssd_pcie:
             for ssd in ssd_pcie:
                 for node in db_controller.get_storage_nodes_by_cluster_id(cluster_id):
-                    if node.api_endpoint == node_ip:
+                    if node.api_endpoint == node_addr:
                         if ssd in node.ssd_pcie:
                             logger.error(f"SSD is being used by other node, ssd: {ssd}, node: {node.get_id()}")
                             return False
@@ -935,7 +935,7 @@ def add_node(cluster_id, node_ip, iface_name, data_nics_list,
 
         total_mem = minimum_hp_memory
         for n in db_controller.get_storage_nodes_by_cluster_id(cluster_id):
-            if n.api_endpoint == node_ip:
+            if n.api_endpoint == node_addr:
                 total_mem += n.spdk_mem
         total_mem += utils.parse_size("500m")
         logger.info("Deploying SPDK")
@@ -999,7 +999,7 @@ def add_node(cluster_id, node_ip, iface_name, data_nics_list,
         snode.rpc_username = rpc_user
         snode.rpc_password = rpc_pass
         snode.cluster_id = cluster_id
-        snode.api_endpoint = node_ip
+        snode.api_endpoint = node_addr
         snode.host_secret = utils.generate_string(20)
         snode.ctrl_secret = utils.generate_string(20)
         snode.number_of_distribs = number_of_distribs


### PR DESCRIPTION
When adding a storage node, the node address (<ip>:5000) has to be given, not the node ip by itself. This PR changes the terminology and internal variable, as well as optimizes the help text.