### PR TITLE
Spoof cluster status in mocked deployment

### DIFF
--- a/manual_testing/check_endpoints.py
+++ b/manual_testing/check_endpoints.py
@@ -24,6 +24,7 @@ SECRET = utils.generate_string(20)
 c.uuid = CLUSTER_UUID
 c.secret = SECRET
 c.write_to_db(db_controller.kv_store)
+c.status = 'online'
 
 
 AUTH_HEADER = {


### PR DESCRIPTION
Previously the missing status caused verbose error messages.