### PR TITLE
Log API request execution duration

### DIFF
--- a/simplyblock_web/app.py
+++ b/simplyblock_web/app.py
@@ -2,10 +2,13 @@
 # encoding: utf-8
 
 import logging
+import sys
+import time
 
 from fastapi import FastAPI, Request
 from fastapi.middleware.wsgi import WSGIMiddleware
 from fastapi.responses import RedirectResponse
+from starlette.middleware.base import BaseHTTPMiddleware
 import uvicorn
 from uvicorn.config import Config
 
@@ -16,11 +19,38 @@ logger = core_utils.get_logger(__name__)
 logger.setLevel(constants.LOG_WEB_LEVEL)
 logging.getLogger().setLevel(constants.LOG_WEB_LEVEL)
 
+access_logger = logging.getLogger('simplyblock_web.access')
+_access_handler = logging.StreamHandler(stream=sys.stdout)
+_access_handler.setFormatter(logging.Formatter(
+    '%(asctime)s: %(thread)d: %(levelname)s: %(message)s'
+    ' %(status_code)s %(duration_ms).2fms'
+))
+access_logger.addHandler(_access_handler)
+access_logger.propagate = False
+
 
 core_utils.init_sentry_sdk()
 
 
+class AccessLogMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next):
+        start = time.monotonic()
+        response = await call_next(request)
+        duration_ms = (time.monotonic() - start) * 1000
+        access_logger.info(
+            '%s %s',
+            request.method,
+            request.url.path,
+            extra={
+                'status_code': response.status_code,
+                'duration_ms': duration_ms,
+            },
+        )
+        return response
+
+
 app: FastAPI = FastAPI()
+app.add_middleware(AccessLogMiddleware)
 app.include_router(public, prefix='/api')
 app.mount('/api/v1', WSGIMiddleware(v1.api))  # For some reason this fails if done in `api/__init__.py`
 
@@ -58,6 +88,7 @@ def main() -> None:
         host='0.0.0.0',
         port=5000,
         log_level='debug',
+        access_log=False,
         proxy_headers=True,
         forwarded_allow_ips='192.168.1.0/24'
     )


### PR DESCRIPTION
This disables the uvicorn-builtin access log and adds a middleware instead to log execution duration of each request.