### PR TITLE
Extending clusters to support being named

### DIFF
--- a/simplyblock_cli/cli-reference.yaml
+++ b/simplyblock_cli/cli-reference.yaml
@@ -799,6 +799,13 @@ commands:
             dest: strict_node_anti_affinity
             type: bool
             action: store_true
+          - name: "--name"
+            help: >
+              Assigns a name to the newly created cluster.
+            dest: name
+            aliases:
+              - "-n"
+            type: str
       - name: add
         help: "Adds a new cluster"
         arguments:
@@ -899,6 +906,13 @@ commands:
             dest: strict_node_anti_affinity
             type: bool
             action: store_true
+          - name: "--name"
+            help: >
+              Assigns a name to the newly created cluster.
+            dest: name
+            aliases:
+              - "-n"
+            type: str
       - name: activate
         help: >
           Activates a cluster.

--- a/simplyblock_cli/cli.py
+++ b/simplyblock_cli/cli.py
@@ -362,6 +362,7 @@ class CLIWrapper(CLIWrapperBase):
         if self.developer_mode:
             argument = subcommand.add_argument('--disable-monitoring', help='Disable monitoring stack, false by default', dest='disable_monitoring', action='store_true')
         argument = subcommand.add_argument('--strict-node-anti-affinity', help='Enable strict node anti affinity for storage nodes. Never more than one chunk is placed on a node. This requires a minimum of _data-chunks-in-stripe + parity-chunks-in-stripe + 1_ nodes in the cluster.', dest='strict_node_anti_affinity', action='store_true')
+        argument = subcommand.add_argument('--name', '-n', help='Assigns a name to the newly created cluster.', type=str, dest='name')
 
     def init_cluster__add(self, subparser):
         subcommand = self.add_sub_command(subparser, 'add', 'Adds a new cluster')
@@ -387,6 +388,7 @@ class CLIWrapper(CLIWrapperBase):
         if self.developer_mode:
             argument = subcommand.add_argument('--enable-qos', help='Enable qos bdev for storage nodes, default: true', type=bool, default=False, dest='enable_qos')
         argument = subcommand.add_argument('--strict-node-anti-affinity', help='Enable strict node anti affinity for storage nodes. Never more than one chunk is placed on a node. This requires a minimum of _data-chunks-in-stripe + parity-chunks-in-stripe + 1_ nodes in the cluster."', dest='strict_node_anti_affinity', action='store_true')
+        argument = subcommand.add_argument('--name', '-n', help='Assigns a name to the newly created cluster.', type=str, dest='name')
 
     def init_cluster__activate(self, subparser):
         subcommand = self.add_sub_command(subparser, 'activate', 'Activates a cluster.')

--- a/simplyblock_cli/clibase.py
+++ b/simplyblock_cli/clibase.py
@@ -633,6 +633,7 @@ class CLIWrapperBase:
         distr_bs = args.distr_bs
         distr_chunk_bs = args.distr_chunk_bs
         ha_type = args.ha_type
+        name = args.name
 
         enable_node_affinity = args.enable_node_affinity
         qpair_count = args.qpair_count
@@ -644,7 +645,7 @@ class CLIWrapperBase:
         return cluster_ops.add_cluster(
             blk_size, page_size_in_blocks, cap_warn, cap_crit, prov_cap_warn, prov_cap_crit,
             distr_ndcs, distr_npcs, distr_bs, distr_chunk_bs, ha_type, enable_node_affinity,
-            qpair_count, max_queue_size, inflight_io_threshold, enable_qos, strict_node_anti_affinity)
+            qpair_count, max_queue_size, inflight_io_threshold, enable_qos, strict_node_anti_affinity, name)
 
     def cluster_create(self, args):
         page_size_in_blocks = args.page_size
@@ -671,13 +672,15 @@ class CLIWrapperBase:
         enable_qos = args.enable_qos
         disable_monitoring = args.disable_monitoring
         strict_node_anti_affinity = args.strict_node_anti_affinity
