### PR TITLE
removed HAProxy logs to graylog

### DIFF
--- a/simplyblock_core/scripts/docker-compose-swarm.yml
+++ b/simplyblock_core/scripts/docker-compose-swarm.yml
@@ -121,7 +121,6 @@ services:
       SIMPLYBLOCK_LOG_LEVEL: "$LOG_LEVEL"
 
   HAProxy:
-    <<: *service-base
     image: haproxytech/haproxy-debian:latest
     deploy:
       mode: global


### PR DESCRIPTION
 the HaProxy change introduced in https://github.com/simplyblock-io/sbcli/pull/573 was breaking cluster create