### PR TITLE
add bind_device_to_spdk API to Snode Ops K8s

### DIFF
--- a/simplyblock_web/blueprints/snode_ops_k8s.py
+++ b/simplyblock_web/blueprints/snode_ops_k8s.py
@@ -15,6 +15,7 @@ from jinja2 import Environment, FileSystemLoader
 import yaml
 from pydantic import BaseModel, Field
 
+from . import snode_ops
 from simplyblock_core import constants, shell_utils, utils as core_utils
 from simplyblock_web import utils, node_utils, node_utils_k8s
 from simplyblock_web.node_utils_k8s import deployment_name, namespace_id_file, pod_name
@@ -557,3 +558,5 @@ def apply_config():
         core_utils.set_hugepages_if_needed(numa, num_pages)
 
     return utils.get_response(True)
+
+api.post('/bind_device_to_spdk')(snode_ops.bind_device_to_spdk)


### PR DESCRIPTION
Without this API, I get this error

```
2025-06-27 05:38:50,321: INFO: 192.168.10.111 - - [27/Jun/2025 05:38:50] "POST /snode/join_swarm HTTP/1.1" 200 -
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/flask/app.py", line 917, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/local/lib/python3.9/site-packages/flask/app.py", line 891, in dispatch_request
    self.raise_routing_exception(req)
  File "/usr/local/lib/python3.9/site-packages/flask/app.py", line 500, in raise_routing_exception
    raise request.routing_exception  # type: ignore[misc]
  File "/usr/local/lib/python3.9/site-packages/flask/ctx.py", line 362, in match_request
    result = self.url_adapter.match(return_rule=True)  # type: ignore
  File "/usr/local/lib/python3.9/site-packages/werkzeug/routing/map.py", line 629, in match
    raise NotFound() from None
werkzeug.exceptions.NotFound: 404 Not Found: The requested URL was not found on the server. If you entered the URL manually please check your spelling and try again.
2025-06-27 05:38:50,327: INFO: 192.168.10.111 - - [27/Jun/2025 05:38:50] "POST /snode/bind_device_to_spdk HTTP/1.1" 404 -
```