### PR TITLE
New flag --enable-journal-device

### DIFF
--- a/simplyblock_cli/cli-reference.yaml
+++ b/simplyblock_cli/cli-reference.yaml
@@ -165,7 +165,6 @@ commands:
               1: auto-create small partitions for journal on nvme devices. 0: use a separate (the smallest) nvme device of the node for journal. The journal needs a maximum of 3% of total available raw disk space."
             dest: partitions
             type: int
-            default: 1
             choices:
               - 0
               - 1

--- a/simplyblock_cli/cli-reference.yaml
+++ b/simplyblock_cli/cli-reference.yaml
@@ -160,16 +160,20 @@ commands:
             type: str
           - name: "--journal-partition"
             help: |
-              **Deprecated:** use `--use-separate-journal-device` instead.
+              **Deprecated:** use `--enable-journal-device` instead.
               
               1: auto-create small partitions for journal on nvme devices. 0: use a separate (the smallest) nvme device of the node for journal. The journal needs a maximum of 3% of total available raw disk space."
             dest: partitions
             type: int
             default: 1
-          - name: "--use-separate-journal-device"
-            help: "Use a separate (the smallest) NVMe device of the node for the journal. Otherwise, the journal uses a maximum of 3% of total available raw disk space across all NVMe devices."
-            dest: use_separate_journal_device
+            choices:
+              - 0
+              - 1
+          - name: "--enable-journal-device"
+            help: "Enables the use of a separate (the smallest) NVMe device of the node for the journal. Otherwise, the journal uses a maximum of 3% of total available raw disk space across all NVMe devices."
+            dest: enable_journal_device
             type: bool
+            default: false
             action: store_true
           - name: "--format-4k"
             help: "Force format nvme devices with 4K"

--- a/simplyblock_cli/cli-reference.yaml
+++ b/simplyblock_cli/cli-reference.yaml
@@ -160,7 +160,7 @@ commands:
             type: str
           - name: "--journal-partition"
             help: |
-              **Deprecated:** use `--enable-separate-journal-device` instead.
+              **Deprecated:** use `--use-separate-journal-device` instead.
               
               1: auto-create small partitions for journal on nvme devices. 0: use a separate (the smallest) nvme device of the node for journal. The journal needs a maximum of 3% of total available raw disk space."
             dest: partitions

--- a/simplyblock_cli/cli-reference.yaml
+++ b/simplyblock_cli/cli-reference.yaml
@@ -159,10 +159,18 @@ commands:
             dest: ifname
             type: str
           - name: "--journal-partition"
-            help: "1: auto-create small partitions for journal on nvme devices. 0: use a separate (the smallest) nvme device of the node for journal. The journal needs a maximum of 3 percent of total available raw disk space."
+            help: |
+              **Deprecated:** use `--enable-separate-journal-device` instead.
+              
+              1: auto-create small partitions for journal on nvme devices. 0: use a separate (the smallest) nvme device of the node for journal. The journal needs a maximum of 3% of total available raw disk space."
             dest: partitions
             type: int
             default: 1
+          - name: "--use-separate-journal-device"
+            help: "Use a separate (the smallest) NVMe device of the node for the journal. Otherwise, the journal uses a maximum of 3% of total available raw disk space across all NVMe devices."
+            dest: use_separate_journal_device
+            type: bool
+            action: store_true
           - name: "--format-4k"
             help: "Force format nvme devices with 4K"
             dest: format_4k

--- a/simplyblock_cli/cli.py
+++ b/simplyblock_cli/cli.py
@@ -122,8 +122,8 @@ class CLIWrapper(CLIWrapperBase):
         subcommand.add_argument('cluster_id', help='Cluster id', type=str)
         subcommand.add_argument('node_addr', help='Address of storage node api to add, like <node-ip>:5000', type=str)
         subcommand.add_argument('ifname', help='Management interface name', type=str)
