### PR TITLE
Set device status back to cannot_allocate on node restart

### DIFF
--- a/simplyblock_core/controllers/device_controller.py
+++ b/simplyblock_core/controllers/device_controller.py
@@ -57,10 +57,10 @@ def device_set_state(device_id, state):
         return False
 
     if device.status != state:
-        old_status = dev.status
+        device.previous_status = device.status
         device.status = state
         snode.write_to_db(db_controller.kv_store)
-        device_events.device_status_change(device, device.status, old_status)
+        device_events.device_status_change(device, device.status, device.previous_status)
 
     if state == NVMeDevice.STATUS_ONLINE:
         logger.info("Make other nodes connect to the node devices")

--- a/simplyblock_core/models/nvme_device.py
+++ b/simplyblock_core/models/nvme_device.py
@@ -63,6 +63,7 @@ class NVMeDevice(BaseModel):
     serial_number: str = ""
     size: int = -1
     testing_bdev: str = ""
+    previous_status: str = ""
 
 
 class JMDevice(NVMeDevice):

--- a/simplyblock_core/storage_node_ops.py
+++ b/simplyblock_core/storage_node_ops.py
@@ -1878,6 +1878,8 @@ def restart_storage_node(
         if db_dev.status in [NVMeDevice.STATUS_UNAVAILABLE, NVMeDevice.STATUS_ONLINE,
                              NVMeDevice.STATUS_CANNOT_ALLOCATE, NVMeDevice.STATUS_READONLY]:
             db_dev.status = NVMeDevice.STATUS_ONLINE
+            if db_dev.previous_status and db_dev.previous_status == NVMeDevice.STATUS_CANNOT_ALLOCATE:
+                db_dev.status = NVMeDevice.STATUS_CANNOT_ALLOCATE
             db_dev.health_check = True
             device_events.device_restarted(db_dev)
     snode.write_to_db(db_controller.kv_store)


### PR DESCRIPTION
Introducing new device attr "previous_status" that would hold the previous device status and would be used on snode restart.