### PR TITLE
use a diff variable name conv_new_size

### DIFF
--- a/simplyblock_cli/cli-reference.yaml
+++ b/simplyblock_cli/cli-reference.yaml
@@ -1399,15 +1399,6 @@ commands:
             help: "Name"
             dest: name
             type: str
-      - name: add-replication
-        help: Assigns the snapshot replication target cluster
-        arguments:
-          - name: "cluster_id"
-            help: "Cluster id"
-            dest: cluster_id
-            type: str
-            completer: _completer_get_cluster_list
-
   - name: "volume"
     help: "Logical volume commands"
     aliases:


### PR DESCRIPTION
Fixed clone snapshot resize Error
```
2026-02-23 05:53:39,897: 140302958458560: INFO: {"cluster_id": "9a7d7cd7-37ed-421c-8b06-cb961ccada4f", "event": "STATUS_CHANGE", "object_name": "SnapShot", "message": "Snapshot cloned: 9d8c7fb5-e4c9-4f04-84bc-3a5f732a5a1f clone id: 19d510be-14ea-4c2c-be3e-65ad5bbd3ca9", "caused_by": "cli"}
2026-02-23 05:53:39,901: 140302958458560: ERROR: New size 1.0 GiB must be higher than the original size 1.0 GiB
```