### PR TITLE
Lint complete project

### DIFF
--- a/.github/workflows/python-checks.yml
+++ b/.github/workflows/python-checks.yml
@@ -71,4 +71,4 @@ jobs:
       run: pip install ruff
 
     - name: Execute linter
-      run: ruff check simplyblock_core simplyblock_web simplyblock_cli e2e
+      run: ruff check simplyblock_core simplyblock_web simplyblock_cli e2e testing

--- a/.github/workflows/python-checks.yml
+++ b/.github/workflows/python-checks.yml
@@ -71,4 +71,4 @@ jobs:
       run: pip install ruff
 
     - name: Execute linter
-      run: ruff check simplyblock_core simplyblock_web simplyblock_cli e2e testing
+      run: ruff check

--- a/.github/workflows/python-checks.yml
+++ b/.github/workflows/python-checks.yml
@@ -71,4 +71,4 @@ jobs:
       run: pip install ruff
 
     - name: Execute linter
-      run: ruff check simplyblock_core simplyblock_web simplyblock_cli
+      run: ruff check simplyblock_core simplyblock_web simplyblock_cli e2e

--- a/.github/workflows/python-checks.yml
+++ b/.github/workflows/python-checks.yml
@@ -71,4 +71,4 @@ jobs:
       run: pip install ruff
 
     - name: Execute linter
-      run: ruff check simplyblock_web simplyblock_web simplyblock_cli
+      run: ruff check simplyblock_core simplyblock_web simplyblock_cli

--- a/e2e/e2e_tests/batch_lvol_limit.py
+++ b/e2e/e2e_tests/batch_lvol_limit.py
@@ -1,4 +1,3 @@
-import time
 import random
 import threading
 from utils.common_utils import sleep_n_sec

--- a/e2e/e2e_tests/cloning_and_snapshot/lvol_batch_clone.py
+++ b/e2e/e2e_tests/cloning_and_snapshot/lvol_batch_clone.py
@@ -1,4 +1,3 @@
-import time
 import threading
 from e2e_tests.cluster_test_base import TestClusterBase
 from utils.common_utils import sleep_n_sec
@@ -157,7 +156,7 @@ class TestSnapshotBatchCloneLVOLs(TestClusterBase):
             self.logger.info(f"Run command (before mounting dev formatted in xfs: {cmd}")
             self.ssh_obj.exec_command(node=self.mgmt_nodes[0], command=cmd)
             self.logger.info(f"Mounting clone device: {clone_device} at {mount_point}")
-            cmd = f"sudo mount {clone_device} {clone_mount_point} -o nouuid"
+            cmd = f"sudo mount {clone_device} {mount_point} -o nouuid"
             self.ssh_obj.exec_command(node=self.mgmt_nodes[0], command=cmd)
         else:
             self.logger.info(f"Mounting clone {clone_name} at {mount_point}")

--- a/e2e/e2e_tests/cloning_and_snapshot/multi_lvol_snapshot_fio.py
+++ b/e2e/e2e_tests/cloning_and_snapshot/multi_lvol_snapshot_fio.py
@@ -92,7 +92,6 @@ class TestMultiLvolFio(TestClusterBase):
                 self.ssh_obj.exec_command(node=self.mgmt_nodes[0], command=connect_str)
 
             final_devices = self.ssh_obj.get_devices(node=self.mgmt_nodes[0])
-            disk_use = None
             self.logger.info("Initial vs final disk:")
             self.logger.info(f"Initial: {initial_devices}")
             self.logger.info(f"Final: {final_devices}")
@@ -106,7 +105,7 @@ class TestMultiLvolFio(TestClusterBase):
         
         lvol_list = self.sbcli_utils.list_lvols()
 
-        with open(self.checksum_log_file, 'w', encoding='utf-8') as checksum_file:
+        with open(self.checksum_log_file, 'w', encoding='utf-8'):
 
             for fs_type in ["ext4", "xfs"]:
                 self.logger.info(f"Processing filesystem type: {fs_type}")

