### PR TITLE
take pvc_name and pvc_namespace as a part of clone

### DIFF
--- a/simplyblock_core/controllers/snapshot_controller.py
+++ b/simplyblock_core/controllers/snapshot_controller.py
@@ -350,7 +350,7 @@ def delete(snapshot_uuid, force_delete=False):
     return True
 
 
-def clone(snapshot_id, clone_name, new_size=0):
+def clone(snapshot_id, clone_name, new_size=0, pvc_name=None, pvc_namespace=None):
     snap = db_controller.get_snapshot_by_id(snapshot_id)
     if not snap:
         msg=f"Snapshot not found {snapshot_id}"
@@ -444,6 +444,11 @@ def clone(snapshot_id, clone_name, new_size=0):
     lvol.vuid = snap.lvol.vuid
     lvol.snapshot_name = snap.snap_bdev
     lvol.subsys_port = snap.lvol.subsys_port
+
+    if pvc_name:
+        lvol.pvc_name = pvc_name
+    if pvc_namespace:
+        lvol.namespace = pvc_namespace
 
     lvol.status = LVol.STATUS_ONLINE
     lvol.bdev_stack = [

--- a/simplyblock_web/blueprints/web_api_snapshot.py
+++ b/simplyblock_web/blueprints/web_api_snapshot.py
@@ -64,5 +64,10 @@ def clone_snapshot():
         new_size = core_utils.parse_size(cl_data['new_size'])
 
     clone_id, error = snapshot_controller.clone(
-        cl_data['snapshot_id'], cl_data['clone_name'], new_size)
+        cl_data['snapshot_id'],
+        cl_data['clone_name'],
+        new_size,
+        cl_data.get('pvc_name', None),
+        cl_data.get('pvc_namespace', None)
+    )
     return utils.get_response(clone_id, error, http_code=400)


### PR DESCRIPTION
Currently when a clone is made, the fields in `pvc_name` and `namespace` of Lvol Object are not updated. 

Making changes, so that when CSI driver call for `/clone` API, it can also pass these values. 