-        argument = subcommand.add_argument('--journal-partition', help='**Deprecated:** use `--use-separate-journal-device` instead.1: auto-create small partitions for journal on nvme devices. 0: use a separate (the smallest) nvme device of the node for journal. The journal needs a maximum of 3%% of total available raw disk space."', type=int, default=1, dest='partitions')
-        argument = subcommand.add_argument('--use-separate-journal-device', help='Use a separate (the smallest) NVMe device of the node for the journal. Otherwise, the journal uses a maximum of 3%% of total available raw disk space across all NVMe devices.', dest='use_separate_journal_device', action='store_true')
+        argument = subcommand.add_argument('--journal-partition', help='**Deprecated:** use `--enable-journal-device` instead.1: auto-create small partitions for journal on nvme devices. 0: use a separate (the smallest) nvme device of the node for journal. The journal needs a maximum of 3%% of total available raw disk space."', type=int, default=1, dest='partitions', choices=[0,1,])
+        argument = subcommand.add_argument('--enable-journal-device', help='Enables the use of a separate (the smallest) NVMe device of the node for the journal. Otherwise, the journal uses a maximum of 3%% of total available raw disk space across all NVMe devices.', default=False, dest='enable_journal_device', action='store_true')
         argument = subcommand.add_argument('--format-4k', help='Force format nvme devices with 4K', dest='format_4k', action='store_true')
         if self.developer_mode:
             argument = subcommand.add_argument('--jm-percent', help='Number in percent to use for JM from each device', type=int, default=3, dest='jm_percent')

--- a/simplyblock_cli/cli.py
+++ b/simplyblock_cli/cli.py
@@ -122,7 +122,7 @@ class CLIWrapper(CLIWrapperBase):
         subcommand.add_argument('cluster_id', help='Cluster id', type=str)
         subcommand.add_argument('node_addr', help='Address of storage node api to add, like <node-ip>:5000', type=str)
         subcommand.add_argument('ifname', help='Management interface name', type=str)
-        argument = subcommand.add_argument('--journal-partition', help='**Deprecated:** use `--enable-separate-journal-device` instead.1: auto-create small partitions for journal on nvme devices. 0: use a separate (the smallest) nvme device of the node for journal. The journal needs a maximum of 3%% of total available raw disk space."', type=int, default=1, dest='partitions')
+        argument = subcommand.add_argument('--journal-partition', help='**Deprecated:** use `--use-separate-journal-device` instead.1: auto-create small partitions for journal on nvme devices. 0: use a separate (the smallest) nvme device of the node for journal. The journal needs a maximum of 3%% of total available raw disk space."', type=int, default=1, dest='partitions')
         argument = subcommand.add_argument('--use-separate-journal-device', help='Use a separate (the smallest) NVMe device of the node for the journal. Otherwise, the journal uses a maximum of 3%% of total available raw disk space across all NVMe devices.', dest='use_separate_journal_device', action='store_true')
         argument = subcommand.add_argument('--format-4k', help='Force format nvme devices with 4K', dest='format_4k', action='store_true')
         if self.developer_mode:

--- a/simplyblock_cli/cli.py
+++ b/simplyblock_cli/cli.py
@@ -122,7 +122,8 @@ class CLIWrapper(CLIWrapperBase):
         subcommand.add_argument('cluster_id', help='Cluster id', type=str)
         subcommand.add_argument('node_addr', help='Address of storage node api to add, like <node-ip>:5000', type=str)
         subcommand.add_argument('ifname', help='Management interface name', type=str)
-        argument = subcommand.add_argument('--journal-partition', help='1: auto-create small partitions for journal on nvme devices. 0: use a separate (the smallest) nvme device of the node for journal. The journal needs a maximum of 3 percent of total available raw disk space.', type=int, default=1, dest='partitions')
+        argument = subcommand.add_argument('--journal-partition', help='**Deprecated:** use `--enable-separate-journal-device` instead.1: auto-create small partitions for journal on nvme devices. 0: use a separate (the smallest) nvme device of the node for journal. The journal needs a maximum of 3%% of total available raw disk space."', type=int, default=1, dest='partitions')
+        argument = subcommand.add_argument('--use-separate-journal-device', help='Use a separate (the smallest) NVMe device of the node for the journal. Otherwise, the journal uses a maximum of 3%% of total available raw disk space across all NVMe devices.', dest='use_separate_journal_device', action='store_true')
         argument = subcommand.add_argument('--format-4k', help='Force format nvme devices with 4K', dest='format_4k', action='store_true')
         if self.developer_mode:
             argument = subcommand.add_argument('--jm-percent', help='Number in percent to use for JM from each device', type=int, default=3, dest='jm_percent')

