### PR TITLE
setup memory reservation for FDB as 4GB

### DIFF
--- a/simplyblock_core/scripts/docker-compose-swarm.yml
+++ b/simplyblock_core/scripts/docker-compose-swarm.yml
@@ -29,7 +29,7 @@ services:
       placement:
         constraints: [ node.role == manager ]
       resources:
-        limits:
+        reservations:
           memory: 4g
 
   fdb-backup-agent:


### PR DESCRIPTION
we have instances where foundation DB was OOM killed. 

```
[737903.423259] fdb-loopprofile invoked oom-killer: gfp_mask=0x100cca(GFP_HIGHUSER_MOVABLE), order=0, oom_score_adj=0
[907443.457453] Memory cgroup out of memory: Killed process 316788 (fdbserver) total-vm:4650720kB, anon-rss:4183372kB, file-rss:7680kB, shmem-rss:0kB, UID:0 pgtables:8556kB oom_score_adj:0
```

The original intention of the parent commit was to allocate a minimum of 4GB. But to set the minimum, we need to use `reservations`. Instead `limits` was used. Due to this the process was getting OOM killed.