### PR TITLE
pass NDCS and NPCS for sb-deployer helm chart

### DIFF
--- a/.github/workflows/bare-metal-deploy.yml
+++ b/.github/workflows/bare-metal-deploy.yml
@@ -180,7 +180,9 @@ jobs:
             --set storagenode.create=true \
             --set storagenode.numPartitions=1 \
             --set image.storageNode.tag=latest \
-            --set storagenode.ifname=eth0     
+            --set storagenode.ifname=eth0 \
+            --set storagenode.distr_ndcs=${NDCS} \
+            --set storagenode.distr_npcs=${NPCS}   
       env:
         NDCS: ${{ inputs.ndcs }}
         NPCS: ${{ inputs.npcs }}


### PR DESCRIPTION
currently these credentials are passed only to CSI driver helm chart. But for cluster activate to work. They should also be passed for sb-deployer helm chart too. 