--- a/simplyblock_cli/cli.py
+++ b/simplyblock_cli/cli.py
@@ -122,7 +122,7 @@ class CLIWrapper(CLIWrapperBase):
         subcommand.add_argument('cluster_id', help='Cluster id', type=str)
         subcommand.add_argument('node_addr', help='Address of storage node api to add, like <node-ip>:5000', type=str)
         subcommand.add_argument('ifname', help='Management interface name', type=str)
-        argument = subcommand.add_argument('--journal-partition', help='**Deprecated:** use `--enable-journal-device` instead.1: auto-create small partitions for journal on nvme devices. 0: use a separate (the smallest) nvme device of the node for journal. The journal needs a maximum of 3%% of total available raw disk space."', type=int, default=1, dest='partitions', choices=[0,1,])
+        argument = subcommand.add_argument('--journal-partition', help='**Deprecated:** use `--enable-journal-device` instead.1: auto-create small partitions for journal on nvme devices. 0: use a separate (the smallest) nvme device of the node for journal. The journal needs a maximum of 3%% of total available raw disk space."', type=int, dest='partitions', choices=[0,1,])
         argument = subcommand.add_argument('--enable-journal-device', help='Enables the use of a separate (the smallest) NVMe device of the node for the journal. Otherwise, the journal uses a maximum of 3%% of total available raw disk space across all NVMe devices.', default=False, dest='enable_journal_device', action='store_true')
         argument = subcommand.add_argument('--format-4k', help='Force format nvme devices with 4K', dest='format_4k', action='store_true')
         if self.developer_mode:

--- a/simplyblock_cli/clibase.py
+++ b/simplyblock_cli/clibase.py
@@ -153,7 +153,6 @@ class CLIWrapperBase:
 
         small_bufsize = args.small_bufsize
         large_bufsize = args.large_bufsize
-        num_partitions_per_dev = args.partitions
         jm_percent = args.jm_percent
 
         max_snap = args.max_snap
@@ -162,6 +161,13 @@ class CLIWrapperBase:
         namespace = args.namespace
         ha_jm_count = args.ha_jm_count
         format_4k = args.format_4k
+
+        if args.use_separate_journal_device:
+            num_partitions_per_dev = 0
+        else:
+            # Deprecated, but still supported for backward compatibility.
+            num_partitions_per_dev = args.partitions
+
         try:
             out = storage_ops.add_node(
                 cluster_id=cluster_id,

--- a/simplyblock_cli/clibase.py
+++ b/simplyblock_cli/clibase.py
@@ -166,12 +166,12 @@ class CLIWrapperBase:
             num_partitions_per_dev = 0
         else:
             # Deprecated but still supported for backward compatibility.
-            print("WARNING: --journal-partition is deprecated, use --enable-journal-device instead")
             if args.partitions is None:
                 num_partitions_per_dev = 1
             elif args.partitions < 0 or args.partitions > 1:
                 self.parser.error("partitions must be either 0 or 1")
             else:
+                print("WARNING: --journal-partition is deprecated, use --enable-journal-device instead")
                 num_partitions_per_dev = args.partitions
 
         try:

--- a/simplyblock_cli/clibase.py
+++ b/simplyblock_cli/clibase.py
@@ -162,11 +162,17 @@ class CLIWrapperBase:
         ha_jm_count = args.ha_jm_count
         format_4k = args.format_4k
 
-        if args.use_separate_journal_device:
+        if args.enable_journal_device:
             num_partitions_per_dev = 0
         else:
-            # Deprecated, but still supported for backward compatibility.
-            num_partitions_per_dev = args.partitions
+            # Deprecated but still supported for backward compatibility.
+            print("WARNING: --journal-partition is deprecated, use --enable-journal-device instead")
+            if args.partitions is None:
+                num_partitions_per_dev = 1
+            elif args.partitions < 0 or args.partitions > 1:
+                self.parser.error("partitions must be either 0 or 1")
+            else:
+                num_partitions_per_dev = args.partitions
 
         try:
             out = storage_ops.add_node(


### PR DESCRIPTION
This PR introduces --enable-journal-device and deprecated --journal-partition for better clarity of its usage. Since the values always come down to 0 or 1, a boolean flag disabling default behavior is easier to understand.