### PR TITLE
Apply safe ruff fixes to simplyblock_core

### DIFF
--- a/simplyblock_core/cluster_ops.py
+++ b/simplyblock_core/cluster_ops.py
@@ -15,7 +15,7 @@ import docker
 import requests
 from jinja2 import Environment, FileSystemLoader
 
-from simplyblock_core import utils, scripts, constants, mgmt_node_ops, storage_node_ops, shell_utils
+from simplyblock_core import utils, scripts, constants, mgmt_node_ops, storage_node_ops
 from simplyblock_core.controllers import cluster_events, device_controller, pool_controller, \
     lvol_controller
 from simplyblock_core.db_controller import DBController

--- a/simplyblock_core/controllers/caching_node_controller.py
+++ b/simplyblock_core/controllers/caching_node_controller.py
@@ -1,5 +1,4 @@
 # coding=utf-8
-import datetime
 import json
 import logging as lg
 import math
@@ -14,7 +13,6 @@ from simplyblock_core.cnode_client import CNodeClient
 from simplyblock_core.db_controller import DBController
 from simplyblock_core.models.caching_node import CachingNode, CachedLVol
 from simplyblock_core.models.iface import IFace
-from simplyblock_core.models.nvme_device import NVMeDevice
 from simplyblock_core.models.pool import Pool
 from simplyblock_core.utils import addNvmeDevices
 from simplyblock_core.rpc_client import RPCClient
