### PR TITLE
R25.10 hotfix dump tree (#879)

### DIFF
--- a/simplyblock_cli/cli-reference.yaml
+++ b/simplyblock_cli/cli-reference.yaml
@@ -724,6 +724,60 @@ commands:
             help: "Device id"
             dest: device_id
             type: str
+      - name: list-snapshots
+        help: "List snapshots on a storage node"
+        arguments:
+          - name: "node_id"
+            help: "Node id"
+            dest: node_id
+            type: str
+          - name: "--json"
+            help: "Print json output"
+            dest: json
+            type: bool
+            action: store_true
+      - name: list-lvols
+        help: "List lvols on a storage node"
+        arguments:
+          - name: "node_id"
+            help: "Node id"
+            dest: node_id
+            type: str
+          - name: "--json"
+            help: "Print json output"
+            dest: json
+            type: bool
+            action: store_true
+      - name: repair-lvstore
+        help: "Try repair any inconsistencies in lvstore on a storage node"
+        arguments:
+          - name: "node_id"
+            help: "Node id"
+            dest: node_id
+            type: str
+          - name: "--validate-only"
+            help: "Validate only, do not perform any repair actions"
+            dest: validate_only
+            type: bool
+            action: store_true
+          - name: "--force-remove-inconsistent"
+            help: "Force remove any inconsistent lvols or snapshots"
+            dest: force_remove_inconsistent
+            type: bool
+            action: store_true
+          - name: "--force_remove_wrong_ref"
+            help: "Force remove lvols or snapshots with wrong reference count"
+            dest: force_remove_wrong_ref
+            type: bool
+            action: store_true
+      - name: lvs-dump-tree
+        help: "dump lvstore tree for debugging"
+        private: true
+        arguments:
+          - name: "node_id"
+            help: "Node id"
+            dest: node_id
+            type: str
   - name: "cluster"
     help: "Cluster commands"
     weight: 200

--- a/simplyblock_cli/cli.py
+++ b/simplyblock_cli/cli.py
@@ -78,6 +78,11 @@ class CLIWrapper(CLIWrapperBase):
         if self.developer_mode:
             self.init_storage_node__set(subparser)
         self.init_storage_node__new_device_from_failed(subparser)
+        self.init_storage_node__list_snapshots(subparser)
+        self.init_storage_node__list_lvols(subparser)
+        self.init_storage_node__repair_lvstore(subparser)
+        if self.developer_mode:
+            self.init_storage_node__lvs_dump_tree(subparser)
 
 
     def init_storage_node__deploy(self, subparser):
@@ -311,6 +316,27 @@ class CLIWrapper(CLIWrapperBase):
     def init_storage_node__new_device_from_failed(self, subparser):
         subcommand = self.add_sub_command(subparser, 'new-device-from-failed', 'Adds a new device to from failed device information')
         subcommand.add_argument('device_id', help='Device id', type=str)
+
+    def init_storage_node__list_snapshots(self, subparser):
+        subcommand = self.add_sub_command(subparser, 'list-snapshots', 'List snapshots on a storage node')
+        subcommand.add_argument('node_id', help='Node id', type=str)
+        argument = subcommand.add_argument('--json', help='Print json output', dest='json', action='store_true')
+
+    def init_storage_node__list_lvols(self, subparser):
+        subcommand = self.add_sub_command(subparser, 'list-lvols', 'List lvols on a storage node')
+        subcommand.add_argument('node_id', help='Node id', type=str)
+        argument = subcommand.add_argument('--json', help='Print json output', dest='json', action='store_true')
+
+    def init_storage_node__repair_lvstore(self, subparser):
+        subcommand = self.add_sub_command(subparser, 'repair-lvstore', 'Try repair any inconsistencies in lvstore on a storage node')
+        subcommand.add_argument('node_id', help='Node id', type=str)
+        argument = subcommand.add_argument('--validate-only', help='Validate only, do not perform any repair actions', dest='validate_only', action='store_true')
+        argument = subcommand.add_argument('--force-remove-inconsistent', help='Force remove any inconsistent lvols or snapshots', dest='force_remove_inconsistent', action='store_true')
+        argument = subcommand.add_argument('--force_remove_wrong_ref', help='Force remove lvols or snapshots with wrong reference count', dest='force_remove_wrong_ref', action='store_true')
+
+    def init_storage_node__lvs_dump_tree(self, subparser):
+        subcommand = self.add_sub_command(subparser, 'lvs-dump-tree', 'dump lvstore tree for debugging')
+        subcommand.add_argument('node_id', help='Node id', type=str)
 
 
     def init_cluster(self):
@@ -939,6 +965,18 @@ class CLIWrapper(CLIWrapperBase):
                         ret = self.storage_node__set(sub_command, args)
                 elif sub_command in ['new-device-from-failed']:
                     ret = self.storage_node__new_device_from_failed(sub_command, args)
+                elif sub_command in ['list-snapshots']:
+                    ret = self.storage_node__list_snapshots(sub_command, args)
+                elif sub_command in ['list-lvols']:
+                    ret = self.storage_node__list_lvols(sub_command, args)
+                elif sub_command in ['repair-lvstore']:
+                    ret = self.storage_node__repair_lvstore(sub_command, args)
+                elif sub_command in ['lvs-dump-tree']:
+                    if not self.developer_mode:
+                        print("This command is private.")
+                        ret = False
+                    else:
+                        ret = self.storage_node__lvs_dump_tree(sub_command, args)
                 else:
                     self.parser.print_help()
 

--- a/simplyblock_cli/clibase.py
+++ b/simplyblock_cli/clibase.py
@@ -341,6 +341,19 @@ class CLIWrapperBase:
     def storage_node__new_device_from_failed(self, sub_command, args):
         return device_controller.new_device_from_failed(args.device_id)
 
+    def storage_node__list_snapshots(self, sub_command, args):
+        return snapshot_controller.list_by_node(args.node_id, args.json)
+
+    def storage_node__list_lvols(self, sub_command, args):
+        return lvol_controller.list_by_node(args.node_id, args.json)
+
+    def storage_node__repair_lvstore(self, sub_command, args):
+        return storage_ops.auto_repair(
+            args.node_id, args.validate_only, args.force_remove_inconsistent, args.force_remove_wrong_ref)
+
+    def storage_node__lvs_dump_tree(self, sub_command, args):
+        return storage_ops.lvs_dump_tree(args.node_id)
+
     def storage_node__set(self, sub_command, args):
         return storage_ops.set_value(args.node_id, args.attr_name, args.attr_value)
 

--- a/simplyblock_core/controllers/lvol_controller.py
+++ b/simplyblock_core/controllers/lvol_controller.py
@@ -1738,3 +1738,34 @@ def inflate_lvol(lvol_id):
     else:
         logger.error(f"Failed to inflate LVol: {lvol_id}")
     return ret
+
+
+def list_by_node(node_id=None, is_json=False):
+    db_controller = DBController()
+    lvols = db_controller.get_lvols()
+    lvols = sorted(lvols, key=lambda x: x.create_dt)
+    data = []
+    for lvol in lvols:
+        if node_id:
+            if lvol.node_id != node_id:
+                continue
+        logger.debug(lvol)
+        cloned_from_snap = ""
+        if lvol.cloned_from_snap:
+            snap = db_controller.get_snapshot_by_id(lvol.cloned_from_snap)
+            cloned_from_snap = snap.snap_uuid
+        data.append({
+            "UUID": lvol.uuid,
+            "BDdev UUID": lvol.lvol_uuid,
+            "BlobID": lvol.blobid,
+            "Name": lvol.lvol_name,
+            "Size": utils.humanbytes(lvol.size),
+            "LVS name": lvol.lvs_name,
+            "BDev": lvol.lvol_bdev,
+            "Node ID": lvol.node_id,
+            "Clone From Snap BDev": cloned_from_snap,
+            "Created At": lvol.create_dt,
+        })
+    if is_json:
+        return json.dumps(data, indent=2)
+    return utils.print_table(data)

--- a/simplyblock_core/controllers/snapshot_controller.py
+++ b/simplyblock_core/controllers/snapshot_controller.py
@@ -1,4 +1,5 @@
 # coding=utf-8
+import json
 import logging as lg
 import math
 import time
@@ -228,23 +229,30 @@ def add(lvol_id, snapshot_name):
     return snap.uuid, False
 
 
-def list(all=False):
+def list(node_id=None):
     snaps = db_controller.get_snapshots()
     data = []
     for snap in snaps:
+        if node_id:
+            if snap.lvol.node_id != node_id:
+                continue
         logger.debug(snap)
-        if snap.deleted is True and all is False:
-            continue
+        clones = []
+        for lvol in db_controller.get_lvols():
+            if lvol.cloned_from_snap and lvol.cloned_from_snap == snap.get_id():
+                clones.append(lvol.get_id())
         data.append({
             "UUID": snap.uuid,
+            "BDdev UUID": snap.snap_uuid,
+            "BlobID": snap.blobid,
             "Name": snap.snap_name,
             "Size": utils.humanbytes(snap.used_size),
-            "ProvSize": utils.humanbytes(snap.size),
             "BDev": snap.snap_bdev,
+            "Node ID": snap.lvol.node_id,
             "LVol ID": snap.lvol.get_id(),
             "Created At": time.strftime("%H:%M:%S, %d/%m/%Y", time.gmtime(snap.created_at)),
-            "Health": snap.health_check,
-            "Status": snap.status,
+            "Base Snapshot": snap.snap_ref_id,
+            "Clones": clones,
         })
     return utils.print_table(data)
 
@@ -598,3 +606,34 @@ def clone(snapshot_id, clone_name, new_size=0, pvc_name=None, pvc_namespace=None
     if new_size:
         lvol_controller.resize_lvol(lvol.get_id(), new_size)
     return lvol.uuid, False
+
+
+def list_by_node(node_id=None, is_json=False):
+    snaps = db_controller.get_snapshots()
+    snaps = sorted(snaps, key=lambda snap: snap.created_at)
+    data = []
+    for snap in snaps:
+        if node_id:
+            if snap.lvol.node_id != node_id:
+                continue
+        logger.debug(snap)
+        clones = []
+        for lvol in db_controller.get_lvols():
+            if lvol.cloned_from_snap and lvol.cloned_from_snap == snap.get_id():
+                clones.append(lvol.get_id())
+        data.append({
+            "UUID": snap.uuid,
+            "BDdev UUID": snap.snap_uuid,
+            "BlobID": snap.blobid,
+            "Name": snap.snap_name,
+            "Size": utils.humanbytes(snap.used_size),
+            "BDev": snap.snap_bdev.split("/")[1],
+            "Node ID": snap.lvol.node_id,
+            "LVol ID": snap.lvol.get_id(),
+            "Created At": time.strftime("%H:%M:%S, %d/%m/%Y", time.gmtime(snap.created_at)),
+            "Base Snapshot": snap.snap_ref_id,
+            "Clones": clones,
+        })
+    if is_json:
+        return json.dumps(data, indent=2)
+    return utils.print_table(data)

--- a/simplyblock_core/rpc_client.py
+++ b/simplyblock_core/rpc_client.py
@@ -1246,8 +1246,8 @@ class RPCClient:
         }
         return self._request("bdev_raid_get_bdevs", params)
 
- 
-
-    
-
-
+    def bdev_lvs_dump_tree(self, lvstore_uuid):
+        params = {
+            "uuid": lvstore_uuid
+        }
+        return self._request("bdev_lvs_dump_tree", params)

--- a/simplyblock_core/storage_node_ops.py
+++ b/simplyblock_core/storage_node_ops.py
@@ -3919,3 +3919,262 @@ def set_value(node_id, attr, value):
             pass
 
     return True
+
+
+def safe_delete_bdev(name, node_id):
+    # On primary node
+    #./ rpc.py bdev_lvol_delete lvsname / name
+    # check the statue code of the following command it must be 0
+    #./ rpc.py bdev_lvol_get_lvol_delete_status lvsname / name
+    # #./ rpc.py bdev_lvol_delete lvsname / name - s
+
+    # On secondary:
+    #./ rpc.py bdev_lvol_delete lvsname / name - s
+
+    db_controller = DBController()
+    primary_node = db_controller.get_storage_node_by_id(node_id)
+    secondary_node = db_controller.get_storage_node_by_id(primary_node.secondary_node_id)
+    bdev_name = f"{primary_node.lvstore}/{name}"
+    logger.info(f"deleting from primary: {bdev_name}")
+    ret, _ = primary_node.rpc_client().delete_lvol(bdev_name)
+    if not ret:
+        logger.error(f"Failed to delete bdev: {bdev_name} from node: {primary_node.get_id()}")
+        return False
+
+    time.sleep(1)
+
+    while True:
+        try:
+            ret = primary_node.rpc_client().bdev_lvol_get_lvol_delete_status(bdev_name)
+        except Exception as e:
+            logger.error(e)
+            return False
+
+        if ret == 1:  # Async lvol deletion is in progress or queued
+            logger.info(f"deletion in progress: {bdev_name}")
+            time.sleep(1)
+
+        elif ret == 0 or ret == 2:  # Lvol may have already been deleted (not found) or delete completed
+            ret, _ = primary_node.rpc_client().delete_lvol(bdev_name, del_async=True)
+            if not ret:
+                logger.error(f"Failed to delete bdev: {bdev_name} from node: {primary_node.get_id()}")
+                return False
+
+            logger.info(f"deletion completed on primary: {bdev_name}")
+            logger.info(f"deleting from secondary: {bdev_name}")
+            ret, _ = secondary_node.rpc_client().delete_lvol(bdev_name, del_async=True)
+            if not ret:
+                logger.error(f"Failed to delete bdev: {bdev_name} from node: {secondary_node.get_id()}")
+                return False
+            else:
+                logger.info(f"deletion completed on secondary: {bdev_name}")
+            return True
+        else:
+            logger.error(f"failed to delete bdev: {bdev_name}, status code: {ret}")
+            return False
+
+
+def auto_repair(node_id, validate_only=False, force_remove_inconsistent=False, force_remove_worng_ref=False):
+    db_controller = DBController()
+    try:
+        snode = db_controller.get_storage_node_by_id(node_id)
+    except KeyError:
+        logger.error("Can not find storage node")
+        return False
+
+    if snode.status != StorageNode.STATUS_ONLINE:
+        logger.error("Storage node is not online")
+        return False
+
+    cluster = db_controller.get_cluster_by_id(snode.cluster_id)
+    if cluster.status not in [Cluster.STATUS_DEGRADED, Cluster.STATUS_ACTIVE]:
+        logger.error("Cluster is not in degraded or active state")
+        return False
+
+    ret = snode.rpc_client().bdev_lvol_get_lvstores(snode.lvstore)
+    if not ret:
+        logger.error("Failed to get LVol info")
+        return False
+    lvs_info = ret[0]
+    if "uuid" in lvs_info and lvs_info['uuid']:
+        lvs_uuid =  lvs_info['uuid']
+    else:
+        logger.error("Failed to get lvstore uuid")
+        return False
+
+    # get the lvstore uuid
+    # ./spdk/scripts/rpc.py -s /mnt/ramdisk/spdk_8080/spdk.sock bdev_lvs_dump_tree  --uuid=1dc5fb34-5ff6-4be6-ab46-eb9f006f5d47 > out_8080.json
+    lvstore_dump = snode.rpc_client().bdev_lvs_dump_tree(lvs_uuid)
+
+    # #sbctl sn list-lvols d4577fa7-545f-4506-b127-7e81fc3a6e34 --json > lvols_8080.json
+    # with open('lvols_8082.json', 'r') as file:
+    #     lvols = json.load(file)
+    lvols = lvol_controller.list_by_node(node_id, is_json=True)
+    if lvols:
+        lvols = json.loads(lvols)
+
+    # #sbctl sn list-snapshots d4577fa7-545f-4506-b127-7e81fc3a6e34 --json > snaps_8080.json
+    # with open('snaps_8082.json', 'r') as file:
+    #     snaps = json.load(file)
+    snaps = snapshot_controller.list_by_node(node_id, is_json=True)
+    if snaps:
+        snaps = json.loads(snaps)
+
+    out_blobid_dict = {}
+    lvols_blobid_dict = {}
+    snaps_blobid_dict = {}
+    diff_list = []
+    diff_lvol_dict = {}
+    diff_snap_dict = {}
+    diff_clone_dict = {}
+    manual_del = {}
+    inconsistent_dict = {}
+    mgmt_diff_dict = {}
+
+
+    for dump in lvstore_dump["lvols"]:
+        out_blobid_dict[dump["blobid"]] = {"uuid": dump["uuid"], "name": dump["name"], "ref": dump["ref"]}
+
+    for lvol in lvols:
+        lvols_blobid_dict[lvol["BlobID"]] = {"uuid": lvol["BDdev UUID"], "name": lvol["BDev"]}
+    for snap in snaps:
+        snaps_blobid_dict[snap["BlobID"]] = {"uuid": snap["BDdev UUID"], "name": snap["BDev"]}
+
+    out_blobid_dict_keys = list(out_blobid_dict.keys())
+    lvols_blobid_dict_keys = list(lvols_blobid_dict.keys())
+    snaps_blobid_dict_keys = list(snaps_blobid_dict.keys())
+
+    for blob in out_blobid_dict_keys:
+        if blob not in (lvols_blobid_dict_keys + snaps_blobid_dict_keys):
+            if out_blobid_dict[blob]["name"] == "hublvol":
+                continue
+            else:
+                # all blob ID in spdk but not in mgmt
+                diff_list.append(blob)
+        else:
+            if blob  in lvols_blobid_dict_keys:
+                if out_blobid_dict[blob]["name"] != lvols_blobid_dict[blob]["name"] or out_blobid_dict[blob]["uuid"] != lvols_blobid_dict[blob]["uuid"]:
+                    inconsistent_dict[blob] = out_blobid_dict[blob]
+                    inconsistent_dict[blob]["type"] = "lvol|clone"
+            if blob in snaps_blobid_dict_keys:
+                if out_blobid_dict[blob]["name"] != snaps_blobid_dict[blob]["name"] or out_blobid_dict[blob]["uuid"] != snaps_blobid_dict[blob]["uuid"]:
+                    inconsistent_dict[blob] = out_blobid_dict[blob]
+                    inconsistent_dict[blob]["type"] = "snap"
+
+
+    for blob in lvols_blobid_dict_keys:
+        if blob not in out_blobid_dict_keys:
+            # All blob in mgmt but not in SPDK
+            mgmt_diff_dict[blob] = lvols_blobid_dict[blob]
+            mgmt_diff_dict[blob]["type"] = "lvol|clone"
+
+    for blob in snaps_blobid_dict_keys:
+        if blob not in out_blobid_dict_keys:
+            # All blob in mgmt but not in SPDK
+            mgmt_diff_dict[blob] = snaps_blobid_dict[blob]
+            mgmt_diff_dict[blob]["type"] = "snap"
+
+    print(f"All diff count is: {len(diff_list)}")
+    print(f"All mgmt diff count is: {len(mgmt_diff_dict.keys())}")
+
+    for blob in diff_list:
+        if "LVOL" in out_blobid_dict[blob]["name"]:
+            if out_blobid_dict[blob]["ref"] !=1:
+                manual_del[blob] = out_blobid_dict[blob]
+            else:
+                diff_lvol_dict[blob] = out_blobid_dict[blob]
+        elif "SNAP" in out_blobid_dict[blob]["name"]:
+            if out_blobid_dict[blob]["ref"] != 2:
+                manual_del[blob] = out_blobid_dict[blob]
+            else:
+                diff_snap_dict[blob] = out_blobid_dict[blob]
+        elif "CLN" in out_blobid_dict[blob]["name"]:
+            if out_blobid_dict[blob]["ref"] !=1:
+                manual_del[blob] = out_blobid_dict[blob]
+            else:
+                diff_clone_dict[blob] = out_blobid_dict[blob]
+
+    if not validate_only:
+        cluster_ops.set_cluster_status(cluster.get_id(), Cluster.STATUS_IN_ACTIVATION)
+        time.sleep(3)
+
+    print(f"safe lvols to be deleted count is {len(diff_lvol_dict.keys())}")
+    print(f"safe snaps to be deleted count is {len(diff_snap_dict.keys())}")
+    print(f"safe clone to be deleted count is {len(diff_clone_dict.keys())}")
+    print(f"manual bdevs to be deleted count is {len(manual_del.keys())}")
+    print(f"inconsistent bdevs to be checked count is {len(inconsistent_dict.keys())}")
+    print("#########################################")
+    print("Safe lvols to be deleted:")
+    for blob, value in diff_lvol_dict.items():
+        print(f"{blob}, {value['uuid']}, {value['name']}, {value['ref']}")
+        if not validate_only:
+            safe_delete_bdev(value['name'], node_id)
+    print("#########################################")
+    print("Safe snaps to be deleted:")
+    for blob, value in diff_snap_dict.items():
+        print(f"{blob}, {value['uuid']}, {value['name']}, {value['ref']}")
+        if not validate_only:
+            safe_delete_bdev(value['name'], node_id)
+    print("#########################################")
+    print("Safe clones to be deleted:")
+    for blob, value in diff_clone_dict.items():
+        print(f"{blob}, {value['uuid']}, {value['name']}, {value['ref']}")
+        if not validate_only:
+            safe_delete_bdev(value['name'], node_id)
+    print("#########################################")
+    print("Manual bdeves to be deleted that have wrong ref number:")
+    for blob, value in manual_del.items():
+        print(f"{blob}, {value['uuid']}, {value['name']}, {value['ref']}")
+        if not validate_only and force_remove_worng_ref:
+            safe_delete_bdev(value['name'], node_id)
+    print("#########################################")
+    print("Inconsistent bdeves to be checked:")
+    for blob, value in inconsistent_dict.items():
+        print(f"{blob}, {value['uuid']}, {value['name']}, {value['ref']}")
+        if not validate_only and force_remove_inconsistent:
+            safe_delete_bdev(value['name'], node_id)
+
+    if not validate_only:
+        cluster_ops.set_cluster_status(cluster.get_id(), Cluster.STATUS_ACTIVE)
+
+    print("#########################################")
+    print("All mgmt bdeves to be checked:")
+    print(mgmt_diff_dict)
+    for blob, value in mgmt_diff_dict.items():
+        print(f"{blob}, {value['uuid']}, {value['name']}, {value['type']}")
+
+    if validate_only:
+        return not(diff_lvol_dict or diff_snap_dict or diff_clone_dict or manual_del or inconsistent_dict or mgmt_diff_dict)
+
+    return True
+
+
+def lvs_dump_tree(node_id):
+    db_controller = DBController()
+    try:
+        snode = db_controller.get_storage_node_by_id(node_id)
+    except KeyError:
+        logger.error("Can not find storage node")
+        return False
+
+    if snode.status != StorageNode.STATUS_ONLINE:
+        logger.error("Storage node is not online")
+        return False
+
+    ret = snode.rpc_client().bdev_lvol_get_lvstores(snode.lvstore)
+    if not ret:
+        logger.error("Failed to get LVol info")
+        return False
+    lvs_info = ret[0]
+    if "uuid" in lvs_info and lvs_info['uuid']:
+        lvs_uuid =  lvs_info['uuid']
+    else:
+        logger.error("Failed to get lvstore uuid")
+        return False
+
+    ret = snode.rpc_client().bdev_lvs_dump_tree(lvs_uuid)
+    if not ret:
+        logger.error("Failed to dump lvstore tree")
+        return False
+
+    return json.dumps(ret, indent=2)

--- a/simplyblock_web/api/internal/storage_node/docker.py
+++ b/simplyblock_web/api/internal/storage_node/docker.py
@@ -73,7 +73,7 @@ def get_amazon_cloud_info():
         import ec2_metadata
         import requests
         session = requests.session()
-        data = ec2_metadata.EC2Metadata(session=session).instance_identity_document
+        data = ec2_metadata.EC2Metadata(session=session).instance_identity_document # type: ignore[call-arg]
         return {
             "id": data["instanceId"],
             "type": data["instanceType"],


### PR DESCRIPTION
* Add 'list-snapshots' command to CLI for snapshot retrieval by node ID

* Add 'list-lvols' command to CLI for listing logical volumes by node ID

* Fix sorting key in list_by_node function to use create_dt instead of created_at

* Update lvol_controller to include snapshot UUID for cloned volumes

* Add 'repair-lvstore' command to CLI for repairing inconsistencies in lvstore

* fix 1

* fix 2

* Adds impl for safe_delete_bdev

* fix 1

* fix 2

* fix 3

* Adds implementation for lvs-dump-tree command in developer mode

* fix linter