### PR TITLE
Fix misleading --data-nics help text (multiple NICs supported)

### DIFF
--- a/simplyblock_cli/cli-reference.yaml
+++ b/simplyblock_cli/cli-reference.yaml
@@ -191,9 +191,9 @@ commands:
             default: 3
             private: true
           - name: "--data-nics"
-            help: "The storage network interface names. Currently, one interface is supported."
+            help: "Storage network interface names. Pass one or more space-separated names; multiple NICs enable multipath."
             description: >
-              Storage network interface names, e.g. eth0,eth1
+              Storage network interface names, space-separated, e.g. `eth0 eth1`
             dest: data_nics
             type: str
             nargs: "+"

--- a/simplyblock_cli/cli.py
+++ b/simplyblock_cli/cli.py
@@ -128,7 +128,7 @@ class CLIWrapper(CLIWrapperBase):
         argument = subcommand.add_argument('--format-4k', help='Force format nvme devices with 4K.', dest='format_4k', action='store_true')
         if self.developer_mode:
             argument = subcommand.add_argument('--jm-percent', help='Number in percent to use for JM from each device. Default: `3`.', type=int, default=3, dest='jm_percent')
-        argument = subcommand.add_argument('--data-nics', help='The storage network interface names. Currently, one interface is supported.', type=str, dest='data_nics', nargs='+')
+        argument = subcommand.add_argument('--data-nics', help='Storage network interface names. Pass one or more space-separated names; multiple NICs enable multipath.', type=str, dest='data_nics', nargs='+')
         if self.developer_mode:
             argument = subcommand.add_argument('--size-of-device', help='The size of device per storage node.', type=str, dest='partition_size')
         if self.developer_mode:


### PR DESCRIPTION
## Summary
- `--data-nics` is defined with `nargs='+'` and `storage_node_ops.add_node` iterates the full list to build per-NIC `IFace` objects (with explicit `len(data_nics) > 1` multipath branches), so the *"Currently, one interface is supported."* help string is wrong.
- The YAML `description` example `eth0,eth1` is actively misleading — argparse splits on whitespace, so a comma-joined value becomes a single bogus token and fails silently downstream (the storage node never registers).
- Updates the help and description to reflect actual behavior; regenerates `cli.py` from `cli-reference.yaml` via `simplyblock_cli/scripts/generate.sh`.

## Test plan
- [ ] `sbctl sn add-node --help` shows the new help text
- [ ] `sbctl sn add-node <cluster> <ip>:5000 eth0 --data-nics eth1 eth2` still registers a node with two data NICs (existing multipath path)
- [ ] No other diffs in `cli.py` from the regeneration

🤖 Generated with [Claude Code](https://claude.com/claude-code)