### PR TITLE
Handle erorrs in bdev_nvme_controller_attach

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,4 @@ ec2-metadata
 flask-swagger-ui
 sentry-sdk[flask]
 flask-openapi3
+jsonschema

--- a/simplyblock_cli/cli.py
+++ b/simplyblock_cli/cli.py
@@ -1046,11 +1046,10 @@ class CLIWrapper(CLIWrapperBase):
             else:
                 self.parser.print_help()
 
-        except Exception as e:
+        except Exception as exc:
+            print('Operation failed: ', exc)
             if args.debug:
-                traceback.print_exc()
-            else:
-                print('Operation failed: ', e)
+                traceback.print_exception(None, exc, exc.__traceback__)
             exit(1)
 
         if not ret:

--- a/simplyblock_cli/scripts/cli-wrapper.jinja2
+++ b/simplyblock_cli/scripts/cli-wrapper.jinja2
@@ -148,11 +148,10 @@ class CLIWrapper(CLIWrapperBase):
             else:
                 self.parser.print_help()
 
-        except Exception as e:
+        except Exception as exc:
+            print('Operation failed: ', exc)
             if args.debug:
-                traceback.print_exc()
-            else:
-                print('Operation failed: ', e)
+                traceback.print_exception(None, exc, exc.__traceback__)
             exit(1)
 
         if not ret:

--- a/simplyblock_core/rpc_client.py
+++ b/simplyblock_core/rpc_client.py
@@ -72,6 +72,7 @@ _response_schema = {
 
 class RPCException(Exception):
     def __init__(self, message: str, code: Optional[int] = None, data: Any = None):
+        super().__init__(message, code, data)
         self.code = code
         self.message = message
         self.data = data

--- a/simplyblock_core/rpc_client.py
+++ b/simplyblock_core/rpc_client.py
@@ -70,14 +70,6 @@ _response_schema = {
 }
 
 
-def print_dict(d):
-    print(json.dumps(d, indent=2))
-
-
-def print_json(s):
-    print(json.dumps(s, indent=2).strip('"'))
-
-
 class RPCException(Exception):
     def __init__(self, message: str, code: Optional[int] = None, data: Any = None):
         self.code = code

--- a/simplyblock_core/rpc_client.py
+++ b/simplyblock_core/rpc_client.py
@@ -288,8 +288,12 @@ class RPCClient:
         return self._request("bdev_nvme_get_controllers", params)
 
     def bdev_nvme_controller_attach(self, name, pci_addr):
-        params = {"name": name, "trtype": "pcie", "traddr": pci_addr}
-        return self._request2("bdev_nvme_attach_controller", params)
+        return self._request3(
+                "bdev_nvme_attach_controller", 
+                name=name,
+                trtype='pcie',
+                traddr=pci_addr,
+        )
 
     def alloc_bdev_controller_attach(self, name, pci_addr):
         params = {"traddr": pci_addr, "ns_id": 1, "label": name}

--- a/simplyblock_core/storage_node_ops.py
+++ b/simplyblock_core/storage_node_ops.py
@@ -389,7 +389,11 @@ def _create_device_partitions(rpc_client, nvme, snode, num_partitions_per_dev, j
     time.sleep(1)
     rpc_client.bdev_nvme_detach_controller(nvme.nvme_controller)
     time.sleep(1)
-    rpc_client.bdev_nvme_controller_attach(nvme.nvme_controller, nvme.pcie_address)
+    try:
+        rpc_client.bdev_nvme_controller_attach(nvme.nvme_controller, nvme.pcie_address)
+    except RPCException as e:
+        logger.error('Failed to create device partitions: ' + str(e))
+        return False
     time.sleep(1)
     rpc_client.bdev_examine(nvme.nvme_bdev)
     time.sleep(1)

--- a/simplyblock_core/utils.py
+++ b/simplyblock_core/utils.py
@@ -1014,7 +1014,7 @@ def addNvmeDevices(rpc_client, snode, devs):
         else:
             pci_st = str(pcie).replace("0", "").replace(":", "").replace(".", "")
             nvme_controller = "nvme_%s" % pci_st
-            nvme_bdevs, err = rpc_client.bdev_nvme_controller_attach(nvme_controller, pcie)
+            nvme_bdevs = rpc_client.bdev_nvme_controller_attach(nvme_controller, pcie)
 
         for nvme_bdev in nvme_bdevs:
             rpc_client.bdev_examine(nvme_bdev)


### PR DESCRIPTION
Currently we are experiencing an issue that causes `bdev_nvme_controller_attach` to fail. In `addNvmeDevices` its error is checked in neither call-site, so the symptom is exposed by a downstream issue of accessing the returned `None` value.

This PR introduces `RPCClient._request3()`, an internal request version that is exception-based, in contrast to `RPCClient._request{1,2})()`. It also changes `RPCClient.bdev_nvme_controller_attach()` to use this new version, and adapts its call-sites accordingly.