### PR TITLE
remove CachedLvolStatsCollector container

### DIFF
--- a/simplyblock_core/scripts/docker-compose-swarm.yml
+++ b/simplyblock_core/scripts/docker-compose-swarm.yml
@@ -106,20 +106,6 @@ services:
     environment:
       SIMPLYBLOCK_LOG_LEVEL: "$LOG_LEVEL"
 
-  CachedLVolStatsCollector:
-    <<: *service-base
-    image: $SIMPLYBLOCK_DOCKER_IMAGE
-    command: "python simplyblock_core/services/cached_lvol_stat_collector.py"
-    deploy:
-      placement:
-        constraints: [node.role == manager]
-    volumes:
-      - "/etc/foundationdb:/etc/foundationdb"
-    networks:
-      - hostnet
-    environment:
-      SIMPLYBLOCK_LOG_LEVEL: "$LOG_LEVEL"
-
   MainDistrEventCollector:
     <<: *service-base
     image: $SIMPLYBLOCK_DOCKER_IMAGE


### PR DESCRIPTION
as a part of https://github.com/simplyblock-io/sbcli/pull/492 caching node related code was removed. So removing this

<img width="1437" alt="Screenshot 2025-07-10 at 00 13 51" src="https://github.com/user-attachments/assets/cab254f7-89f4-44d6-8eb4-fe7991baf29c" />
