### PR TITLE
[e2e] include commit ID and commit author

### DIFF
--- a/.github/workflows/e2e-docker.yml
+++ b/.github/workflows/e2e-docker.yml
@@ -45,7 +45,7 @@ on:
       test_case_to_run:
         description: 'Specific test case to run (leave empty to run all)'
         required: false
-        default: 'TestSingleNodeFailure'
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}
@@ -140,8 +140,8 @@ jobs:
         if: always()
         env:
           GITHUB_RUN_ID: ${{ github.run_id }}
-          MINIO_ACCESS_KEY: "KxtpwblgG3AFDYJkyg8i"
-          MINIO_SECRET_KEY: "Yae4q5wJU9ZBzJhdsUGzu9wWqON8o0ERU7nGbJER"
+          MINIO_ACCESS_KEY: ${{ secrets.MINIO_ACCESS_KEY }}
+          MINIO_SECRET_KEY: ${{ secrets.MINIO_SECRET_KEY }}
           MNODES: "${{ needs.deploy.outputs.mnodes }}"
           STORAGE_PRIVATE_IPS: "${{ needs.deploy.outputs.storage_private_ips }}"
           USER: "root"
@@ -259,8 +259,10 @@ jobs:
           fi
 
           TIME_TAKEN="${TEST_TIME_HOURS}h ${TEST_TIME_MINS}m ${TEST_TIME_SECS}s"
+          COMMIT_SHA=$(git rev-parse --short HEAD)
+          COMMIT_AUTHOR=$(git log -1 --pretty=format:'%an')
 
-          MESSAGE="Python E2E tests run triggered on branch *${BRANCH_NAME}*. \nTotal Time Taken to run the tests: ${TIME_TAKEN}. \n\n${OVERALL_STATUS}\nGitHub Run: ${GITHUB_RUN_URL}\nAWS Logs: ${LOGS_URL}\n\n*Configuration*: *NDCS: ${NDCS}, NPCS: ${NPCS}, Block Size: ${BS}, Chunk Block Size: ${CHUNK_BS}*\n\nTotal Tests: *${TOTAL_TESTS}*, Passed Tests: *${PASSED_TESTS}*, Failed Tests: *${FAILED_TESTS}*\n\n-- Test Cases Passed :white_check_mark:\n${PASSED_CASES_BULLETS}\n\n-- Test Cases Failed :x:\n${FAILED_CASES_BULLETS}\n\n-- Test Cases Skipped :x:\n${SKIPPED_CASES_BULLETS}"
+          MESSAGE="Python E2E tests run triggered on branch *${BRANCH_NAME}* at ${COMMIT_SHA} by ${COMMIT_AUTHOR}. \nTotal Time Taken to run the tests: ${TIME_TAKEN}. \n\n${OVERALL_STATUS}\nGitHub Run: ${GITHUB_RUN_URL}\nAWS Logs: ${LOGS_URL}\n\n*Configuration*: *NDCS: ${NDCS}, NPCS: ${NPCS}, Block Size: ${BS}, Chunk Block Size: ${CHUNK_BS}*\n\nTotal Tests: *${TOTAL_TESTS}*, Passed Tests: *${PASSED_TESTS}*, Failed Tests: *${FAILED_TESTS}*\n\n-- Test Cases Passed :white_check_mark:\n${PASSED_CASES_BULLETS}\n\n-- Test Cases Failed :x:\n${FAILED_CASES_BULLETS}\n\n-- Test Cases Skipped :x:\n${SKIPPED_CASES_BULLETS}"
 
           curl -X POST -H 'Content-type: application/json' --data "{\"text\":\"${MESSAGE}\"}" $SLACK_WEBHOOK_URL
 


### PR DESCRIPTION
* Remove the default value. Because, if there is default value, when I leave `test_case_to_run` field as empty, GitHub Actions populates the field with default value 🥲 . Hence removing the default value. 
* move Minio secrets to GitHub Actions secrets
* Include Commit ID and Commit Author in the Slack message