### PR TITLE
run E2E docker for Pre release & release branches

### DIFF
--- a/.github/workflows/e2e-docker.yml
+++ b/.github/workflows/e2e-docker.yml
@@ -3,7 +3,9 @@ name: End-to-end test docker
 on:
   push:
     branches:
-      - main
+      # - main
+      - R*-PRE
+      - R*-Hotfix
 
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Currently, due to ongoing issues,  the E2E are currently failing on the main branch. The team is actively working to fix them. To reduce noise, we could run these tests for Pre release branches. So that we understand the stability of the fixes. 