### PR TITLE
Add snode/spdk_proxy_restart API path to k8s file

### DIFF
--- a/simplyblock_web/api/internal/storage_node/kubernetes.py
+++ b/simplyblock_web/api/internal/storage_node/kubernetes.py
@@ -600,7 +600,7 @@ def is_alive():
     })}}},
 })
 def spdk_proxy_restart(query: utils.RPCPortParams):
-    return spdk_process_kill(query)
+    return utils.get_response(True)
 
 
 api.post('/bind_device_to_spdk')(snode_ops.bind_device_to_spdk)


### PR DESCRIPTION
The new path is used to restart the spdk proxy by restarting the pod