### PR TITLE
Allow device of state cannot_allocate to start expanding

### DIFF
--- a/simplyblock_core/constants.py
+++ b/simplyblock_core/constants.py
@@ -221,3 +221,5 @@ prometheus_patch = {
 }
 
 qos_class_meta_and_migration_weight_percent = 25
+
+MIG_PARALLEL_JOBS = 16

--- a/simplyblock_core/rpc_client.py
+++ b/simplyblock_core/rpc_client.py
@@ -922,7 +922,7 @@ class RPCClient:
         params = {"name": name}
         return self._request("distr_migration_status", params)
 
-    def distr_migration_failure_start(self, name, storage_ID, qos_high_priority=False, job_size=1024):
+    def distr_migration_failure_start(self, name, storage_ID, qos_high_priority=False, job_size=1024, jobs=4):
         params = {
             "name": name,
             "storage_ID": storage_ID,
@@ -931,9 +931,11 @@ class RPCClient:
             params["qos_high_priority"] = qos_high_priority
         if job_size:
             params["job_size"] = job_size
+        if jobs:
+            params["jobs"] = jobs
         return self._request("distr_migration_failure_start", params)
 
-    def distr_migration_expansion_start(self, name, qos_high_priority=False, job_size=1024):
+    def distr_migration_expansion_start(self, name, qos_high_priority=False, job_size=1024, jobs=4):
         params = {
             "name": name,
         }
@@ -941,6 +943,8 @@ class RPCClient:
             params["qos_high_priority"] = qos_high_priority
         if job_size:
             params["job_size"] = job_size
+        if jobs:
+            params["jobs"] = jobs
         return self._request("distr_migration_expansion_start", params)
 
     def bdev_raid_add_base_bdev(self, raid_bdev, base_bdev):

--- a/simplyblock_core/services/tasks_runner_failed_migration.py
+++ b/simplyblock_core/services/tasks_runner_failed_migration.py
@@ -2,7 +2,7 @@
 import time
 from datetime import datetime
 
-from simplyblock_core import db_controller, utils
+from simplyblock_core import db_controller, utils, constants
 from simplyblock_core.controllers import tasks_controller, device_controller
 from simplyblock_core.models.cluster import Cluster
 from simplyblock_core.models.job_schedule import JobSchedule
@@ -88,7 +88,7 @@ def task_runner(task):
         if db.get_cluster_by_id(snode.cluster_id).is_qos_set():
             qos_high_priority = True
         rsp = rpc_client.distr_migration_failure_start(
-            distr_name, device.cluster_device_order, qos_high_priority, job_size=1024)
+            distr_name, device.cluster_device_order, qos_high_priority, job_size=1024, jobs=constants.MIG_PARALLEL_JOBS)
         if not rsp:
             logger.error(f"Failed to start device migration task, storage_ID: {device.cluster_device_order}")
             task.function_result = "Failed to start device migration task"

--- a/simplyblock_core/services/tasks_runner_migration.py
+++ b/simplyblock_core/services/tasks_runner_migration.py
@@ -2,7 +2,7 @@
 import time
 from datetime import datetime, timezone
 
-from simplyblock_core import db_controller, utils
+from simplyblock_core import db_controller, utils, constants
 from simplyblock_core.controllers import tasks_events, tasks_controller
 from simplyblock_core.models.cluster import Cluster
 from simplyblock_core.models.job_schedule import JobSchedule
@@ -91,7 +91,8 @@ def task_runner(task):
         qos_high_priority = False
         if db.get_cluster_by_id(snode.cluster_id).is_qos_set():
             qos_high_priority = True
-        rsp = rpc_client.distr_migration_expansion_start(distr_name, qos_high_priority, job_size=1024)
+        rsp = rpc_client.distr_migration_expansion_start(distr_name, qos_high_priority, job_size=1024,
+                                                         jobs=constants.MIG_PARALLEL_JOBS)
         if not rsp:
             logger.error(f"Failed to start device migration task, storage_ID: {device.cluster_device_order}")
             task.function_result = "Failed to start device migration task, retry later"
