### PR TITLE
R25.10 hotfix spdk proxy stats

### DIFF
--- a/simplyblock_core/services/spdk_http_proxy_server.py
+++ b/simplyblock_core/services/spdk_http_proxy_server.py
@@ -23,7 +23,6 @@ logger.setLevel(logging.INFO)
 read_line_time_diff: dict = {}
 recv_from_spdk_time_diff: dict = {}
 def print_stats():
-    global read_line_time_diff, recv_from_spdk_time_diff
     while True:
         try:
             time.sleep(3)
@@ -34,8 +33,11 @@ def print_stats():
             for k,v in read_line_time_diff.items():
                 if k > t - 3*1000*1000*1000:
                     last_3_sec.append(v)
-            read_line_time_diff_avg_last_3_sec = int(sum(last_3_sec)/len(last_3_sec))
-            logger.info(f"Periodic stats: {t}: read_line_time max={read_line_time_diff_max}ns, avg={read_line_time_diff_avg}ns, last 3s avg={read_line_time_diff_avg_last_3_sec}ns")
+            if len(last_3_sec) > 0:
+                read_line_time_diff_avg_last_3_sec = int(sum(last_3_sec)/len(last_3_sec))
+            else:
+                read_line_time_diff_avg_last_3_sec = 0
+            logger.info(f"Periodic stats: {t}: read_line_time: max={read_line_time_diff_max} ns, avg={read_line_time_diff_avg} ns, last_3s_avg={read_line_time_diff_avg_last_3_sec} ns")
             if len(read_line_time_diff) > 10000:
                 read_line_time_diff.clear()
 
@@ -45,8 +47,11 @@ def print_stats():
             for k,v in recv_from_spdk_time_diff.items():
                 if k > t - 3*1000*1000*1000:
                     last_3_sec.append(v)
-            recv_from_spdk_time_avg_last_3_sec = int(sum(last_3_sec)/len(last_3_sec))
-            logger.info(f"Periodic stats: {t}: recv_from_spdk_time max={recv_from_spdk_time_max}ns, avg={recv_from_spdk_time_avg}ns, last 3s avg={recv_from_spdk_time_avg_last_3_sec}ns")
+            if len(last_3_sec) > 0:
+                recv_from_spdk_time_avg_last_3_sec = int(sum(last_3_sec)/len(last_3_sec))
+            else:
+                recv_from_spdk_time_avg_last_3_sec = 0
+            logger.info(f"Periodic stats: {t}: recv_from_spdk_time: max={recv_from_spdk_time_max} ns, avg={recv_from_spdk_time_avg} ns, last_3s_avg={recv_from_spdk_time_avg_last_3_sec} ns")
             if len(recv_from_spdk_time_diff) > 10000:
                 recv_from_spdk_time_diff.clear()
         except Exception as e:
@@ -64,7 +69,6 @@ def get_env_var(name, default=None, is_required=False):
 
 unix_sockets: list[socket] = []  # type: ignore[valid-type]
 def rpc_call(req):
-    global recv_from_spdk_time_diff
     logger.info(f"active threads: {threading.active_count()}")
     logger.info(f"active unix sockets: {len(unix_sockets)}")
     req_data = json.loads(req.decode('ascii'))
@@ -138,7 +142,6 @@ class ServerHandler(BaseHTTPRequestHandler):
         self.end_headers()
 
     def do_POST(self):
-        global read_line_time_diff
         req_time = time.time_ns()
         self.server_session.append(req_time)
         logger.info(f"incoming request at: {req_time}")
@@ -146,11 +149,11 @@ class ServerHandler(BaseHTTPRequestHandler):
         if self.headers['Authorization'] != 'Basic ' + self.key:
             self.do_AUTHHEAD()
         else:
+            read_line_time_start = time.time_ns()
             if "Content-Length" in self.headers:
                 data_string = self.rfile.read(int(self.headers['Content-Length']))
             elif "chunked" in self.headers.get("Transfer-Encoding", ""):
                 data_string = b''
-                read_line_time_start = time.time_ns()
                 while True:
                     line = self.rfile.readline().strip()
                     chunk_length = int(line, 16)
@@ -166,10 +169,10 @@ class ServerHandler(BaseHTTPRequestHandler):
                     # Finally, a chunk size of 0 is an end indication
                     if chunk_length == 0:
                         break
-                read_line_time_end = time.time_ns()
-                time_diff = read_line_time_end - read_line_time_start
-                logger.info(f"read_line_time_diff: {time_diff}")
-                read_line_time_diff[read_line_time_start] = time_diff
+            read_line_time_end = time.time_ns()
+            time_diff = read_line_time_end - read_line_time_start
+            logger.info(f"read_line_time_diff: {time_diff}")
+            read_line_time_diff[read_line_time_start] = time_diff
             try:
                 response = rpc_call(data_string)
                 if response is not None:


### PR DESCRIPTION
Prints max, avg and last 3 sec avg for read lines from http socket and rpc response receive from spdk

Example prints:


2025-12-08 13:33:33,258: INFO: Periodic stats: 1765200813258265496: read_line_time: max=21063 ns, avg=9187 ns, last_3s_avg=8187 ns
2025-12-08 13:33:33,258: INFO: Periodic stats: 1765200813258265496: recv_from_spdk_time: max=8303547 ns, avg=6489292 ns, last_3s_avg=4615891 ns
