### PR TITLE
lvol detail: get used size

### DIFF
--- a/simplyblock_core/cluster_ops.py
+++ b/simplyblock_core/cluster_ops.py
@@ -371,8 +371,6 @@ def create_cluster(blk_size, page_size_in_blocks, cli_pass,
 
     cluster.write_to_db(db_controller.kv_store)
 
-    qos_controller.add_class("Default", 100, cluster.get_id())
-
     cluster_events.cluster_create(cluster)
 
     mgmt_node_ops.add_mgmt_node(dev_ip, mode, cluster.uuid)

--- a/simplyblock_core/env_var
+++ b/simplyblock_core/env_var
@@ -1,5 +1,5 @@
 SIMPLY_BLOCK_COMMAND_NAME=sbcli-dev
-SIMPLY_BLOCK_VERSION=19.2.23
+SIMPLY_BLOCK_VERSION=19.2.24
 
 SIMPLY_BLOCK_DOCKER_IMAGE=public.ecr.aws/simply-block/simplyblock:main
 SIMPLY_BLOCK_SPDK_ULTRA_IMAGE=public.ecr.aws/simply-block/ultra:main-latest

--- a/simplyblock_web/api/v2/dtos.py
+++ b/simplyblock_web/api/v2/dtos.py
@@ -197,6 +197,7 @@ class VolumeDTO(BaseModel):
     nodes: List[util.UrlPath]
     port: util.Port
     size: util.Unsigned
+    used_size: util.Unsigned
     cloned_from: Optional[util.UrlPath]
     crypto_key: Optional[Tuple[str, str]]
     high_availability: bool
@@ -206,7 +207,7 @@ class VolumeDTO(BaseModel):
     max_w_mbytes: util.Unsigned
 
     @staticmethod
-    def from_model(model: LVol, request: Request, cluster_id: str):
+    def from_model(model: LVol, request: Request, cluster_id: str, used_size: util.Unsigned = 0):
         return VolumeDTO(
             id=UUID(model.get_id()),
             name=model.lvol_name,
@@ -223,6 +224,7 @@ class VolumeDTO(BaseModel):
             ],
             port=model.subsys_port,
             size=model.size,
+            used_size=used_size,
             cloned_from=str(request.url_for(
                 'clusters:storage-pools:snapshots:detail',
                 cluster_id=cluster_id,

--- a/simplyblock_web/test/api/v2/test_volume.py
+++ b/simplyblock_web/test/api/v2/test_volume.py
@@ -35,6 +35,8 @@ def test_volume_get(call, cluster, storage_pool, volume):
     assert volume_details['name'] == 'volumeX'
     assert volume_details['id'] == volume
     assert volume_details['size'] == 2 * 10 ** 9
+    assert 'used_size' in volume_details
+    assert volume_details['used_size'] >= 0
     # TODO assert schema
 
 


### PR DESCRIPTION
Currently used size is not available as a part of lvol detail API. So adding it.