### PR TITLE
fix grafana dashboard JSON files that are accidentally changed in the lint PR

### DIFF
--- a/simplyblock_core/scripts/dashboards/cluster.json
+++ b/simplyblock_core/scripts/dashboards/cluster.json
@@ -2070,7 +2070,7 @@
                                 "names": [
                                     "{__name__=\"cluster_unmap_io_ps\", cluster=\"c3663938-6610-44d5-9897-d7bfa60a43e1\", exported_job=\"collector\", instance=\"192.168.178.52:9091\", job=\"metricsgateway\"}"
                                 ],
-                                "prefix": "All except Exception:",
+                                "prefix": "All except:",
                                 "readOnly": true
                             }
                         },

--- a/simplyblock_core/scripts/dashboards/devices.json
+++ b/simplyblock_core/scripts/dashboards/devices.json
@@ -2087,7 +2087,7 @@
                                 "names": [
                                     "{__name__=\"device_unmap_io_ps\", cluster=\"c3663938-6610-44d5-9897-d7bfa60a43e1\", exported_job=\"collector\", instance=\"192.168.178.52:9091\", job=\"metricsgateway\"}"
                                 ],
-                                "prefix": "All except Exception:",
+                                "prefix": "All except:",
                                 "readOnly": true
                             }
                         },

--- a/simplyblock_core/scripts/dashboards/lvols.json
+++ b/simplyblock_core/scripts/dashboards/lvols.json
@@ -2086,7 +2086,7 @@
                                 "names": [
                                     "{__name__=\"lvol_unmap_io_ps\", cluster=\"c3663938-6610-44d5-9897-d7bfa60a43e1\", exported_job=\"collector\", instance=\"192.168.178.52:9091\", job=\"metricsgateway\"}"
                                 ],
-                                "prefix": "All except Exception:",
+                                "prefix": "All except:",
                                 "readOnly": true
                             }
                         },

--- a/simplyblock_core/scripts/dashboards/nodes.json
+++ b/simplyblock_core/scripts/dashboards/nodes.json
@@ -101,7 +101,7 @@
                                 "names": [
                                     "{__name__=\"snode_size_total\", cluster=\"9baa11f4-0b47-47e1-9dec-20dacdda59d0\", exported_job=\"collector\", instance=\"pushgateway:9091\", job=\"metricsgateway\", snode=\"90499750-6b1e-4452-8ff5-125166f33865\"}"
                                 ],
-                                "prefix": "All except Exception:",
+                                "prefix": "All except:",
                                 "readOnly": true
                             }
                         },
@@ -2111,7 +2111,7 @@
                                 "names": [
                                     "{__name__=\"snode_unmap_io_ps\", cluster=\"c3663938-6610-44d5-9897-d7bfa60a43e1\", exported_job=\"collector\", instance=\"192.168.178.52:9091\", job=\"metricsgateway\"}"
                                 ],
-                                "prefix": "All except Exception:",
+                                "prefix": "All except:",
                                 "readOnly": true
                             }
                         },

--- a/simplyblock_core/scripts/dashboards/pools.json
+++ b/simplyblock_core/scripts/dashboards/pools.json
@@ -2084,7 +2084,7 @@
                                 "names": [
                                     "{__name__=\"pool_unmap_io_ps\", cluster=\"c3663938-6610-44d5-9897-d7bfa60a43e1\", exported_job=\"collector\", instance=\"192.168.178.52:9091\", job=\"metricsgateway\"}"
                                 ],
-                                "prefix": "All except Exception:",
+                                "prefix": "All except:",
                                 "readOnly": true
                             }
                         },


### PR DESCRIPTION
In the PR, https://github.com/simplyblock-io/sbcli/pull/392 while making lint changes, accidentally edited the Grafana dashboards file. So reverting those changes


<img width="817" alt="Screenshot 2025-06-19 at 20 26 48" src="https://github.com/user-attachments/assets/c9d8999a-e7f6-40d1-af91-a62179d171c3" />
