### PR TITLE
use limit 0 for cluster status task

### DIFF
--- a/simplyblock_core/services/tasks_cluster_status.py
+++ b/simplyblock_core/services/tasks_cluster_status.py
@@ -10,7 +10,7 @@ cluster_commands = [
     "sbcli-dev cluster show",
     "sbcli-dev cluster get-capacity",
     "sbcli-dev cluster get-io-stats",
-    "sbcli-dev cluster get-logs",
+    "sbcli-dev cluster get-logs --limit 0",
     "sbcli-dev lvol list --cluster-id",
 ]
 


### PR DESCRIPTION
## Summary of changes

```
--limit LIMIT  show last number of logs, default 50
```

by default we only show last 5 logs. Using the --limit as 0 so that we show all the logs. 
