### PR TITLE
fix k8s_job_name_length: add else condition

### DIFF
--- a/simplyblock_web/blueprints/snode_ops_k8s.py
+++ b/simplyblock_web/blueprints/snode_ops_k8s.py
@@ -340,6 +340,8 @@ def spdk_process_start(body: SPDKParams):
     k8s_job_name_length = len(node_prepration_job_name+node_name)
     if k8s_job_name_length > 63:
         node_prepration_job_name += node_name[k8s_job_name_length-63:]
+    else:
+        node_prepration_job_name += node_name
 
     logger.debug(f"deploying k8s job to prepare worker: {node_name}")
 


### PR DESCRIPTION
as a part of https://github.com/simplyblock-io/sbcli/pull/446, introduced a check to trim job name if it exceeds 63 chars.  But forgot to add the else condition adding it now. 


Otherwise seeing errors like this. 

`Invalid value: \"snode-spdk-job-\": a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*'), spec.template.labels: Invalid value: \"snode-spdk-job-\": a valid label must be an empty string or consist of alphanumeric characters`