### PR TITLE
python package publish on main branch push or workflow dispatch only

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -3,6 +3,8 @@ name: Python Package Build
 on:
   workflow_dispatch:
   push:
+    branches:
+      - main
     paths:
       - 'simplyblock_core/env_var'
 


### PR DESCRIPTION
python package publish on main branch push or workflow dispatch only

Currently when I raise a PR to update version, the main branch build is failing, because the change is already as a part of the PR. 