@@ -117,7 +115,7 @@ def add_node(cluster_id, node_ip, iface_name, data_nics_list, spdk_cpu_mask, spd
     while retries > 0:
         resp, _ = cnode_api.spdk_process_is_up()
         if resp:
-            logger.info(f"Pod is up")
+            logger.info("Pod is up")
             break
         else:
             logger.info("Pod is not running, waiting...")
@@ -185,18 +183,18 @@ def add_node(cluster_id, node_ip, iface_name, data_nics_list, spdk_cpu_mask, spd
     #     cache_size = ssd_dev.size
 
     if supported_ssd_size < ssd_size:
-        logger.info(f"SSD size is bigger than the supported size, creating partition")
+        logger.info("SSD size is bigger than the supported size, creating partition")
 
         nbd_device = rpc_client.nbd_start_disk(ssd_dev.nvme_bdev)
         time.sleep(3)
         if not nbd_device:
-            logger.error(f"Failed to start nbd dev")
+            logger.error("Failed to start nbd dev")
             return False
 
         jm_percent = int((supported_ssd_size/ssd_size) * 100)
         result, error = cnode_api.make_gpt_partitions(nbd_device, jm_percent)
         if error:
-            logger.error(f"Failed to make partitions")
+            logger.error("Failed to make partitions")
             logger.error(error)
             return False
         time.sleep(3)
@@ -223,7 +221,7 @@ def add_node(cluster_id, node_ip, iface_name, data_nics_list, spdk_cpu_mask, spd
     snode.cache_size = cache_size
 
     # create tmp ocf
-    logger.info(f"Creating first ocf bdev...")
+    logger.info("Creating first ocf bdev...")
 
     ret = rpc_client.bdev_malloc_create("malloc_tmp", 512, int(utils.parse_size('100MiB')/512))
     if not ret:
@@ -268,7 +266,7 @@ def recreate(node_id):
         while retries > 0:
             resp, _ = cnode_api.spdk_process_is_up()
             if resp:
-                logger.info(f"Pod is up")
+                logger.info("Pod is up")
                 break
             else:
                 logger.info("Pod is not running, waiting...")
@@ -306,7 +304,7 @@ def recreate(node_id):
     logger.info(f"Cache size: {utils.humanbytes(snode.cache_size)}")
 
     # create tmp ocf
-    logger.info(f"Creating first ocf bdev...")
+    logger.info("Creating first ocf bdev...")
 
     ret = rpc_client.bdev_malloc_create("malloc_tmp", 512, int(utils.parse_size('100MiB') / 512))
     if not ret:
@@ -345,7 +343,7 @@ def connect(caching_node_id, lvol_id, force=False):
 
     pool = db_controller.get_pool_by_id(lvol.pool_uuid)
     if pool.status == Pool.STATUS_INACTIVE:
-        logger.error(f"Pool is disabled")
+        logger.error("Pool is disabled")
         return False
 
     cnode = None
@@ -456,7 +454,7 @@ def connect(caching_node_id, lvol_id, force=False):
             break
 
     if not dev_path:
-        logger.error(f"Device path was not found")
+        logger.error("Device path was not found")
         return False
 
     logger.info(f"Device path: {dev_path}")

--- a/simplyblock_core/controllers/device_controller.py
+++ b/simplyblock_core/controllers/device_controller.py
@@ -2,7 +2,7 @@ import time
 import logging
 
 from simplyblock_core import distr_controller, utils, storage_node_ops
-from simplyblock_core.controllers import device_events, lvol_controller, tasks_controller
+from simplyblock_core.controllers import device_events, tasks_controller
 from simplyblock_core.db_controller import DBController
 from simplyblock_core.models.nvme_device import NVMeDevice, JMDevice
 from simplyblock_core.models.storage_node import StorageNode

--- a/simplyblock_core/controllers/device_events.py
+++ b/simplyblock_core/controllers/device_events.py
@@ -42,4 +42,4 @@ def device_restarted(device, caused_by=ec.CAUSED_BY_CLI):
 
 
 def device_reset(device, caused_by=ec.CAUSED_BY_CLI):
-    _device_event(device, f"Device reset", caused_by, ec.EVENT_STATUS_CHANGE)
+    _device_event(device, "Device reset", caused_by, ec.EVENT_STATUS_CHANGE)

--- a/simplyblock_core/controllers/health_controller.py
+++ b/simplyblock_core/controllers/health_controller.py
@@ -194,7 +194,7 @@ def _check_node_hublvol(node: StorageNode, node_bdev_names=None, node_lvols_nqns
         if ret:
             logger.info(f"Checking lvstore: {node.lvstore} ... ok")
             lvs_info = ret[0]
-            logger.info(f"lVol store Info:")
+            logger.info("lVol store Info:")
             lvs_info_dict = []
             expected: dict[str, Any] = {}
             expected["lvs leadership"] = True
@@ -263,7 +263,7 @@ def _check_sec_node_hublvol(node: StorageNode, node_bdev=None, node_lvols_nqns=N
         if ret:
             logger.info(f"Checking lvstore: {primary_node.lvstore} ... ok")
             lvs_info = ret[0]
-            logger.info(f"lVol store Info:")
+            logger.info("lVol store Info:")
             lvs_info_dict = []
             expected: dict [str, Any] = {}
             expected["name"] = primary_node.lvstore
@@ -332,7 +332,7 @@ def _check_node_lvstore(
     for distr in distribs_list:
         if distr in node_bdev_names:
             logger.info(f"Checking distr bdev : {distr} ... ok")
-            logger.info(f"Checking distr JM names:")
+            logger.info("Checking distr JM names:")
             if distr in node_distribs_list:
                 jm_names = storage_node_ops.get_node_jm_names(node)
             elif stack_src_node:

--- a/simplyblock_core/controllers/lvol_events.py
+++ b/simplyblock_core/controllers/lvol_events.py
@@ -21,11 +21,11 @@ def _lvol_event(lvol, message, caused_by, event):
 
 
 def lvol_create(lvol, caused_by=ec.CAUSED_BY_CLI):
-    _lvol_event(lvol, f"LVol created", caused_by, ec.EVENT_OBJ_CREATED)
+    _lvol_event(lvol, "LVol created", caused_by, ec.EVENT_OBJ_CREATED)
 
 
 def lvol_delete(lvol, caused_by=ec.CAUSED_BY_CLI):
-    _lvol_event(lvol, f"LVol deleted", caused_by, ec.EVENT_OBJ_DELETED)
+    _lvol_event(lvol, "LVol deleted", caused_by, ec.EVENT_OBJ_DELETED)
 
 
 def lvol_status_change(lvol, new_state, old_status, caused_by=ec.CAUSED_BY_CLI):

--- a/simplyblock_core/controllers/pool_controller.py
+++ b/simplyblock_core/controllers/pool_controller.py
@@ -173,7 +173,7 @@ def delete_pool(uuid):
         logger.error(f"Pool not found {uuid}")
         return False
     if pool.status == Pool.STATUS_INACTIVE:
-        logger.error(f"Pool is disabled")
+        logger.error("Pool is disabled")
         return False
 
     lvols = db_controller.get_lvols_by_pool_id(uuid)

--- a/simplyblock_core/controllers/snapshot_controller.py
+++ b/simplyblock_core/controllers/snapshot_controller.py
@@ -1,20 +1,17 @@
 # coding=utf-8
-import datetime
-import json
 import logging as lg
 import time
 import uuid
 
 from simplyblock_core.controllers import lvol_controller, snapshot_events, pool_controller
 
-from simplyblock_core import utils, distr_controller, constants
+from simplyblock_core import utils, constants
 from simplyblock_core.db_controller import DBController
 from simplyblock_core.models.pool import Pool
 from simplyblock_core.models.snapshot import SnapShot
 from simplyblock_core.models.lvol_model import LVol
 from simplyblock_core.models.storage_node import StorageNode
 from simplyblock_core.rpc_client import RPCClient
-from simplyblock_core.snode_client import SNodeClient
 
 
 logger = lg.getLogger()
@@ -31,7 +28,7 @@ def add(lvol_id, snapshot_name):
 
     pool = db_controller.get_pool_by_id(lvol.pool_uuid)
     if pool.status == Pool.STATUS_INACTIVE:
-        msg = f"Pool is disabled"
+        msg = "Pool is disabled"
         logger.error(msg)
         return False, msg
 
@@ -123,7 +120,7 @@ def add(lvol_id, snapshot_name):
             if sec_node.status == StorageNode.STATUS_ONLINE:
                 secondary_node = sec_node
             elif sec_node.status == StorageNode.STATUS_DOWN:
-                msg = f"Secondary node is in down status, can not create snapshot"
+                msg = "Secondary node is in down status, can not create snapshot"
                 logger.error(msg)
                 return False, msg
             else:
@@ -137,7 +134,7 @@ def add(lvol_id, snapshot_name):
 
         else:
             # both primary and secondary are not online
-            msg = f"Host nodes are not online"
+            msg = "Host nodes are not online"
             logger.error(msg)
             return False, msg
 
@@ -247,7 +244,7 @@ def delete(snapshot_uuid, force_delete=False):
             clones.append(lvol)
 
     if len(clones) >= 1:
-        logger.warning(f"Soft delete snapshot with clones")
+        logger.warning("Soft delete snapshot with clones")
         snap = db_controller.get_snapshot_by_id(snapshot_uuid)
         snap.deleted = True
         snap.write_to_db(db_controller.kv_store)
@@ -284,7 +281,7 @@ def delete(snapshot_uuid, force_delete=False):
             if lvol_controller.is_node_leader(host_node, snap.lvol.lvs_name):
                 primary_node = host_node
                 if sec_node.status == StorageNode.STATUS_DOWN:
-                    msg = f"Secondary node is in down status, can not delete snapshot"
+                    msg = "Secondary node is in down status, can not delete snapshot"
                     logger.error(msg)
                     return False
 
@@ -314,7 +311,7 @@ def delete(snapshot_uuid, force_delete=False):
 
         else:
             # both primary and secondary are not online
-            msg = f"Host nodes are not online"
+            msg = "Host nodes are not online"
             logger.error(msg)
             return False
 
@@ -508,7 +505,7 @@ def clone(snapshot_id, clone_name, new_size=0):
             if lvol_controller.is_node_leader(host_node, lvol.lvs_name):
                 primary_node = host_node
                 if sec_node.status == StorageNode.STATUS_DOWN:
-                    msg = f"Secondary node is in down status, can not clone snapshot"
+                    msg = "Secondary node is in down status, can not clone snapshot"
                     logger.error(msg)
                     lvol.remove(db_controller.kv_store)
                     return False, msg
@@ -537,7 +534,7 @@ def clone(snapshot_id, clone_name, new_size=0):
 
         else:
             # both primary and secondary are not online
-            msg = f"Host nodes are not online"
+            msg = "Host nodes are not online"
             logger.error(msg)
             lvol.remove(db_controller.kv_store)
             return False, msg

--- a/simplyblock_core/models/base_model.py
+++ b/simplyblock_core/models/base_model.py
@@ -1,6 +1,5 @@
 # coding=utf-8
 import pprint
-import logging
 
 import json
 from inspect import ismethod

--- a/simplyblock_core/models/job_schedule.py
+++ b/simplyblock_core/models/job_schedule.py
@@ -1,6 +1,5 @@
 # coding=utf-8
 import datetime
-import time
 
 from simplyblock_core.models.base_model import BaseModel
 

--- a/simplyblock_core/models/stats.py
+++ b/simplyblock_core/models/stats.py
@@ -3,7 +3,6 @@ import json
 import uuid
 
 from simplyblock_core.models.base_model import BaseModel
-from simplyblock_core.models.pool import Pool
 
 
 class StatsObject(BaseModel):

--- a/simplyblock_core/scripts/helpers/nvme_disconnect_by_ip.py
+++ b/simplyblock_core/scripts/helpers/nvme_disconnect_by_ip.py
@@ -2,7 +2,6 @@
 # encoding: utf-8
 import json
 import logging
-import os
 import subprocess
 import sys
 

--- a/simplyblock_core/services/caching_node_monitor.py
+++ b/simplyblock_core/services/caching_node_monitor.py
@@ -69,7 +69,7 @@ while True:
             node.rpc_password,
             timeout=3, retry=1)
         try:
-            logger.info(f"Calling rpc get_version...")
+            logger.info("Calling rpc get_version...")
             response = rpc_client.get_version()
             if response:
                 logger.info(f"Node {node.hostname} is online")

--- a/simplyblock_core/services/capacity_and_stats_collector.py
+++ b/simplyblock_core/services/capacity_and_stats_collector.py
@@ -1,5 +1,4 @@
 # coding=utf-8
-import os
 import time
 
 from simplyblock_core import constants, db_controller, utils

--- a/simplyblock_core/services/lvol_monitor.py
+++ b/simplyblock_core/services/lvol_monitor.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from simplyblock_core import constants, db_controller, utils
 from simplyblock_core.models.cluster import Cluster
 from simplyblock_core.models.lvol_model import LVol
-from simplyblock_core.controllers import health_controller, lvol_events, lvol_controller
+from simplyblock_core.controllers import health_controller, lvol_events
 from simplyblock_core.models.storage_node import StorageNode
 from simplyblock_core.rpc_client import RPCClient
 

--- a/simplyblock_core/services/lvol_stat_collector.py
+++ b/simplyblock_core/services/lvol_stat_collector.py
@@ -1,6 +1,5 @@
 # coding=utf-8
 import time
-import os
 
 from simplyblock_core import constants, db_controller, utils
 from simplyblock_core.controllers import lvol_events

--- a/simplyblock_core/services/main_distr_event_collector.py
+++ b/simplyblock_core/services/main_distr_event_collector.py
@@ -1,5 +1,4 @@
 # coding=utf-8
-import datetime
 import threading
 import time
 
@@ -66,15 +65,15 @@ def process_device_event(event):
                 device_controller.device_remove(device_obj.get_id())
 
             elif event.message in ['error_write', 'error_unmap']:
-                logger.info(f"Setting device to read-only")
+                logger.info("Setting device to read-only")
                 device_controller.device_set_read_only(device_obj.get_id())
 
             elif event.message == 'error_write_cannot_allocate':
-                logger.info(f"Setting device to cannot_allocate")
+                logger.info("Setting device to cannot_allocate")
                 device_controller.device_set_state(device_obj.get_id(), NVMeDevice.STATUS_CANNOT_ALLOCATE)
 
             else:
-                logger.info(f"Setting device to unavailable")
+                logger.info("Setting device to unavailable")
                 device_controller.device_set_unavailable(device_obj.get_id())
                 device_controller.device_set_io_error(device_obj.get_id(), True)
         else:

--- a/simplyblock_core/services/mgmt_node_monitor.py
+++ b/simplyblock_core/services/mgmt_node_monitor.py
@@ -1,5 +1,4 @@
 # coding=utf-8
-import os
 
 import time
 from datetime import datetime

--- a/simplyblock_core/services/spdk/client.py
+++ b/simplyblock_core/services/spdk/client.py
@@ -23,12 +23,12 @@ def get_addr_type(addr):
     try:
         socket.inet_pton(socket.AF_INET, addr)
         return socket.AF_INET
-    except Exception as e:
+    except Exception:
         pass
     try:
         socket.inet_pton(socket.AF_INET6, addr)
         return socket.AF_INET6
-    except Exception as e:
+    except Exception:
         pass
     if os.path.exists(addr):
         return socket.AF_UNIX
@@ -60,7 +60,7 @@ class JSONRPCClient(object):
             try:
                 self._connect(addr, port)
                 return
-            except Exception as e:
+            except Exception:
                 # ignore and retry in 200ms
                 time.sleep(0.2)
 

--- a/simplyblock_core/services/storage_node_monitor.py
+++ b/simplyblock_core/services/storage_node_monitor.py
@@ -176,7 +176,7 @@ def update_cluster_status(cluster_id):
             #     can_activate = False
             #     break
             if tasks_controller.get_active_node_restart_task(cluster_id, node.get_id()):
-                logger.error(f"can not activate cluster: restart tasks found")
+                logger.error("can not activate cluster: restart tasks found")
                 can_activate = False
                 break
 
@@ -322,7 +322,7 @@ while True:
 
                 if not node_port_check:
                     if cluster.status in [Cluster.STATUS_ACTIVE, Cluster.STATUS_DEGRADED, Cluster.STATUS_READONLY]:
-                        logger.error(f"Port check failed")
+                        logger.error("Port check failed")
                         set_node_down(snode)
                         continue
 
@@ -359,7 +359,7 @@ while True:
                         tasks_controller.add_node_to_auto_restart(snode)
                 elif not node_port_check:
                     if cluster.status in [Cluster.STATUS_ACTIVE, Cluster.STATUS_DEGRADED, Cluster.STATUS_READONLY]:
-                        logger.error(f"Port check failed")
+                        logger.error("Port check failed")
                         set_node_down(snode)
 
                 else:

--- a/simplyblock_core/services/tasks_runner_failed_migration.py
+++ b/simplyblock_core/services/tasks_runner_failed_migration.py
@@ -1,7 +1,5 @@
 # coding=utf-8
-import logging
 import time
-import sys
 from datetime import datetime
 
 from simplyblock_core import db_controller, utils
@@ -113,7 +111,7 @@ def task_runner(task):
 
             return out
     except Exception as e:
-        logger.error(f"Failed to get migration task status")
+        logger.error("Failed to get migration task status")
         logger.exception(e)
         task.function_result = "Failed to get migration status"
 

--- a/simplyblock_core/services/tasks_runner_migration.py
+++ b/simplyblock_core/services/tasks_runner_migration.py
@@ -2,7 +2,7 @@
 import time
 from datetime import datetime, timezone
 
-from simplyblock_core import constants, db_controller, utils
+from simplyblock_core import db_controller, utils
 from simplyblock_core.controllers import tasks_events, tasks_controller
 from simplyblock_core.models.cluster import Cluster
 from simplyblock_core.models.job_schedule import JobSchedule
@@ -110,7 +110,7 @@ def task_runner(task):
             res = rpc_client.distr_migration_status(**mig_info)
             return utils.handle_task_result(task, res)
     except Exception as e:
-        logger.error(f"Failed to get migration task status")
+        logger.error("Failed to get migration task status")
         logger.exception(e)
         task.function_result = "Failed to get migration status"
 

--- a/simplyblock_core/services/tasks_runner_new_dev_migration.py
+++ b/simplyblock_core/services/tasks_runner_new_dev_migration.py
@@ -1,7 +1,5 @@
 # coding=utf-8
-import logging
 import time
-import sys
 from datetime import datetime, timezone
 
 from simplyblock_core import db_controller, utils
@@ -124,7 +122,7 @@ def task_runner(task):
             res = rpc_client.distr_migration_status(**mig_info)
             return utils.handle_task_result(task, res, allowed_error_codes=allowed_error_codes)
     except Exception as e:
-        logger.error(f"Failed to get migration task status")
+        logger.error("Failed to get migration task status")
         logger.exception(e)
         task.function_result = "Failed to get migration status"
 

--- a/simplyblock_core/services/tasks_runner_restart.py
+++ b/simplyblock_core/services/tasks_runner_restart.py
@@ -163,8 +163,8 @@ def task_runner_node(task):
 
     if task.status != JobSchedule.STATUS_RUNNING:
         if node.status == StorageNode.STATUS_RESTARTING:
-            logger.info(f"Node is restarting, stopping task")
-            task.function_result = f"Node is restarting"
+            logger.info("Node is restarting, stopping task")
+            task.function_result = "Node is restarting"
             task.status = JobSchedule.STATUS_DONE
             task.write_to_db(db.kv_store)
             return True
@@ -179,7 +179,7 @@ def task_runner_node(task):
     if not ping_check or not node_api_check:
         # node is unreachable, retry
         logger.info(f"Node is not reachable: {task.node_id}, retry")
-        task.function_result = f"Node is unreachable, retry"
+        task.function_result = "Node is unreachable, retry"
         task.retry += 1
         task.write_to_db(db.kv_store)
         return False
@@ -189,7 +189,7 @@ def task_runner_node(task):
     logger.info(f"Shutdown node {node.get_id()}")
     ret = storage_node_ops.shutdown_storage_node(node.get_id(), force=True)
     if ret:
-        logger.info(f"Node shutdown succeeded")
+        logger.info("Node shutdown succeeded")
 
     time.sleep(3)
 
@@ -197,7 +197,7 @@ def task_runner_node(task):
     logger.info(f"Restart node {node.get_id()}")
     ret = storage_node_ops.restart_storage_node(node.get_id(), force=True)
     if ret:
-        logger.info(f"Node restart succeeded")
+        logger.info("Node restart succeeded")
 
     time.sleep(3)
     node = db.get_storage_node_by_id(task.node_id)

--- a/simplyblock_core/storage_node_ops.py
+++ b/simplyblock_core/storage_node_ops.py
@@ -1,10 +1,8 @@
 # coding=utf- 8
 import datetime
 import json
-import math
 import os
 
-import pprint
 import threading
 
 import time
@@ -19,7 +17,6 @@ from simplyblock_core.constants import LINUX_DRV_MASS_STORAGE_NVME_TYPE_ID, LINU
 from simplyblock_core.controllers import lvol_controller, storage_events, snapshot_controller, device_events, \
     device_controller, tasks_controller, health_controller, tcp_ports_events
 from simplyblock_core.db_controller import DBController
-from simplyblock_core import shell_utils
 from simplyblock_core.models.iface import IFace
 from simplyblock_core.models.job_schedule import JobSchedule
 from simplyblock_core.models.lvol_model import LVol
@@ -322,7 +319,7 @@ def _create_device_partitions(rpc_client, nvme, snode, num_partitions_per_dev, j
     nbd_device = rpc_client.nbd_start_disk(nvme.nvme_bdev)
     time.sleep(3)
     if not nbd_device:
-        logger.error(f"Failed to start nbd dev")
+        logger.error("Failed to start nbd dev")
         return False
     snode_api = SNodeClient(snode.api_endpoint)
     partition_percent = 0
@@ -331,7 +328,7 @@ def _create_device_partitions(rpc_client, nvme, snode, num_partitions_per_dev, j
 
     result, error = snode_api.make_gpt_partitions(nbd_device, jm_percent, num_partitions_per_dev, partition_percent)
     if error:
-        logger.error(f"Failed to make partitions")
+        logger.error("Failed to make partitions")
         logger.error(error)
         return False
     time.sleep(3)
@@ -416,7 +413,7 @@ def _prepare_cluster_devices_partitions(snode, devices):
     if jm_devices:
         jm_device = _create_jm_stack_on_raid(rpc_client, jm_devices, snode, after_restart=False)
         if not jm_device:
-            logger.error(f"Failed to create JM device")
+            logger.error("Failed to create JM device")
             return False
 
         snode.jm_device = jm_device
@@ -440,7 +437,7 @@ def _prepare_cluster_devices_jm_on_dev(snode, devices):
         if nvme.status == NVMeDevice.STATUS_JM:
             jm_device = _create_jm_stack_on_device(rpc_client, nvme, snode, after_restart=False)
             if not jm_device:
-                logger.error(f"Failed to create JM device")
+                logger.error("Failed to create JM device")
                 return False
             snode.jm_device = jm_device
             continue
@@ -520,7 +517,7 @@ def _prepare_cluster_devices_on_restart(snode, clear_data=False):
         if all_bdevs_found:
             ret = _create_jm_stack_on_raid(rpc_client, jm_device.jm_nvme_bdev_list, snode, after_restart=not clear_data)
             if not ret:
-                logger.error(f"Failed to create JM device")
+                logger.error("Failed to create JM device")
                 return False
 
 
@@ -846,7 +843,7 @@ def add_node(cluster_id, node_addr, iface_name, data_nics_list,
             logger.info(f"huge_free: {utils.humanbytes(memory_details['huge_free'])}")
             logger.info(f"Minimum required huge pages memory is : {utils.humanbytes(minimum_hp_memory)}")
         else:
-            logger.error(f"Cannot get memory info from the instance.. Exiting")
+            logger.error("Cannot get memory info from the instance.. Exiting")
             return False
 
         # Calculate minimum sys memory
@@ -1036,7 +1033,7 @@ def add_node(cluster_id, node_addr, iface_name, data_nics_list,
         # 2- set socket implementation options
         ret = rpc_client.sock_impl_set_options()
         if not ret:
-            logger.error(f"Failed to set optimized socket options")
+            logger.error("Failed to set optimized socket options")
             return False
 
         # 3- set nvme config
@@ -1225,7 +1222,7 @@ def delete_storage_node(node_id, force=False):
         return False
 
     if snode.status != StorageNode.STATUS_REMOVED:
-        logger.error(f"Node must be in removed status")
+        logger.error("Node must be in removed status")
         return False
 
     tasks = tasks_controller.get_active_node_tasks(snode.cluster_id, snode.get_id())
@@ -1489,7 +1486,7 @@ def restart_storage_node(
         logger.info(f"Free: {utils.humanbytes(memory_details['free'])}")
         logger.info(f"Minimum required huge pages memory is : {utils.humanbytes(minimum_hp_memory)}")
     else:
-        logger.error(f"Cannot get memory info from the instance.. Exiting")
+        logger.error("Cannot get memory info from the instance.. Exiting")
         return False
 
     # Calculate minimum sys memory
@@ -1772,7 +1769,7 @@ def restart_storage_node(
             node.remote_devices = _connect_to_remote_devs(node, force_conect_restarting_nodes=True)
             node.write_to_db(kv_store)
 
-        logger.info(f"Sending device status event")
+        logger.info("Sending device status event")
         snode = db_controller.get_storage_node_by_id(snode.get_id())
         for db_dev in snode.nvme_devices:
             distr_controller.send_dev_status_event(db_dev, db_dev.status)
@@ -1810,7 +1807,7 @@ def restart_storage_node(
                 node.remote_devices = _connect_to_remote_devs(node, force_conect_restarting_nodes=True)
                 node.write_to_db(kv_store)
 
-            logger.info(f"Sending device status event")
+            logger.info("Sending device status event")
             snode = db_controller.get_storage_node_by_id(snode.get_id())
             for db_dev in snode.nvme_devices:
                 distr_controller.send_dev_status_event(db_dev, db_dev.status)
@@ -2688,7 +2685,7 @@ def health_check(node_id):
                 break
             # logger.info(f"name: {name}, product_name: {product_name}, driver: {driver}")
 
-        logger.info(f"getting device bdevs")
+        logger.info("getting device bdevs")
         for dev in snode.nvme_devices:
             nvme_bdev = rpc_client.get_bdevs(dev.nvme_bdev)
             if snode.enable_test_device:

--- a/simplyblock_core/utils.py
+++ b/simplyblock_core/utils.py
@@ -1,5 +1,4 @@
 # coding=utf-8
-import glob
 import json
 import logging
 import math
@@ -11,14 +10,11 @@ import subprocess
 import sys
 import uuid
 import time
-import psutil
-from typing import Set, Union
+from typing import Union
 from kubernetes import client, config
 import docker
 from prettytable import PrettyTable
-from graypy import GELFTCPHandler
 from docker.errors import APIError, DockerException, ImageNotFound
-import psutil
 
 from simplyblock_core import constants
 from simplyblock_core import shell_utils
@@ -268,7 +264,7 @@ def parse_history_param(history_string):
     results = re.search(r'^(\d+[hmd])(\d+[hmd])?$', history_string.lower())
     if not results:
         logger.error(f"Error parsing history string: {history_string}")
-        logger.info(f"History format: xxdyyh , e.g: 1d12h, 1d, 2h, 1m")
+        logger.info("History format: xxdyyh , e.g: 1d12h, 1d, 2h, 1m")
         return False
 
     history_in_seconds = 0
@@ -732,7 +728,7 @@ def handle_task_result(task: JobSchedule, res: dict, allowed_error_codes=None):
             return True
 
         elif migration_status == "none":
-            task.function_result = f"mig retry after restart"
+            task.function_result = "mig retry after restart"
             task.retry += 1
             task.status = JobSchedule.STATUS_SUSPENDED
             del task.function_params['migration']
@@ -843,7 +839,7 @@ def run_tuned():
             ["sudo", "tuned-adm", "profile", "realtime"],
             check=True
         )
-        print(f"Successfully run the tuned adm profile")
+        print("Successfully run the tuned adm profile")
     except subprocess.CalledProcessError as e:
         logger.error(f"Error running the tuned adm profile: {e}")
 


### PR DESCRIPTION
Currently we apply the linter only to simplyblock_web and simplyblock_cli as simplyblock_core does not pass the checks and there are violations requiring non-trivial fixes. This PR applies the trivial, automatic ruff fixes to pave the way to using the linter on the core codebase as well.