### PR TITLE
Conditionally run TLS-based servers

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,3 +26,4 @@ fastapi
 uvicorn
 prometheus_api_client
 paramiko
+pydantic-settings

--- a/simplyblock_core/services/spdk_http_proxy_server.py
+++ b/simplyblock_core/services/spdk_http_proxy_server.py
@@ -5,6 +5,7 @@ import json
 import logging
 import os
 import socket
+import ssl
 import sys
 import threading
 import time
@@ -12,6 +13,8 @@ import time
 from http.server import HTTPServer
 from http.server import ThreadingHTTPServer
 from http.server import BaseHTTPRequestHandler
+
+from simplyblock_core.settings import Settings
 
 
 logger_handler = logging.StreamHandler(stream=sys.stdout)
@@ -254,6 +257,11 @@ def run_server(host, port, user, password, is_threading_enabled=False):
     try:
         ServerHandler.key = key
         httpd = (ThreadingHTTPServer if is_threading_enabled else HTTPServer)((host, port), ServerHandler)
+        settings = Settings()
+        if settings.tls_enabled:
+            context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+            context.load_cert_chain(settings.tls_certificate, settings.tls_key)
+            httpd.socket = context.wrap_socket(httpd.socket, server_side=True)
         httpd.timeout = TIMEOUT
         logger.info('Started RPC http proxy server')
         httpd.serve_forever()

--- a/simplyblock_core/settings.py
+++ b/simplyblock_core/settings.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    model_config = SettingsConfigDict(env_prefix="sb_", case_sensitive=False)
+
+    tls_certificate: Path = Path("/etc/simplyblock/tls/tls.crt")
+    tls_key: Path = Path("/etc/simplyblock/tls/tls.key")
+
+    @property
+    def tls_enabled(self) -> bool:
+        return self.tls_certificate.is_file() and self.tls_key.is_file()

--- a/simplyblock_web/api/v2/storage_node.py
+++ b/simplyblock_web/api/v2/storage_node.py
@@ -33,7 +33,7 @@ def list(cluster: Cluster) -> List[StorageNodeDTO]:
 
 
 class StorageNodeParams(BaseModel):
-    node_address: Annotated[str, Field(web_utils.IP_PATTERN)]
+    node_address: Annotated[str, Field(pattern=web_utils.IP_PATTERN)]
     interface_name: str
     max_snapshots: Optional[int] = Field(500)
     ha_jm: Optional[bool] = Field(True)
@@ -232,7 +232,7 @@ def shutdown(cluster: Cluster, storage_node: StorageNode, force: bool = False) -
 class _RestartParams(BaseModel):
     force: bool = False
     reattach_volume: bool = False
-    node_address: Optional[Annotated[str, Field(web_utils.IP_PATTERN)]] = None
+    node_address: Optional[Annotated[str, Field(pattern=web_utils.IP_PATTERN)]] = None
 
 
 @instance_api.post('/start', name='clusters:storage-nodes:start', status_code=202, responses={202: {"content": None}})  # Same as restart for now

--- a/simplyblock_web/app.py
+++ b/simplyblock_web/app.py
@@ -14,6 +14,7 @@ from uvicorn.config import Config
 
 from simplyblock_web.api import public, v1
 from simplyblock_core import constants, utils as core_utils
+from simplyblock_core.settings import Settings
 
 logger = core_utils.get_logger(__name__)
 logger.setLevel(constants.LOG_WEB_LEVEL)
@@ -83,6 +84,7 @@ def main() -> None:
     """
     Main entry point for running the FastAPI application.
     """
+    settings = Settings()
     config: Config = uvicorn.Config(
         app=app,
         host='0.0.0.0',
@@ -90,7 +92,9 @@ def main() -> None:
         log_level='debug',
         access_log=False,
         proxy_headers=True,
-        forwarded_allow_ips='192.168.1.0/24'
+        forwarded_allow_ips='192.168.1.0/24',
+        ssl_certfile=settings.tls_certificate if settings.tls_enabled else None,
+        ssl_keyfile=settings.tls_key if settings.tls_enabled else None,
     )
     server: uvicorn.Server = uvicorn.Server(config)
     server.run()

--- a/simplyblock_web/node_webapp.py
+++ b/simplyblock_web/node_webapp.py
@@ -6,6 +6,7 @@ import argparse
 from flask_openapi3 import OpenAPI
 
 from simplyblock_core import constants
+from simplyblock_core.settings import Settings
 from simplyblock_web import utils
 from simplyblock_web.api import internal as internal_api
 
@@ -42,4 +43,6 @@ if __name__ == '__main__':
     if mode == "storage_node_k8s":
         app.register_api(internal_api.storage_node.kubernetes.api)
 
-    app.run(host='0.0.0.0', debug=constants.LOG_WEB_DEBUG)
+    settings = Settings()
+    ssl_ctx = (settings.tls_certificate, settings.tls_key) if settings.tls_enabled else None
+    app.run(host='0.0.0.0', debug=constants.LOG_WEB_DEBUG, ssl_context=ssl_ctx)


### PR DESCRIPTION
This adds a setting to provide TLS certificate and key. When these are present, API, SNodeAPI, and SPDK Proxy run TLS-based servers. Otherwise, regular HTTP servers are used, so this is a non-breaking change.

Tested by confirming that all three adapted services respond to HTTP requests when TLS configuration is absent, and to HTTPS when it is present.

The `IP_PATTERN` change is unrelated. I noticed it when testing and decided to simply include the fix here.