### PR TITLE
Fix sfam-2450 cluster update issues

### DIFF
--- a/simplyblock_core/cluster_ops.py
+++ b/simplyblock_core/cluster_ops.py
@@ -1174,9 +1174,13 @@ def update_cluster(cluster_id, mgmt_only=False, restart=False, spdk_image=None, 
         for service in cluster_docker.services.list():
             if image_parts in service.attrs['Spec']['Labels']['com.docker.stack.image'] or \
             "simplyblock" in service.attrs['Spec']['Labels']['com.docker.stack.image']:
-                logger.info(f"Updating service {service.name}")
-                service.update(image=service_image, force_update=True)
-                service_names.append(service.attrs['Spec']['Name'])
+                if service.name == "app_CachingNodeMonitor":
+                    logger.info(f"Removing service {service.name}")
+                    service.remove()
+                else:
+                    logger.info(f"Updating service {service.name}")
+                    service.update(image=service_image, force_update=True)
+                    service_names.append(service.attrs['Spec']['Name'])
 
         if "app_SnapshotMonitor" not in service_names:
             logger.info("Creating snapshot monitor service")

--- a/simplyblock_core/models/cluster.py
+++ b/simplyblock_core/models/cluster.py
@@ -45,7 +45,7 @@ class Cluster(BaseModel):
     distr_npcs: int = 0
     enable_node_affinity: bool = False
     grafana_endpoint: str = ""
-    mode: str = ""
+    mode: str = "docker"
     grafana_secret: str = ""
     contact_point: str = ""
     ha_type: str = "single"


### PR DESCRIPTION
- set cluster mode to default "docker"
- remove service "app_CachingNodeMonitor" from services during cluster update