### PR TITLE
fix reference before asignment error during suspend

### DIFF
--- a/simplyblock_core/storage_node_ops.py
+++ b/simplyblock_core/storage_node_ops.py
@@ -2175,6 +2175,7 @@ def suspend_storage_node(node_id, force=False):
                 rpc_client.bdev_distrib_force_to_non_leader(node.jm_vuid)
 
     # else:
+    sec_node = None
     try:
         sec_node = db_controller.get_storage_node_by_id(snode.secondary_node_id)
         if sec_node.status == StorageNode.STATUS_ONLINE:
@@ -2186,8 +2187,6 @@ def suspend_storage_node(node_id, force=False):
                         ret = sec_node_client.nvmf_subsystem_listener_set_ana_state(
                             lvol.nqn, iface.ip4_address, lvol.subsys_port, False, ana="inaccessible")
             time.sleep(1)
-            # sec_node_client.bdev_lvol_set_leader(snode.lvstore, leader=False)
-            # sec_node_client.bdev_distrib_force_to_non_leader(snode.jm_vuid)
     except KeyError:
         pass
 
@@ -2196,7 +2195,6 @@ def suspend_storage_node(node_id, force=False):
             if iface.ip4_address:
                 ret = rpc_client.listeners_del(
                     lvol.nqn, iface.get_transport_type(), iface.ip4_address, lvol.subsys_port)
-    # time.sleep(1)
 
     rpc_client.bdev_lvol_set_leader(snode.lvstore, leader=False)
     rpc_client.bdev_distrib_force_to_non_leader(snode.jm_vuid)


### PR DESCRIPTION
```
sbcli-dev -d sn suspend b863a904-36df-4396-9b45-1cb7d1892f54
2025-06-24 13:57:44,920: INFO: Node found: vm07_8082 in state: online
2025-06-24 13:57:44,926: INFO: Suspending node
2025-06-24 13:57:44,931: DEBUG: Requesting method: bdev_lvol_set_leader_all, params: {'lvs_name': '', 'lvs_leadership': False, 'bs_nonleadership': False}
2025-06-24 13:57:44,943: DEBUG: Response: status_code: 200
2025-06-24 13:57:44,943: DEBUG: Response json: {"jsonrpc": "2.0", "id": 1, "error": {"code": -19, "message": "No such device"}}
2025-06-24 13:57:44,943: DEBUG: Requesting method: bdev_distrib_force_to_non_leader, params: None
2025-06-24 13:57:44,951: DEBUG: Response: status_code: 200
2025-06-24 13:57:44,951: DEBUG: Response json: {"jsonrpc": "2.0", "id": 1, "result": true}
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/simplyblock_cli/cli.py", line 918, in run
    ret = self.storage_node__suspend(sub_command, args)
  File "/usr/local/lib/python3.9/site-packages/simplyblock_cli/clibase.py", line 199, in storage_node__suspend
    return storage_ops.suspend_storage_node(args.node_id, args.force)
  File "/usr/local/lib/python3.9/site-packages/simplyblock_core/storage_node_ops.py", line 2210, in suspend_storage_node
    if sec_node and sec_node.status == StorageNode.STATUS_ONLINE:
UnboundLocalError: local variable 'sec_node' referenced before assignment
```