### PR TITLE
raise duplicate cluster name as 409 conflict

### DIFF
--- a/simplyblock_web/api/v2/cluster.py
+++ b/simplyblock_web/api/v2/cluster.py
@@ -87,7 +87,10 @@ def list() -> List[ClusterDTO]:
 
 @api.post('/', name='clusters:create', status_code=201, responses={201: {"content": None}})
 def add(parameters: ClusterParams):
-    cluster_id_or_false = cluster_ops.add_cluster(**parameters.model_dump(exclude_none=True))
+    try:
+        cluster_id_or_false = cluster_ops.add_cluster(**parameters.model_dump(exclude_none=True))
+    except ValueError as e:
+        raise HTTPException(status_code=409, detail=str(e))
     if not cluster_id_or_false:
         raise ValueError('Failed to create cluster')
 


### PR DESCRIPTION
At the moment, duplicate cluster name validation is raised as 500 error.

```
INFO:     10.42.0.14:56048 - "POST /api/v2/clusters/ HTTP/1.1" 500 Internal Server Error
ERROR:    Exception in ASGI application
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/uvicorn/protocols/http/h11_impl.py", line 409, in run_asgi
    result = await app(  # type: ignore[func-returns-value]
  File "/usr/local/lib/python3.9/site-packages/uvicorn/middleware/proxy_headers.py", line 60, in __call__
    return await self.app(scope, receive, send)
  File "/usr/local/lib/python3.9/site-packages/fastapi/applications.py", line 1138, in __call__
    await super().__call__(scope, receive, send)
  File "/usr/local/lib/python3.9/site-packages/starlette/applications.py", line 113, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/usr/local/lib/python3.9/site-packages/starlette/middleware/errors.py", line 186, in __call__
    raise exc
  File "/usr/local/lib/python3.9/site-packages/starlette/middleware/errors.py", line 164, in __call__
    await self.app(scope, receive, _send)
  File "/usr/local/lib/python3.9/site-packages/starlette/middleware/exceptions.py", line 63, in __call__
    await wrap_app_handling_exceptions(self.app, conn)(scope, receive, send)
  File "/usr/local/lib/python3.9/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
    raise exc
  File "/usr/local/lib/python3.9/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app
    await app(scope, receive, sender)
  File "/usr/local/lib/python3.9/site-packages/fastapi/middleware/asyncexitstack.py", line 18, in __call__
    await self.app(scope, receive, send)
  File "/usr/local/lib/python3.9/site-packages/starlette/routing.py", line 716, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/usr/local/lib/python3.9/site-packages/starlette/routing.py", line 736, in app
    await route.handle(scope, receive, send)
  File "/usr/local/lib/python3.9/site-packages/starlette/routing.py", line 290, in handle
    await self.app(scope, receive, send)
  File "/usr/local/lib/python3.9/site-packages/fastapi/routing.py", line 121, in app
    await wrap_app_handling_exceptions(app, request)(scope, receive, send)
  File "/usr/local/lib/python3.9/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
    raise exc
  File "/usr/local/lib/python3.9/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app
    await app(scope, receive, sender)
  File "/usr/local/lib/python3.9/site-packages/fastapi/routing.py", line 107, in app
    response = await f(request)
  File "/usr/local/lib/python3.9/site-packages/fastapi/routing.py", line 426, in app
    raw_response = await run_endpoint_function(
  File "/usr/local/lib/python3.9/site-packages/fastapi/routing.py", line 316, in run_endpoint_function
    return await run_in_threadpool(dependant.call, **values)
  File "/usr/local/lib/python3.9/site-packages/starlette/concurrency.py", line 38, in run_in_threadpool
    return await anyio.to_thread.run_sync(func)
  File "/usr/local/lib/python3.9/site-packages/anyio/to_thread.py", line 63, in run_sync
    return await get_async_backend().run_sync_in_worker_thread(
  File "/usr/local/lib/python3.9/site-packages/anyio/_backends/_asyncio.py", line 2502, in run_sync_in_worker_thread
    return await future
  File "/usr/local/lib/python3.9/site-packages/anyio/_backends/_asyncio.py", line 986, in run
    result = context.run(func, *args)
  File "/usr/local/lib/python3.9/site-packages/simplyblock_web/api/v2/cluster.py", line 90, in add
    cluster_id_or_false = cluster_ops.add_cluster(**parameters.model_dump(exclude_none=True))
  File "/usr/local/lib/python3.9/site-packages/simplyblock_core/cluster_ops.py", line 486, in add_cluster
    raise ValueError(f"A cluster with the name '{name}' already exists")
ValueError: A cluster with the name 'simplyblock-cluster' already exists
```

This fix catches the ValueError and returns a 409 Conflict with the message 
```
A cluster with the name 'simplyblock-cluster' already exists
```
