### PR TITLE
Centralize ruff configuration

### DIFF
--- a/.github/workflows/python-checks.yml
+++ b/.github/workflows/python-checks.yml
@@ -71,4 +71,4 @@ jobs:
       run: pip install ruff
 
     - name: Execute linter
-      run: ruff check simplyblock_web simplyblock_cli --exclude simplyblock_cli/cli.py
+      run: ruff check simplyblock_web simplyblock_cli

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,6 @@
 [build-system]
 requires = ['setuptools>70']
 build-backend = 'setuptools.build_meta'
+
+[tool.ruff]
+extend-exclude = ['simplyblock_cli/cli.py']


### PR DESCRIPTION
This makes it easier to run ruff locally before publishing changes.