### PR TITLE
fix 63 char limit

### DIFF
--- a/simplyblock_web/blueprints/snode_ops_k8s.py
+++ b/simplyblock_web/blueprints/snode_ops_k8s.py
@@ -339,7 +339,7 @@ def spdk_process_start(body: SPDKParams):
     # limit the job name length to 63 characters
     k8s_job_name_length = len(node_prepration_job_name+node_name)
     if k8s_job_name_length > 63:
-        node_prepration_job_name = node_name[k8s_job_name_length-63:]
+        node_prepration_job_name += node_name[k8s_job_name_length-63:]
 
     logger.debug(f"deploying k8s job to prepare worker: {node_name}")
 

--- a/simplyblock_web/blueprints/snode_ops_k8s.py
+++ b/simplyblock_web/blueprints/snode_ops_k8s.py
@@ -333,11 +333,13 @@ def spdk_process_start(body: SPDKParams):
         logger.info("SPDK deployment found, removing...")
         spdk_process_kill()
 
-    node_prepration_job_name_prefix = "snode-spdk-job-"
+    node_prepration_job_name = "snode-spdk-job-"
     node_name = os.environ.get("HOSTNAME", "")
-    k8s_job_name_length = len(node_prepration_job_name_prefix+node_name)
+
+    # limit the job name length to 63 characters
+    k8s_job_name_length = len(node_prepration_job_name+node_name)
     if k8s_job_name_length > 63:
-        node_name = node_name[k8s_job_name_length-63:]
+        node_prepration_job_name = node_name[k8s_job_name_length-63:]
 
     logger.debug(f"deploying k8s job to prepare worker: {node_name}")
 
@@ -354,6 +356,7 @@ def spdk_process_start(body: SPDKParams):
             'RPC_USERNAME': body.rpc_username,
             'RPC_PASSWORD': body.rpc_password,
             'HOSTNAME': node_name,
+            'JOBNAME': node_prepration_job_name,
             'NAMESPACE': namespace,
             'FDB_CONNECTION': body.fdb_connection,
             'SIMPLYBLOCK_DOCKER_IMAGE': constants.SIMPLY_BLOCK_DOCKER_IMAGE,

--- a/simplyblock_web/templates/storage_init_job.yaml.j2
+++ b/simplyblock_web/templates/storage_init_job.yaml.j2
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: snode-spdk-job-{{ HOSTNAME }}
+  name: {{ JOBNAME }}
   namespace: {{ NAMESPACE }}
 spec:
   template:


### PR DESCRIPTION
```
kubernetes.client.exceptions.ApiException: (422)
app_TasksNodeAddRunner.1.y9mba17z8gcs@githubactions-mgmt-1    | Reason: Unprocessable Entity
app_TasksNodeAddRunner.1.y9mba17z8gcs@githubactions-mgmt-1    | HTTP response headers: HTTPHeaderDict({'Audit-Id': '30b9e0d1-a50e-48e5-9b6b-00981ea959ba', 'Cache-Control': 'no-cache, private', 'Content-Type': 'application/json', 'X-Kubernetes-Pf-Flowschema-Uid': '8b7f73d8-f87d-4644-8c85-bcb6b9f4de10', 'X-Kubernetes-Pf-Prioritylevel-Uid': '33a620ed-85d9-4cb2-9ee2-cb30d1f667be', 'Date': 'Wed, 25 Jun 2025 08:35:33 GMT', 'Transfer-Encoding': 'chunked'})
app_TasksNodeAddRunner.1.y9mba17z8gcs@githubactions-mgmt-1    | HTTP response body: {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"Job.batch \"-githubactions-gk-simplyblock-pool-e97b0bae-2nsh\" is invalid: [metadata.name: Invalid value: \"-githubactions-gk-simplyblock-pool-e97b0bae-2nsh\": a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*'), spec.template.labels: Invalid value: \"-githubactions-gk-simplyblock-pool-e97b0bae-2nsh\": a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')]","reason":"Invalid","details":{"name":"-githubactions-gk-simplyblock-pool-e97b0bae-2nsh","group":"batch","kind":"Job","causes":[{"reason":"FieldValueInvalid","message":"Invalid value: \"-githubactions-gk-simplyblock-pool-e97b0bae-2nsh\": a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')","field":"metadata.name"},{"reason":"FieldValueInvalid","message":"Invalid value: \"-githubactions-gk-simplyblock-pool-e97b0bae-2nsh\": a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')","field":"spec.template.labels"},{"reason":"FieldValueInvalid","message":"Invalid value: \"-githubactions-gk-simplyblock-pool-e97b0bae-2nsh\": a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')","field":"spec.template.labels"}]},"code":422}
```

the error: 
`metadata.name: Invalid value: \"-githubactions-gk-simplyblock-pool-e97b0bae-2nsh\": a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric characte`


### Testing

Tested this on GCP k8s cluster.
```
[manohar@githubactions-mgmt-1 ~]$ sbcli-dev cluster list
+--------------------------------------+-----------------------------------------------------------------+---------+-------+----------+-----+--------+
| UUID                                 | NQN                                                             | ha_type | #mgmt | #storage | Mod | Status |
+--------------------------------------+-----------------------------------------------------------------+---------+-------+----------+-----+--------+
| f0ba7120-9a08-4b00-88cf-b9e7b9dfeb2d | nqn.2023-02.io.simplyblock:f0ba7120-9a08-4b00-88cf-b9e7b9dfeb2d | ha      | 1     | 3        | 1x1 | ACTIVE |
+--------------------------------------+-----------------------------------------------------------------+---------+-------+----------+-----+--------+
```