### PR TITLE
Work around type issue in jsonschema 4.24

### DIFF
--- a/simplyblock_cli/scripts/cli-wrapper-gen.py
+++ b/simplyblock_cli/scripts/cli-wrapper-gen.py
@@ -124,7 +124,7 @@ with open("%s/cli-reference.yaml" % base_path) as stream:
         with open("%s/cli-reference-schema.yaml" % base_path) as schema:
             schema_content = yaml.safe_load(schema)
             validator_type = validators.validator_for(schema_content)
-            validator = validator_type(schema_content)
+            validator = validator_type(schema_content)  # type: ignore
             errors = list(validator.iter_errors(reference))
             if errors:
                 print("Generator failed on schema validation. Found the following errors:", file=sys.stderr)


### PR DESCRIPTION
The type checker fails without any related change in our code base. There seems to be a recent upstream change, expecting a `registry` parameter we do not pass. Since it has been working fine without it and a more correct way of doing things is not immediately obvious, we simply ignore this error for the moment and revisit the violation in future jsonschema versions.