### PR TITLE
user ClusterFirstWithHostNet for spdk pod

### DIFF
--- a/simplyblock_web/static/deploy_spdk.yaml
+++ b/simplyblock_web/static/deploy_spdk.yaml
@@ -13,6 +13,7 @@ spec:
         app: spdk-app
     spec:
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       volumes:
         - name: socket-dir
           emptyDir:

--- a/simplyblock_web/templates/storage_deploy_spdk.yaml.j2
+++ b/simplyblock_web/templates/storage_deploy_spdk.yaml.j2
@@ -16,6 +16,7 @@ spec:
   nodeSelector:
     kubernetes.io/hostname: {{ HOSTNAME }}
   hostNetwork: true
+  dnsPolicy: ClusterFirstWithHostNet
   tolerations:
     - effect: NoSchedule
       operator: Exists


### PR DESCRIPTION
Currently SPDK pods runs with `hostNetwork` set to `true`. Due to this, it cannot resolve the service DNS like for example:
```
simplyblock-webappapi.simplyblock.svc.cluster.local
```

This PR allows both pods to use both Cluster DNS and the Host networks.


### testing

```
kubectl get pod snode-spdk-pod-8080-8bf499 -oyaml | grep dnsPolicy
  dnsPolicy: ClusterFirstWithHostNet
```

and the cluster is also created
```
sbctl sn list
+--------------------------------------+-----------------------------+---------------+-----+-------+--------+--------+---------+-----+----------+--------+--------+-------+-------+-------------------------------------------------+--------------------------------------+
| UUID                                 | Hostname                    | Management IP | Dev | LVols | Status | Health | Up time | CPU | MEM      | SPDK P | LVOL P | DEV P | HUB P | LVS Ports                                       | Secondary node ID                    |
+--------------------------------------+-----------------------------+---------------+-----+-------+--------+--------+---------+-----+----------+--------+--------+-------+-------+-------------------------------------------------+--------------------------------------+
| 204ccc01-3f07-4dc3-a6c5-2496556c22ec | storage-node-1_8080 | 10.0.2.3      | 1/1 | 0     | online | True   | 35m 1s  | 10  | 10.3 GiB | 8080   | 4420   | 4421  | 4424  | LVS_5846(L:4420,H:4424) LVS_5921(L:4427,H:4428) | 65a7b2bb-5e09-49de-8dee-75770c125891 |
| 65a7b2bb-5e09-49de-8dee-75770c125891 | storage-node-2_8081 | 10.0.2.6      | 1/1 | 0     | online | True   | 30m 33s | 10  | 10.3 GiB | 8081   | 4425   | 4422  | 4426  | LVS_5846(L:4420,H:4424) LVS_9938(L:4425,H:4426) | 36b69ff6-5407-4ec2-b5b5-25a504361795 |
| 36b69ff6-5407-4ec2-b5b5-25a504361795 | storage-node-3_8082 | 10.0.2.5      | 1/1 | 0     | online | True   | 26m 3s  | 10  | 10.3 GiB | 8082   | 4427   | 4423  | 4428  | LVS_9938(L:4425,H:4426) LVS_5921(L:4427,H:4428) | 204ccc01-3f07-4dc3-a6c5-2496556c22ec |
+--------------------------------------+-----------------------------+---------------+-----+-------+--------+--------+---------+-----+----------+--------+--------+-------+-------+-------------------------------------------------+--------------------------------------+
```

resolv.conf is updated
```
kubectl exec -it snode-spdk-pod-8082-8bf499 -- cat /etc/resolv.conf 
Defaulted container "spdk-container" out of: spdk-container, spdk-proxy-container
search default.svc.cluster.local svc.cluster.local cluster.local us-east1-d.c.<project-id>.internal c.<project-id>.internal google.internal
nameserver 10.43.0.10
options ndots:5
```

and SPDK pod is able to resolve too. 

```
kubectl exec snode-spdk-pod-8080-8bf499 -c spdk-proxy-container -- curl -v http://minio.default.svc.cluster.local:9000/minio/health/live
```
