### PR TITLE
Fix CI api tests

### DIFF
--- a/.github/workflows/api-test.yml
+++ b/.github/workflows/api-test.yml
@@ -31,7 +31,7 @@ jobs:
 
     - name: Run tests
       run: |
-        pytest simplyblock_web \
+        pytest -v simplyblock_web \
           --entrypoint=${{ inputs.cluster_ip }} \
           --cluster=${{ inputs.cluster_id }} \
           --secret=${{ inputs.cluster_secret }}

--- a/.github/workflows/api-test.yml
+++ b/.github/workflows/api-test.yml
@@ -25,6 +25,10 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
 
+    - name: Install dependencies
+      run: |
+        pip3 install -r test-requirements.txt
+
     - name: Run tests
       run: |
         pytest simplyblock_web \

--- a/.github/workflows/bare-metal-deploy.yml
+++ b/.github/workflows/bare-metal-deploy.yml
@@ -51,8 +51,6 @@ on:
 jobs:
   deploy:
     runs-on: ${{ inputs.runs_on }}
-    concurrency:
-      group: ${{ inputs.cluster }}
 
     outputs:
       cluster_id: ${{ steps.deployment.outputs.cluster_id }}

--- a/.github/workflows/cluster-deployment.yml
+++ b/.github/workflows/cluster-deployment.yml
@@ -1,15 +1,23 @@
 name: Deploy and test cluster
 
 on:
-  workflow_dispatch:
+  workflow_call:
     inputs:
       cluster:
         description: 'Cluster identifier'
         required: true
+        type: string
       docker_image:
         description: 'Docker image'
-        default: 'public.ecr.aws/simply-block/simplyblock:main'
-        required: false
+        type: string
+        required: true
+      sbcli_source:
+        description: 'Docker image'
+        type: string
+        required: true
+
+concurrency:
+  group: ${{ inputs.cluster }}
 
 permissions:
   contents: read
@@ -19,9 +27,9 @@ jobs:
     uses: ./.github/workflows/bare-metal-deploy.yml
     with:
       runs_on: self-hosted
-      cluster: ${{ github.event.inputs.cluster }}
-      docker_image: ${{ github.event.inputs.docker_image }}
-      sbcli_source: ${{ github.head_ref || github.ref_name }}
+      cluster: ${{ inputs.cluster }}
+      docker_image: ${{ inputs.docker_image }}
+      sbcli_source: ${{ inputs.sbcli_source }}
 
   test:
     needs: deploy

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -8,7 +8,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  mock-deploy:
+  mock-integration:
     runs-on: ubuntu-latest
     services:
       docker:
@@ -47,21 +47,11 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 10
 
-  deploy:
-    needs: [await-image, mock-deploy]
+  integration:
+    needs: [await-image, mock-integration]
     if: ${{ vars.ci_cluster != '' }}
-    uses: ./.github/workflows/bare-metal-deploy.yml
+    uses: ./.github/workflows/cluster-deployment.yml
     with:
-      runs_on: self-hosted
       cluster: ${{ vars.ci_cluster }}
       docker_image: simplyblock/simplyblock:${{ github.head_ref || github.ref_name }}
       sbcli_source: ${{ github.head_ref || github.ref_name }}
-
-  test:
-    needs: deploy
-    uses: ./.github/workflows/api-test.yml
-    with:
-      runs_on: self-hosted
-      cluster_id: ${{ needs.deploy.outputs.cluster_id }}
-      cluster_ip: ${{ needs.deploy.outputs.cluster_ip }}
-      cluster_secret: ${{ needs.deploy.outputs.cluster_secret }}

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,3 @@
+pytest
+pytest-timeout
+requests


### PR DESCRIPTION
- add tracking for test-dependencies and install them in the CI execution
- make CI test output more verbose
- enforce serial execution of cluster deployment and API tests, avoiding potential interleaving of jobs