### PR TITLE
fix 500 error on cluster delete

### DIFF
--- a/simplyblock_web/api/v2/cluster.py
+++ b/simplyblock_web/api/v2/cluster.py
@@ -95,7 +95,10 @@ def update(cluster: Cluster, parameters: UpdatableClusterParameters):
 
 @instance_api.delete('/', name='clusters:delete', status_code=204, responses={204: {"content": None}})
 def delete(cluster: Cluster) -> Response:
-    cluster_ops.delete_cluster(cluster.get_id())
+    try:
+        cluster_ops.delete_cluster(cluster.get_id())
+    except ValueError as e:
+        raise HTTPException(409, str(e)) from e
     return Response(status_code=204)
 
 


### PR DESCRIPTION
At the moment, we get 500 on cluster delete. 

```
INFO:     10.42.0.15:37024 - "DELETE /api/v2/clusters/d5f00df2-01c8-4716-bcdc-32418307f2e2/ HTTP/1.1" 500 Internal Server Error
  File "/usr/local/lib/python3.9/site-packages/anyio/to_thread.py", line 63, in run_sync
    return await get_async_backend().run_sync_in_worker_thread(
  File "/usr/local/lib/python3.9/site-packages/anyio/_backends/_asyncio.py", line 2502, in run_sync_in_worker_thread
    return await future
  File "/usr/local/lib/python3.9/site-packages/anyio/_backends/_asyncio.py", line 986, in run
    result = context.run(func, *args)
  File "/usr/local/lib/python3.9/site-packages/simplyblock_web/api/v2/cluster.py", line 121, in delete
    cluster_ops.delete_cluster(cluster.get_id())
  File "/usr/local/lib/python3.9/site-packages/simplyblock_core/cluster_ops.py", line 1473, in delete_cluster
    raise ValueError("Can only remove Empty cluster, Storage nodes found")
ValueError: Can only remove Empty cluster, Storage nodes found
```

Fixing this by removing a 409 Error with the same error message.

```
INFO:     10.42.0.15:51782 - "DELETE /api/v2/clusters/d5f00df2-01c8-4716-bcdc-32418307f2e2/ HTTP/1.1" 409 Conflict
```