@@ -106,16 +107,16 @@ def task_runner(task):
 
     try:
         if "migration" in task.function_params:
-            allowed_error_codes = []
+            allow_all_errors = False
             for node in db.get_storage_nodes_by_cluster_id(task.cluster_id):
                 for dev in node.nvme_devices:
                     if dev.status in [NVMeDevice.STATUS_READONLY, NVMeDevice.STATUS_CANNOT_ALLOCATE]:
-                        allowed_error_codes = [8, 32, 520]
+                        allow_all_errors = True
                         break
 
             mig_info = task.function_params["migration"]
             res = rpc_client.distr_migration_status(**mig_info)
-            return utils.handle_task_result(task, res, allowed_error_codes=allowed_error_codes)
+            return utils.handle_task_result(task, res, allow_all_errors=allow_all_errors)
     except Exception as e:
         logger.error("Failed to get migration task status")
         logger.exception(e)

--- a/simplyblock_core/services/tasks_runner_new_dev_migration.py
+++ b/simplyblock_core/services/tasks_runner_new_dev_migration.py
@@ -2,7 +2,7 @@
 import time
 from datetime import datetime, timezone
 
-from simplyblock_core import db_controller, utils
+from simplyblock_core import db_controller, utils, constants
 from simplyblock_core.controllers import tasks_controller
 from simplyblock_core.models.cluster import Cluster
 from simplyblock_core.models.job_schedule import JobSchedule
@@ -75,7 +75,8 @@ def task_runner(task):
             if dev.status == NVMeDevice.STATUS_FAILED:
                 all_devs_online = False
             elif dev.status not in [NVMeDevice.STATUS_ONLINE,
-                                  NVMeDevice.STATUS_FAILED_AND_MIGRATED]:
+                                    NVMeDevice.STATUS_FAILED_AND_MIGRATED,
+                                    NVMeDevice.STATUS_CANNOT_ALLOCATE]:
                 all_devs_online_or_failed = False
                 all_devs_online = False
                 break
@@ -101,7 +102,8 @@ def task_runner(task):
         qos_high_priority = False
         if db.get_cluster_by_id(snode.cluster_id).is_qos_set():
             qos_high_priority = True
-        rsp = rpc_client.distr_migration_expansion_start(distr_name, qos_high_priority, job_size=1024)
+        rsp = rpc_client.distr_migration_expansion_start(distr_name, qos_high_priority, job_size=1024,
+                                                         jobs=constants.MIG_PARALLEL_JOBS)
         if not rsp:
             logger.error(f"Failed to start device migration task, storage_ID: {device.cluster_device_order}")
             task.function_result = "Failed to start device migration task"

--- a/simplyblock_core/utils/__init__.py
+++ b/simplyblock_core/utils/__init__.py
@@ -730,7 +730,7 @@ def strfdelta(tdelta):
     return out.strip()
 
 
-def handle_task_result(task: JobSchedule, res: dict, allowed_error_codes=None):
+def handle_task_result(task: JobSchedule, res: dict, allowed_error_codes=None, allow_all_errors=False):
     if res:
         if not allowed_error_codes:
             allowed_error_codes = [0]
@@ -743,7 +743,7 @@ def handle_task_result(task: JobSchedule, res: dict, allowed_error_codes=None):
             if error_code == 0:
                 task.function_result = "Done"
                 task.status = JobSchedule.STATUS_DONE
-            elif error_code in allowed_error_codes:
+            elif error_code in allowed_error_codes or allow_all_errors:
                 task.function_result = f"mig completed with status: {error_code}"
                 task.status = JobSchedule.STATUS_DONE
             else:


### PR DESCRIPTION
Increase the jobs for migrations to 16

Allow all errors in case of a device in state cannot_allocate and read_only in the cluster when migration is completed