--- a/e2e/e2e_tests/cloning_and_snapshot/single_lvol_multi_clone.py
+++ b/e2e/e2e_tests/cloning_and_snapshot/single_lvol_multi_clone.py
@@ -1,6 +1,4 @@
 import time
-import os
-import random
 import threading
 from e2e_tests.cluster_test_base import TestClusterBase
 from utils.common_utils import sleep_n_sec

--- a/e2e/e2e_tests/cluster_test_base.py
+++ b/e2e/e2e_tests/cluster_test_base.py
@@ -5,12 +5,11 @@ from utils.ssh_utils import SshUtils, RunnerK8sLog
 from utils.common_utils import CommonUtils
 from logger_config import setup_logger
 from utils.common_utils import sleep_n_sec
-from exceptions.custom_exception import CoreFileFoundException
 import traceback
-import threading
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-import string, random
+import string
+import random
 
 
 def generate_random_sequence(length):
@@ -485,11 +484,10 @@ class TestClusterBase:
         """
         node_details = self.sbcli_utils.get_storage_node_details(storage_node_id=node_uuid)
         self.logger.info(f"Storage Node Details: {node_details}")
-        device_details = self.sbcli_utils.get_device_details(storage_node_id=node_uuid)
+        self.sbcli_utils.get_device_details(storage_node_id=node_uuid)
         lvol_id = self.sbcli_utils.get_lvol_id(lvol_name=self.lvol_name)
-        lvol_details = self.sbcli_utils.get_lvol_details(lvol_id=lvol_id)
+        self.sbcli_utils.get_lvol_details(lvol_id=lvol_id)
 
-        offline_device = []
 
         if isinstance(node_status, list):
             assert node_details[0]["status"] in node_status, \

--- a/e2e/e2e_tests/data_migration/data_migration_ha_fio.py
+++ b/e2e/e2e_tests/data_migration/data_migration_ha_fio.py
@@ -1,12 +1,9 @@
 from pathlib import Path
 import threading
-import json
 from e2e_tests.cluster_test_base import TestClusterBase
 from utils.common_utils import sleep_n_sec, convert_bytes_to_gb_tb
 from logger_config import setup_logger
-from datetime import datetime, timedelta
-import traceback
-from requests.exceptions import HTTPError
+from datetime import datetime
 import random
 
 

--- a/e2e/e2e_tests/ha_journal/lvol_journal_device_node_restart.py
+++ b/e2e/e2e_tests/ha_journal/lvol_journal_device_node_restart.py
@@ -1,12 +1,7 @@
 from pathlib import Path
 import threading
-import json
 from e2e_tests.cluster_test_base import TestClusterBase
 from utils.common_utils import sleep_n_sec
-from logger_config import setup_logger
-from datetime import datetime
-import traceback
-from requests.exceptions import HTTPError
 
 
 class LvolJournalManager:

--- a/e2e/e2e_tests/mgmt_restart_fio_run.py
+++ b/e2e/e2e_tests/mgmt_restart_fio_run.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from pathlib import Path
 import threading
 import random

--- a/e2e/e2e_tests/multi_lvol_run_fio.py
+++ b/e2e/e2e_tests/multi_lvol_run_fio.py
@@ -1,5 +1,4 @@
 import time
-import os
 import random
 import threading
 from e2e_tests.cluster_test_base import TestClusterBase

--- a/e2e/e2e_tests/single_node_failure.py
+++ b/e2e/e2e_tests/single_node_failure.py
@@ -5,7 +5,6 @@ from e2e_tests.cluster_test_base import TestClusterBase
 from utils.common_utils import sleep_n_sec
 from logger_config import setup_logger
 from datetime import datetime
-import traceback
 from requests.exceptions import HTTPError
 
 class TestSingleNodeFailure(TestClusterBase):
@@ -223,7 +222,7 @@ class TestSingleNodeFailure(TestClusterBase):
         self.common_utils.validate_event_logs(cluster_id=self.cluster_id,
                                               operations=steps)
         
-        end_time = self.common_utils.manage_fio_threads(node=self.mgmt_nodes[0],
+        self.common_utils.manage_fio_threads(node=self.mgmt_nodes[0],
                                                         threads=[fio_thread1],
                                                         timeout=1000)
         
@@ -381,7 +380,7 @@ class TestHASingleNodeFailure(TestClusterBase):
 
         for i in range(3):
             lvol_name = f"LVOL_{i}"
-            lvol_id = self.add_lvol_and_run_fio(lvol_name)
+            self.add_lvol_and_run_fio(lvol_name)
 
         # no_lvol_node_uuid = self.sbcli_utils.get_lvol_by_id(lvol_id)['results'][0]['node_id']
 

--- a/e2e/e2e_tests/single_node_multi_fio_perf.py
+++ b/e2e/e2e_tests/single_node_multi_fio_perf.py
@@ -434,5 +434,5 @@ class TestLvolFioNpcsCustom(TestLvolFioBase):
         # Cleanup after running FIO
         self.cleanup_lvols(lvol_configs)
 
-        self.logger.info(f"Test Case Passed.")
+        self.logger.info("Test Case Passed.")
 

--- a/e2e/e2e_tests/single_node_outage.py
+++ b/e2e/e2e_tests/single_node_outage.py
@@ -1,7 +1,6 @@
 ### simplyblock e2e tests
 from datetime import datetime
 import os
-import time
 import threading
 from e2e_tests.cluster_test_base import TestClusterBase
 from utils.common_utils import sleep_n_sec
@@ -185,7 +184,7 @@ class TestSingleNodeOutage(TestClusterBase):
                                      new_size="25G")
         
         node_details = self.sbcli_utils.get_storage_node_details(no_lvol_node_uuid)
-        node_ip = node_details[0]["mgmt_ip"]
+        node_details[0]["mgmt_ip"]
         if not self.k8s_test:
             for node in self.storage_nodes:
                 self.ssh_obj.restart_docker_logging(
@@ -367,7 +366,7 @@ class TestHASingleNodeOutage(TestClusterBase):
 
         for i in range(3):
             lvol_name = f"LVOL_{i}"
-            lvol_id = self.add_lvol_and_run_fio(lvol_name)
+            self.add_lvol_and_run_fio(lvol_name)
 
         # no_lvol_node_uuid = self.sbcli_utils.get_lvol_by_id(lvol_id)['results'][0]['node_id']
 
@@ -378,8 +377,8 @@ class TestHASingleNodeOutage(TestClusterBase):
                 break
 
         no_lvol_node_uuid = no_lvol_node['uuid']
-        node_ip = no_lvol_node["mgmt_ip"]
-        instance_id = no_lvol_node["cloud_instance_id"]
+        no_lvol_node["mgmt_ip"]
+        no_lvol_node["cloud_instance_id"]
 
         self.validations(node_uuid=no_lvol_node_uuid,
                          node_status="online",

--- a/e2e/e2e_tests/single_node_reboot.py
+++ b/e2e/e2e_tests/single_node_reboot.py
@@ -238,7 +238,7 @@ class TestSingleNodeReboot(TestClusterBase):
         self.common_utils.validate_event_logs(cluster_id=self.cluster_id,
                                               operations=steps)
         
-        end_time = self.common_utils.manage_fio_threads(node=self.mgmt_nodes[0],
+        self.common_utils.manage_fio_threads(node=self.mgmt_nodes[0],
                                                         threads=[fio_thread1],
                                                         timeout=1000)
         
@@ -391,7 +391,7 @@ class TestHASingleNodeReboot(TestClusterBase):
 
         for i in range(3):
             lvol_name = f"LVOL_{i}"
-            lvol_id = self.add_lvol_and_run_fio(lvol_name)
+            self.add_lvol_and_run_fio(lvol_name)
 
         # no_lvol_node_uuid = self.sbcli_utils.get_lvol_by_id(lvol_id)['results'][0]['node_id']
 

--- a/e2e/e2e_tests/upgrade_tests/major_upgrade.py
+++ b/e2e/e2e_tests/upgrade_tests/major_upgrade.py
@@ -1,6 +1,4 @@
-from datetime import datetime
 import os
-import time
 import threading
 from e2e_tests.cluster_test_base import TestClusterBase
 from utils.common_utils import sleep_n_sec

--- a/e2e/logs/cleanup.py
+++ b/e2e/logs/cleanup.py
@@ -1,6 +1,5 @@
 import os
 import paramiko
-import argparse
 import time
 
 # SSH Configuration

--- a/e2e/logs/upload_logs_to_miniio.py
+++ b/e2e/logs/upload_logs_to_miniio.py
@@ -369,7 +369,7 @@ def cleanup_local_logs():
     print(f"[INFO] Cleaning up local logs from {logs_dir}...")
     subprocess.run(f"rm -rf {logs_dir}/*.log", shell=True, check=True)
     subprocess.run(f"rm -rf {logs_dir}/*.txt", shell=True, check=True)
-    print(f"[SUCCESS] Local logs cleaned up.")
+    print("[SUCCESS] Local logs cleaned up.")
 
 
 # **Step 1: Process Management Node (Same for both Docker & Kubernetes mode)**

--- a/e2e/management-stress-test-scripts/lvol_memory_track.py
+++ b/e2e/management-stress-test-scripts/lvol_memory_track.py
@@ -1,7 +1,6 @@
 import argparse
 import subprocess
 import matplotlib.pyplot as plt
-import re
 import time
 import numpy as np
 import threading
@@ -124,7 +123,7 @@ class ManagementStressUtils:
             mem_line = lines[0]
 
             mem_data = [float(value) for value in mem_line.split() if value.replace('.', '', 1).isdigit()]
-            total_memory, used_memory, buffer_memory = mem_data[0], mem_data[2], mem_data[3]
+            _total_memory, used_memory, buffer_memory = mem_data[0], mem_data[2], mem_data[3]
             cmd = "top -bn1 | grep Cpu | awk '{print $2}'"
             cpu_usage = float(ManagementStressUtils.exec_cmd(cmd=cmd))
             used_memory = ManagementStressUtils.convert_to_gb(f"{used_memory} MB")

--- a/e2e/stress_test/continuous_failover_ha.py
+++ b/e2e/stress_test/continuous_failover_ha.py
@@ -1,5 +1,4 @@
 from utils.common_utils import sleep_n_sec
-from logger_config import setup_logger
 from datetime import datetime
 from stress_test.lvol_ha_stress_fio import TestLvolHACluster
 from exceptions.custom_exception import LvolNotConnectException

--- a/e2e/stress_test/continuous_failover_ha_multi_client.py
+++ b/e2e/stress_test/continuous_failover_ha_multi_client.py
@@ -1,5 +1,4 @@
 from utils.common_utils import sleep_n_sec
-from logger_config import setup_logger
 from datetime import datetime
 from stress_test.lvol_ha_stress_fio import TestLvolHACluster
 from exceptions.custom_exception import LvolNotConnectException

--- a/e2e/stress_test/continuous_failover_ha_multi_outage.py
+++ b/e2e/stress_test/continuous_failover_ha_multi_outage.py
@@ -1,5 +1,4 @@
 from utils.common_utils import sleep_n_sec
-from logger_config import setup_logger
 from datetime import datetime
 from stress_test.continuous_failover_ha_multi_client import RandomMultiClientFailoverTest
 from exceptions.custom_exception import LvolNotConnectException

--- a/e2e/stress_test/lvol_ha_stress_fio.py
+++ b/e2e/stress_test/lvol_ha_stress_fio.py
@@ -5,7 +5,6 @@ from e2e_tests.data_migration.data_migration_ha_fio import FioWorkloadTest
 from logger_config import setup_logger
 from datetime import datetime
 from exceptions.custom_exception import LvolNotConnectException
-from requests.exceptions import HTTPError
 from pathlib import Path
 
 

--- a/e2e/stress_test/lvol_stress_fio_run.py
+++ b/e2e/stress_test/lvol_stress_fio_run.py
@@ -1,12 +1,10 @@
 from utils.common_utils import sleep_n_sec
-from logger_config import setup_logger
 from datetime import datetime
 from stress_test.lvol_ha_stress_fio import TestLvolHACluster
 from exceptions.custom_exception import LvolNotConnectException
 import threading
 import string
 import random
-import os
 
 
 def random_char(len):

--- a/e2e/utils/fio_iolog_parser.py
+++ b/e2e/utils/fio_iolog_parser.py
@@ -2,9 +2,7 @@ import os
 import sys
 import argparse
 import logging
-from typing import List, Tuple, Optional, Dict
-from collections import defaultdict
-from pathlib import Path
+from typing import List, Tuple, Dict
 import re
 
 LOG_DIR = "iolog-debug"

--- a/e2e/utils/get_lba_diff_report.py
+++ b/e2e/utils/get_lba_diff_report.py
@@ -159,7 +159,6 @@ FIO Corruption Analysis Script
 
 import paramiko
 from scp import SCPClient
-import subprocess
 import os
 from pathlib import Path
 import posixpath

--- a/e2e/utils/proxmox.py
+++ b/e2e/utils/proxmox.py
@@ -1,5 +1,4 @@
 import os
-import sys
 import time
 import re
 import requests

--- a/e2e/utils/ssh_utils.py
+++ b/e2e/utils/ssh_utils.py
@@ -9,7 +9,9 @@ from logger_config import setup_logger
 from pathlib import Path
 from datetime import datetime
 import threading
-import random, string, re
+import random
+import string
+import re
 import subprocess
 
 

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ def get_env_var(name, default=None):
         try:
             k, v = line.split("=")
             data[k.strip()] = v.strip()
-        except:
+        except Exception:
             pass
     return data.get(name, default)
 

--- a/testing/dd_utils.py
+++ b/testing/dd_utils.py
@@ -12,7 +12,7 @@ def cp_blocks_to_file(disk_path, output_file, block_size=512, blocks_count=512):
     line = ''
     while True:
         out = process.stderr.read(1)
-        if out == '' and process.poll() != None:
+        if out == '' and process.poll() is not None:
             break
         if out != '':
             s = out.decode("utf-8")
@@ -21,4 +21,4 @@ def cp_blocks_to_file(disk_path, output_file, block_size=512, blocks_count=512):
                 line = ''
             else:
                 line = line + s
-    print line
+    print(line)

--- a/testing/verification/playbooks/unit_tests/plays/2.py
+++ b/testing/verification/playbooks/unit_tests/plays/2.py
@@ -1,5 +1,3 @@
-import argparse
-import json
 import sys
 
 sys.path.append('/root/spdk/python/')

--- a/testing/verification/playbooks/unit_tests/plays/3.py
+++ b/testing/verification/playbooks/unit_tests/plays/3.py
@@ -1,5 +1,3 @@
-import argparse
-import json
 import sys
 
 sys.path.append('/root/spdk/python/')

--- a/testing/verification/playbooks/unit_tests/plays/4.py
+++ b/testing/verification/playbooks/unit_tests/plays/4.py
@@ -1,5 +1,3 @@
-import argparse
-import json
 import sys
 
 sys.path.append('/root/spdk/python/')


### PR DESCRIPTION
This fixes the remaining linter errors in `e2e`, `testing`, and `setup.py`, and changes the workflow to run against the whole project, instead of a whitelist of directories.