+        name = args.name
 
         return cluster_ops.create_cluster(
             blk_size, page_size_in_blocks,
             CLI_PASS, cap_warn, cap_crit, prov_cap_warn, prov_cap_crit,
             ifname, log_del_interval, metrics_retention_period, contact_point, grafana_endpoint,
             distr_ndcs, distr_npcs, distr_bs, distr_chunk_bs, ha_type, enable_node_affinity,
-            qpair_count, max_queue_size, inflight_io_threshold, enable_qos, disable_monitoring, strict_node_anti_affinity)
+            qpair_count, max_queue_size, inflight_io_threshold, enable_qos, disable_monitoring,
+            strict_node_anti_affinity, name)
 
     def query_yes_no(self, question, default="yes"):
         """Ask a yes/no question via raw_input() and return their answer.

--- a/simplyblock_core/cluster_ops.py
+++ b/simplyblock_core/cluster_ops.py
@@ -124,7 +124,8 @@ def _set_max_result_window(cluster_ip, max_window=100000):
 def create_cluster(blk_size, page_size_in_blocks, cli_pass,
                    cap_warn, cap_crit, prov_cap_warn, prov_cap_crit, ifname, log_del_interval, metrics_retention_period,
                    contact_point, grafana_endpoint, distr_ndcs, distr_npcs, distr_bs, distr_chunk_bs, ha_type,
-                   enable_node_affinity, qpair_count, max_queue_size, inflight_io_threshold, enable_qos, disable_monitoring, strict_node_anti_affinity) -> str:
+                   enable_node_affinity, qpair_count, max_queue_size, inflight_io_threshold, enable_qos, disable_monitoring,
+                   strict_node_anti_affinity, name) -> str:
 
     if distr_ndcs == 0 and distr_npcs == 0:
         raise ValueError("both distr_ndcs and distr_npcs cannot be 0")
@@ -181,6 +182,7 @@ def create_cluster(blk_size, page_size_in_blocks, cli_pass,
     logger.info("Adding new cluster object")
     cluster = Cluster()
     cluster.uuid = str(uuid.uuid4())
+    cluster.cluster_name = name
     cluster.blk_size = blk_size
     cluster.page_size_in_blocks = page_size_in_blocks
     cluster.nqn = f"{constants.CLUSTER_NQN}:{cluster.uuid}"
@@ -304,7 +306,7 @@ def _run_fio(mount_point) -> None:
 
 def add_cluster(blk_size, page_size_in_blocks, cap_warn, cap_crit, prov_cap_warn, prov_cap_crit,
                 distr_ndcs, distr_npcs, distr_bs, distr_chunk_bs, ha_type, enable_node_affinity, qpair_count,
-                max_queue_size, inflight_io_threshold, enable_qos, strict_node_anti_affinity) -> str:
+                max_queue_size, inflight_io_threshold, enable_qos, strict_node_anti_affinity, name) -> str:
     db_controller = DBController()
     clusters = db_controller.get_clusters()
     if not clusters:
@@ -316,6 +318,7 @@ def add_cluster(blk_size, page_size_in_blocks, cap_warn, cap_crit, prov_cap_warn
     logger.info("Adding new cluster")
     cluster = Cluster()
     cluster.uuid = str(uuid.uuid4())
+    cluster.cluster_name = name
     cluster.blk_size = blk_size
     cluster.page_size_in_blocks = page_size_in_blocks
     cluster.nqn = f"{constants.CLUSTER_NQN}:{cluster.uuid}"
@@ -618,6 +621,7 @@ def list() -> t.List[dict]:
             status = f"{status} - ReBalancing"
         data.append({
             "UUID": cl.get_id(),
+            "Name": cl.cluster_name if cl.cluster_name is not None else "-",
             "NQN": cl.nqn,
             "ha_type": cl.ha_type,
             "#mgmt": len(mt),

--- a/simplyblock_core/models/cluster.py
+++ b/simplyblock_core/models/cluster.py
@@ -53,6 +53,7 @@ class Cluster(BaseModel):
     iscsi: str = ""
     max_queue_size: int = 128
     model_ids: List[str] = []
+    cluster_name: str = None # type: ignore[assignment]
     nqn: str = ""
     page_size_in_blocks: int = 2097152
     prov_cap_crit: int = 190

--- a/simplyblock_web/blueprints/web_api_cluster.py
+++ b/simplyblock_web/blueprints/web_api_cluster.py
@@ -45,6 +45,7 @@ def add_cluster():
     ha_type = cl_data.get('ha_type', 'single')
     enable_node_affinity = cl_data.get('enable_node_affinity', False)
     qpair_count = cl_data.get('qpair_count', 256)
+    name = cl_data.get('name', None)
 
     max_queue_size = cl_data.get('max_queue_size', 128)
     inflight_io_threshold = cl_data.get('inflight_io_threshold', 4)
@@ -54,7 +55,7 @@ def add_cluster():
     return utils.get_response(cluster_ops.add_cluster(
         blk_size, page_size_in_blocks, cap_warn, cap_crit, prov_cap_warn, prov_cap_crit,
         distr_ndcs, distr_npcs, distr_bs, distr_chunk_bs, ha_type, enable_node_affinity,
-        qpair_count, max_queue_size, inflight_io_threshold, enable_qos, strict_node_anti_affinity
+        qpair_count, max_queue_size, inflight_io_threshold, enable_qos, strict_node_anti_affinity, name
     ))
 
 


### PR DESCRIPTION
This PR adds names to cluster objects. The field is optional and can be set via "--name" or "-n" on cluster create and cluster add operations.

If the name is not explicitly set, or for old cluster objects which were created before the name existed, the cluster listing returns "-" and the API returns null. it should, potentially, be possible to update the cluster name using a new cluster edit operation, but this is out of the scope of this pull request and can be added by a separate one.