### PR TITLE
limit k8s job name to 63 chars

### DIFF
--- a/simplyblock_web/blueprints/snode_ops_k8s.py
+++ b/simplyblock_web/blueprints/snode_ops_k8s.py
@@ -333,12 +333,16 @@ def spdk_process_start(body: SPDKParams):
         logger.info("SPDK deployment found, removing...")
         spdk_process_kill()
 
-    node_name = os.environ.get("HOSTNAME")
-    logger.debug(f"deploying caching node spdk on worker: {node_name}")
+    node_prepration_job_name_prefix = "snode-spdk-job-"
+    node_name = os.environ.get("HOSTNAME", "")
+    k8s_job_name_length = len(node_prepration_job_name_prefix+node_name)
+    if k8s_job_name_length > 63:
+        node_name = node_name[k8s_job_name_length-63:]
+
+    logger.debug(f"deploying k8s job to prepare worker: {node_name}")
 
     try:
         env = Environment(loader=FileSystemLoader(os.path.join(TOP_DIR, 'templates')), trim_blocks=True, lstrip_blocks=True)
-
         values = {
             'SPDK_IMAGE': body.spdk_image,
             "L_CORES": body.l_cores,

--- a/simplyblock_web/templates/storage_init_job.yaml.j2
+++ b/simplyblock_web/templates/storage_init_job.yaml.j2
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: snode-spdk-deployment-{{ HOSTNAME }}
+  name: snode-spdk-job-{{ HOSTNAME }}
   namespace: {{ NAMESPACE }}
 spec:
   template:


### PR DESCRIPTION
k8s deployment is failing due to this error. So limiting size of the job name to 63 chars.

```
app_TasksNodeAddRunner.1.n1cb8i2n01f4@githubactions-mgmt-1    | Reason: Unprocessable Entity
app_TasksNodeAddRunner.1.n1cb8i2n01f4@githubactions-mgmt-1    | HTTP response headers: HTTPHeaderDict({'Audit-Id': 'ed98c6be-19ec-4e37-aeec-234388e5d753', 'Cache-Control': 'no-cache, private', 'Content-Type': 'application/json', 'X-Kubernetes-Pf-Flowschema-Uid': '8b7f73d8-f87d-4644-8c85-bcb6b9f4de10', 'X-Kubernetes-Pf-Prioritylevel-Uid': '33a620ed-85d9-4cb2-9ee2-cb30d1f667be', 'Date': 'Wed, 25 Jun 2025 06:10:59 GMT', 'Content-Length': '903'})
app_TasksNodeAddRunner.1.n1cb8i2n01f4@githubactions-mgmt-1    | HTTP response body: {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"Job.batch \"snode-spdk-deployment-gke-githubactions-gk-simplyblock-pool-e97b0bae-2nsh\" is invalid: spec.template.labels: Invalid value: \"snode-spdk-deployment-gke-githubactions-gk-simplyblock-pool-e97b0bae-2nsh\": must be no more than 63 characters","reason":"Invalid","details":{"name":"snode-spdk-deployment-gke-githubactions-gk-simplyblock-pool-e97b0bae-2nsh","group":"batch","kind":"Job","causes":[{"reason":"FieldValueInvalid","message":"Invalid value: \"snode-spdk-deployment-gke-githubactions-gk-simplyblock-pool-e97b0bae-2nsh\": must be no more than 63 characters","field":"spec.template.labels"},{"reason":"FieldValueInvalid","message":"Invalid value: \"snode-spdk-deployment-gke-githubactions-gk-simplyblock-pool-e97b0bae-2nsh\": must be no more than 63 characters","field":"spec.template.labels"}]},"code":422}
```

more specifically the error is: 
`"snode-spdk-deployment-gke-githubactions-gk-simplyblock-pool-e97b0bae-2nsh\": must be no more than 63 characters`