### PR TITLE
enable k8s based integration tests

### DIFF
--- a/.github/workflows/bare-metal-deploy.yml
+++ b/.github/workflows/bare-metal-deploy.yml
@@ -39,7 +39,7 @@ on:
       k8s_snode:
         description: "Run snode on k8s"
         required: false
-        default: false
+        default: true
         type: boolean
 
     outputs:
@@ -169,20 +169,13 @@ jobs:
           --set logicalVolume.pool_name=testing1 \
           --set image.simplyblock.tag=${SBCLI_BRANCH} \
           --set image.csi.tag=latest \
-          --set logicalVolume.distr_ndcs=${NDCS} \
-          --set logicalVolume.distr_npcs=${NPCS} \
-          --set cachingnode.create=false \
-          --set logicalVolume.encryption=false \
-          --set storagenode.create=true
-
-          helm install sb-controller ./simplyblock-csi/charts/sb-controller/latest \
-            --set cachingnode.create=false \
-            --set storagenode.create=true \
-            --set storagenode.numPartitions=1 \
-            --set image.storageNode.tag=latest \
-            --set storagenode.ifname=eth0 \
-            --set storagenode.distr_ndcs=${NDCS} \
-            --set storagenode.distr_npcs=${NPCS}   
+          --set logicalVolume.numDataChunks=${NDCS} \
+          --set logicalVolume.numParityChunks=${NPCS} \
+          --set storagenode.create=true \
+          --set storagenode.numPartitions=1 \
+          --set image.storageNode.tag=latest \
+          --set autoClusterActivate=true
+   
       env:
         NDCS: ${{ inputs.ndcs }}
         NPCS: ${{ inputs.npcs }}

--- a/.github/workflows/bare-metal-deploy.yml
+++ b/.github/workflows/bare-metal-deploy.yml
@@ -122,7 +122,7 @@ jobs:
           echo "making sure the cluster is clean"
           helm uninstall sb-controller || true
           helm uninstall simplyblock-csi || true
-          kubectl get pods | grep snode-spdk-deployment | awk '{print $1}' | xargs kubectl delete pod || true
+          kubectl get pods | grep snode-spdk-pod | awk '{print $1}' | xargs kubectl delete pod || true
           eval $DEPLOY_CMD
         fi
         echo "mnodes=$MNODES" >> ${GITHUB_OUTPUT:-/dev/stdout}
@@ -156,7 +156,6 @@ jobs:
       if: ${{ inputs.k8s_snode == true }}
       run: |
         set -e
-        sudo rm -rf /var/lib/rancher/k3s/server/manifests/traefik.yaml
         mkdir -p $HOME/.kube
         KEY="$HOME/.ssh/simplyblock-us-east-2.pem"
         scp -i "$KEY" -o StrictHostKeyChecking=no root@${MNODE}:/etc/rancher/k3s/k3s.yaml $HOME/.kube/config

--- a/.github/workflows/cluster-deployment.yml
+++ b/.github/workflows/cluster-deployment.yml
@@ -23,7 +23,54 @@ permissions:
   contents: read
 
 jobs:
+  cleanup:
+    runs-on: self-hosted
+    steps:
+      - name: Checkout deployment tooling
+        uses: actions/checkout@v4
+        with:
+          repository: simplyblock-io/simplyBlockDeploy
+          path: deploy
+
+      - name: cleanup cluster
+        timeout-minutes: 15
+        run: |
+          cd deploy/bare-metal
+          cluster="${{ inputs.cluster }}"
+          cluster="${cluster:1}"
+          echo "cleaning up cluster $cluster"
+          KEY="~/.ssh/simplyblock-us-east-2.pem"
+          eval $(python3 inventory.py inventory/c${cluster}.yml)
+
+          # restart all nodes
+          for node in $STORAGE_PRIVATE_IPS; do
+            echo "restart node $node"
+            ssh -i $KEY -o StrictHostKeyChecking=no root@$node "
+              (nohup bash -c 'sleep 1; reboot' >/dev/null 2>&1 &)
+              exit 0
+            "
+          done
+
+          # remove partions on each nodes
+          for node in $STORAGE_PRIVATE_IPS; do
+            sleep 5
+            echo "Waiting for $node to come online..."
+            until ssh -i $KEY -o StrictHostKeyChecking=no -o ConnectTimeout=5 -o BatchMode=yes root@$node "echo 'Node is up'" 2>/dev/null; do
+              sleep 5
+            done
+
+            ssh -i $KEY -o StrictHostKeyChecking=no root@$node "
+              for disk in nvme0n1 nvme1n1 nvme2n1 nvme3n1; do
+                for part in 1 2; do
+                  echo "Removing partition \$part from disk \$disk"
+                  sudo parted /dev/\$disk rm \$part || true
+                done
+              done
+            "
+          done
+
   deploy:
+    needs: cleanup
     uses: ./.github/workflows/bare-metal-deploy.yml
     with:
       runs_on: self-hosted

--- a/simplyblock_web/node_configure.py
+++ b/simplyblock_web/node_configure.py
@@ -61,7 +61,7 @@ if __name__ == "__main__":
         if args.pci_blocked:
             pci_blocked = [str(x) for x in args.pci_blocked.split(',')]
 
-        generate_automated_deployment_config(
+        status = generate_automated_deployment_config(
             max_lvol=max_lvol,
             max_prov=max_prov,
             sockets_to_use=sockets_to_use,
@@ -69,3 +69,5 @@ if __name__ == "__main__":
             pci_allowed=pci_allowed,
             pci_blocked=pci_blocked
         )
+        if not status:
+            raise RuntimeError("Failed to generate automated deployment configuration.")

--- a/simplyblock_web/test/api/test_storage_node.py
+++ b/simplyblock_web/test/api/test_storage_node.py
@@ -52,7 +52,7 @@ def test_suspend_resume(call):
     assert call('GET', '/storagenode')[0]['status'] == 'online'
 
 
-@pytest.mark.timeout(30)
+@pytest.mark.timeout(120)
 def test_restart(call):
     node = call('GET', '/storagenode')[0]
     assert node['status'] == 'online'
@@ -76,7 +76,7 @@ def test_shutdown_unsuspended(call):
 
 
 
-@pytest.mark.timeout(40)
+@pytest.mark.timeout(120)
 def test_shutdown(call):
     node = call('GET', '/storagenode')[0]
     assert node['status'] == 'online'


### PR DESCRIPTION
* Make Kubernetes based deployment as the default in CI
* we run `simplyblock_web/node_configure.py` as a part of the init container. Any failure during this stage should be raised immediately. 
* Had to increase the timeout for the tests. Because in k8s environment, the initContainers takes a bit of an extra time.