### PR TITLE
Introduce SNodeClient helper

### DIFF
--- a/simplyblock_cli/clibase.py
+++ b/simplyblock_cli/clibase.py
@@ -240,7 +240,7 @@ class CLIWrapperBase:
             return storage_ops.restart_storage_node(
                 node_id, max_lvol, max_snap, max_prov,
                 spdk_image, spdk_debug,
-                small_bufsize, large_bufsize, node_ip=args.node_ip, reattach_volume=reattach_volume, force=args.force,
+                small_bufsize, large_bufsize, node_address=args.node_ip, reattach_volume=reattach_volume, force=args.force,
                 new_ssd_pcie=ssd_pcie, force_lvol_recreate=args.force_lvol_recreate, spdk_proxy_image=getattr(args, 'spdk_proxy_image', None))
         except Exception as e:
             print(e)

--- a/simplyblock_core/controllers/device_controller.py
+++ b/simplyblock_core/controllers/device_controller.py
@@ -9,7 +9,6 @@ from simplyblock_core.models.nvme_device import NVMeDevice, JMDevice
 from simplyblock_core.models.storage_node import StorageNode
 from simplyblock_core.prom_client import PromClient
 from simplyblock_core.rpc_client import RPCClient
-from simplyblock_core.snode_client import SNodeClient
 
 logger = logging.getLogger()
 
@@ -260,7 +259,7 @@ def restart_device(device_id, force=False):
 
     if not snode.rpc_client().bdev_nvme_controller_list(device_obj.nvme_controller):
         try:
-            ret = SNodeClient(snode.api_endpoint, timeout=30, retry=1).bind_device_to_spdk(device_obj.pcie_address)
+            ret = snode.client(timeout=30, retry=1).bind_device_to_spdk(device_obj.pcie_address)
             logger.debug(ret)
             snode.rpc_client().bdev_nvme_controller_attach(device_obj.nvme_controller, device_obj.pcie_address)
             snode.rpc_client().bdev_examine(f"{device_obj.nvme_controller}n1")
@@ -970,7 +969,7 @@ def new_device_from_failed(device_id):
 
     if not device_node.rpc_client().bdev_nvme_controller_list(device.nvme_controller):
         try:
-            ret = SNodeClient(device_node.api_endpoint, timeout=30, retry=1).bind_device_to_spdk(device.pcie_address)
+            ret = device_node.client(timeout=30, retry=1).bind_device_to_spdk(device.pcie_address)
             logger.debug(ret)
             device_node.rpc_client().bdev_nvme_controller_attach(device.nvme_controller, device.pcie_address)
         except Exception as e:

--- a/simplyblock_core/controllers/health_controller.py
+++ b/simplyblock_core/controllers/health_controller.py
@@ -12,7 +12,6 @@ from simplyblock_core.models.cluster import Cluster
 from simplyblock_core.models.nvme_device import NVMeDevice, JMDevice, RemoteDevice
 from simplyblock_core.models.storage_node import StorageNode
 from simplyblock_core.rpc_client import RPCClient
-from simplyblock_core.snode_client import SNodeClient
 from simplyblock_core.controllers import device_controller
 
 logger = utils.get_logger(__name__)
@@ -117,10 +116,10 @@ def _check_node_rpc(rpc_ip, rpc_port, rpc_username, rpc_password, timeout=5, ret
     return False, False
 
 
-def _check_node_api(ip):
+def _check_node_api(node):
     try:
-        snode_api = SNodeClient(f"{ip}:5000", timeout=90, retry=2)
-        logger.debug(f"Node API={ip}:5000")
+        snode_api = node.client(timeout=90, retry=2)
+        logger.debug(f"Node API={node.api_endpoint}")
         ret, _ = snode_api.is_live()
         logger.debug(f"snode is alive: {ret}")
         if ret:
@@ -178,7 +177,7 @@ def _check_node_ping(ip):
 
 
 def _check_ping_from_node(ip, ifname, node):
-    snodeapi = SNodeClient(node.api_endpoint, timeout=3, retry=3)
+    snodeapi = node.client(timeout=3, retry=3)
     try:
         ret, _ = snodeapi.ping_ip(ip, ifname)
         return bool(ret)
@@ -616,7 +615,7 @@ def check_node(node_id, with_devices=True):
     logger.info(f"Check: ping mgmt ip {snode.mgmt_ip} ... {ping_check}")
 
     # 2- check node API
-    node_api_check = _check_node_api(snode.mgmt_ip)
+    node_api_check = _check_node_api(snode)
     logger.info(f"Check: node API {snode.mgmt_ip}:5000 ... {node_api_check}")
 
     # 3- check node RPC

--- a/simplyblock_core/controllers/health_controller.py
+++ b/simplyblock_core/controllers/health_controller.py
@@ -130,14 +130,6 @@ def _check_node_api(ip):
     return False
 
 
-def _check_spdk_process_up(ip, rpc_port, cluster_id):
-    snode_api = SNodeClient(f"{ip}:5000", timeout=90, retry=2)
-    logger.debug(f"Node API={ip}:5000")
-    is_up, _ = snode_api.spdk_process_is_up(rpc_port, cluster_id)
-    logger.debug(f"SPDK is {is_up}")
-    return is_up
-
-
 def _log_port_check_failure(db_controller, snode, port, exc):
     # ECONNREFUSED from the node-agent's /firewall endpoint is routine during
     # activation and restart windows. Downgrade to WARNING so a transient miss

--- a/simplyblock_core/controllers/lvol_controller.py
+++ b/simplyblock_core/controllers/lvol_controller.py
@@ -21,7 +21,6 @@ from simplyblock_core.models.lvol_model import LVol
 from simplyblock_core.models.storage_node import StorageNode
 from simplyblock_core.prom_client import PromClient
 from simplyblock_core.rpc_client import RPCClient
-from simplyblock_core.snode_client import SNodeClient
 
 logger = lg.getLogger()
 
@@ -52,7 +51,7 @@ def _register_pool_dhchap_keys_on_node(pool, snode, rpc_client):
     Returns a dict with 'dhchap_key' and 'dhchap_ctrlr_key' keyring names,
     or an empty dict on failure.
     """
-    snode_api = SNodeClient(snode.api_endpoint)
+    snode_api = snode.client()
     safe_pool = pool.get_id().replace("-", "_")
     key_names = {}
 
@@ -90,7 +89,7 @@ def _register_dhchap_keys_on_node(snode, host_nqn, host_entry, rpc_client):
     Returns a dict mapping key type ('dhchap_key', 'dhchap_ctrlr_key', 'psk')
     to the SPDK keyring name for use in subsystem_add_host.
     """
-    snode_api = SNodeClient(snode.api_endpoint)
+    snode_api = snode.client()
     # Sanitize host NQN for use as filename
     safe_host = host_nqn.replace(":", "_").replace(".", "_")
     key_names = {}

--- a/simplyblock_core/models/storage_node.py
+++ b/simplyblock_core/models/storage_node.py
@@ -11,6 +11,7 @@ from simplyblock_core.models.iface import IFace
 from simplyblock_core.models.job_schedule import JobSchedule
 from simplyblock_core.models.nvme_device import NVMeDevice, JMDevice, RemoteDevice, RemoteJMDevice
 from simplyblock_core.rpc_client import RPCClient, RPCException
+from simplyblock_core.snode_client import SNodeClient
 
 logger = utils.get_logger(__name__)
 
@@ -143,6 +144,11 @@ class StorageNode(BaseNodeObject):
         if self.hublvol:
             return self.hublvol.nvmf_port
         return 0
+
+    def client(self, **kwargs):
+        """Return API client to this node
+        """
+        return SNodeClient(self.api_endpoint, **kwargs)
 
     def rpc_client(self, **kwargs):
         """Return rpc client to this node

--- a/simplyblock_core/services/new_device_discovery.py
+++ b/simplyblock_core/services/new_device_discovery.py
@@ -5,8 +5,6 @@ from simplyblock_core import constants, db_controller, storage_node_ops, utils
 from simplyblock_core.models.nvme_device import NVMeDevice
 from simplyblock_core.models.storage_node import StorageNode
 
-from simplyblock_core.snode_client import SNodeClient
-
 logger = utils.get_logger(__name__)
 
 # get DB controller
@@ -29,7 +27,7 @@ while True:
         if node.jm_device and 'serial_number' in node.jm_device.device_data_dict:
             known_sn.append(node.jm_device.device_data_dict['serial_number'])
 
-        snode_api = SNodeClient(node.api_endpoint)
+        snode_api = node.client()
         node_info, _ = snode_api.info()
 
 

--- a/simplyblock_core/services/storage_node_monitor.py
+++ b/simplyblock_core/services/storage_node_monitor.py
@@ -10,7 +10,6 @@ from simplyblock_core.models.cluster import Cluster
 from simplyblock_core.models.job_schedule import JobSchedule
 from simplyblock_core.models.nvme_device import NVMeDevice, JMDevice
 from simplyblock_core.models.storage_node import StorageNode
-from simplyblock_core.snode_client import SNodeClient
 
 logger = utils.get_logger(__name__)
 
@@ -479,7 +478,7 @@ def check_node(snode):
 
     # 2- check node API
     try:
-        snode_api = SNodeClient(f"{snode.mgmt_ip}:5000", timeout=10, retry=2)
+        snode_api = snode.client(timeout=10, retry=2)
         ret, _ = snode_api.is_live()
         logger.info(f"Check: node API {snode.mgmt_ip}:5000 ... {ret}")
         if not ret:
@@ -493,8 +492,8 @@ def check_node(snode):
 
     # 3- check spdk process through node API
     try:
-        snode_api = SNodeClient(f"{snode.mgmt_ip}:5000", timeout=40, retry=2)
-        is_up, _ = snode_api.spdk_process_is_up( snode.rpc_port, snode.cluster_id)
+        snode_api = snode.client(timeout=40, retry=2)
+        is_up, _ = snode_api.spdk_process_is_up(snode.rpc_port, snode.cluster_id)
         logger.info(f"Check: spdk process {snode.mgmt_ip}:5000 ... {bool(is_up)}")
         if not is_up:
             logger.info("Check: node API failed, setting node offline")

--- a/simplyblock_core/services/tasks_runner_restart.py
+++ b/simplyblock_core/services/tasks_runner_restart.py
@@ -6,7 +6,7 @@ from simplyblock_core.controllers import device_controller, health_controller, t
 from simplyblock_core.models.job_schedule import JobSchedule
 from simplyblock_core.models.nvme_device import NVMeDevice
 from simplyblock_core.models.storage_node import StorageNode
-from simplyblock_core.snode_client import SNodeClient, SNodeClientException
+from simplyblock_core.snode_client import SNodeClientException
 
 
 logger = utils.get_logger(__name__)
@@ -71,7 +71,7 @@ def _ensure_spdk_killed(node):
     # the container in `exited` state).  Skipping the kill RPC avoids a ~30 s
     # retry-then-timeout cycle on an already-dead container.
     try:
-        client = SNodeClient(node.api_endpoint, timeout=5, retry=2)
+        client = node.client(timeout=5, retry=2)
         is_up, _ = client.spdk_process_is_up(node.rpc_port, node.cluster_id)
         if not is_up:
             logger.info(
@@ -88,8 +88,7 @@ def _ensure_spdk_killed(node):
 
     try:
         logger.info(f"Killing SPDK on node {node.get_id()} (rpc_port={node.rpc_port})")
-        SNodeClient(node.api_endpoint, timeout=10, retry=5).spdk_process_kill(
-            node.rpc_port, node.cluster_id)
+        node.client(timeout=10, retry=5).spdk_process_kill(node.rpc_port, node.cluster_id)
         return True
     except SNodeClientException as exc:
         logger.error(

--- a/simplyblock_core/storage_node_ops.py
+++ b/simplyblock_core/storage_node_ops.py
@@ -642,7 +642,7 @@ def _create_device_partitions(rpc_client, nvme, snode, num_partitions_per_dev, j
     if not nbd_device:
         logger.error("Failed to start nbd dev")
         return False
-    snode_api = SNodeClient(snode.api_endpoint)
+    snode_api = snode.client()
     partition_percent = 0
     if partition_size:
         partition_percent = int(partition_size * 100 / nvme.size)
@@ -2011,7 +2011,7 @@ def remove_storage_node(node_id, force_remove=False, force_migrate=False):
     try:
         if health_controller._check_node_api(snode.mgmt_ip):
             logger.info("Stopping SPDK container")
-            snode_api = SNodeClient(snode.api_endpoint, timeout=20)
+            snode_api = snode.client(timeout=20)
             snode_api.spdk_process_kill(snode.rpc_port, snode.cluster_id)
             snode_api.leave_swarm()
             pci_address = []
@@ -2167,7 +2167,7 @@ def _restart_storage_node_impl(
     active_rdma = False
     fabric_tcp = cluster.fabric_tcp
     fabric_rdma = cluster.fabric_rdma
-    snode_api = SNodeClient(snode.api_endpoint, timeout=5 * 60, retry=3)
+    snode_api = snode.client(timeout=5 * 60, retry=3)
     for nic in snode.data_nics:
         if fabric_rdma and snode_api.ifc_is_roce(nic["if_name"]):
             nic.trtype = "RDMA"
@@ -2636,7 +2636,7 @@ def _restart_storage_node_impl(
             """Kill SPDK and set offline on fatal error."""
             logger.error(f"Restart abort: {reason}")
             storage_events.snode_restart_failed(snode)
-            snode_api_inner = SNodeClient(snode.api_endpoint, timeout=5, retry=5)
+            snode_api_inner = snode.client(timeout=5, retry=5)
             snode_api_inner.spdk_process_kill(snode.rpc_port, snode.cluster_id)
             set_node_status(snode.get_id(), StorageNode.STATUS_OFFLINE)
 
@@ -3140,7 +3140,7 @@ def shutdown_storage_node(node_id, force=False):
     time.sleep(1)
     logger.info("Stopping SPDK")
     try:
-        SNodeClient(snode.api_endpoint, timeout=10, retry=10).spdk_process_kill(snode.rpc_port, snode.cluster_id)
+        snode.client(timeout=10, retry=10).spdk_process_kill(snode.rpc_port, snode.cluster_id)
     except SNodeClientException:
         logger.error('Failed to kill SPDK')
         return False
@@ -3148,7 +3148,7 @@ def shutdown_storage_node(node_id, force=False):
     for dev in snode.nvme_devices:
         if dev.pcie_address not in pci_address:
             try:
-                ret = SNodeClient(snode.api_endpoint, timeout=30, retry=1).bind_device_to_nvme(dev.pcie_address)
+                ret = snode.client(timeout=30, retry=1).bind_device_to_nvme(dev.pcie_address)
                 logger.debug(ret)
                 pci_address.append(dev.pcie_address)
             except Exception as e:
@@ -3790,8 +3790,7 @@ def health_check(node_id):
 
     try:
         logger.info("Connecting to node's API")
-        snode_api = SNodeClient(f"{snode.mgmt_ip}:5000")
-        node_info, _ = snode_api.info()
+        node_info, _ = snode.client().info()
         logger.info(f"Node info: {node_info['hostname']}")
 
     except Exception as e:
@@ -3807,8 +3806,7 @@ def get_info(node_id):
         logger.exception("Can not find storage node")
         return False
 
-    snode_api = SNodeClient(f"{snode.mgmt_ip}:5000")
-    node_info, _ = snode_api.info()
+    node_info, _ = snode.client().info()
     return json.dumps(node_info, indent=2)
 
 
@@ -4497,7 +4495,7 @@ def recreate_lvstore_on_non_leader(snode, leader_node, primary_node, activation_
                      snode.get_id(), primary_node.lvstore, reason)
         try:
             storage_events.snode_restart_failed(snode)
-            snode_api = SNodeClient(snode.api_endpoint, timeout=5, retry=5)
+            snode_api = snode.client(timeout=5, retry=5)
             snode_api.spdk_process_kill(snode.rpc_port, snode.cluster_id)
         except Exception as ke:
             logger.error("Failed to kill SPDK during abort: %s", ke)
@@ -4926,7 +4924,7 @@ def recreate_lvstore(snode, force=False, lvs_primary=None, activation_mode=False
 
     def _kill_app():
         storage_events.snode_restart_failed(snode)
-        snode_api = SNodeClient(snode.api_endpoint, timeout=5, retry=5)
+        snode_api = snode.client(timeout=5, retry=5)
         snode_api.spdk_process_kill(snode.rpc_port, snode.cluster_id)
         # spdk_process_kill returns as soon as the HTTP request is
         # queued — SPDK may keep serving IO for a short while after.

--- a/simplyblock_core/storage_node_ops.py
+++ b/simplyblock_core/storage_node_ops.py
@@ -2037,7 +2037,7 @@ def restart_storage_node(
         node_id, max_lvol=0, max_snap=0, max_prov=0,
         spdk_image=None, set_spdk_debug=None,
         small_bufsize=0, large_bufsize=0,
-        force=False, node_ip=None, reattach_volume=False, clear_data=False, new_ssd_pcie=[],
+        force=False, node_address=None, reattach_volume=False, clear_data=False, new_ssd_pcie=[],
         force_lvol_recreate=False, spdk_proxy_image=None):
     """Wrapper that guarantees the node is reset to OFFLINE if the restart
     fails after the RESTARTING status has been set.  Without this, any
@@ -2049,7 +2049,7 @@ def restart_storage_node(
             node_id, max_lvol=max_lvol, max_snap=max_snap, max_prov=max_prov,
             spdk_image=spdk_image, set_spdk_debug=set_spdk_debug,
             small_bufsize=small_bufsize, large_bufsize=large_bufsize,
-            force=force, node_ip=node_ip, reattach_volume=reattach_volume,
+            force=force, node_address=node_address, reattach_volume=reattach_volume,
             clear_data=clear_data, new_ssd_pcie=new_ssd_pcie,
             force_lvol_recreate=force_lvol_recreate, spdk_proxy_image=spdk_proxy_image)
     except Exception:
@@ -2074,7 +2074,7 @@ def _restart_storage_node_impl(
         node_id, max_lvol=0, max_snap=0, max_prov=0,
         spdk_image=None, set_spdk_debug=None,
         small_bufsize=0, large_bufsize=0,
-        force=False, node_ip=None, reattach_volume=False, clear_data=False, new_ssd_pcie=[],
+        force=False, node_address=None, reattach_volume=False, clear_data=False, new_ssd_pcie=[],
         force_lvol_recreate=False, spdk_proxy_image=None):
     db_controller = DBController()
     logger.info("Restarting storage node")
@@ -2116,16 +2116,16 @@ def _restart_storage_node_impl(
         return False
     snode = db_controller.get_storage_node_by_id(node_id)
 
-    if node_ip:
-        if node_ip != snode.api_endpoint:
-            logger.info(f"Restarting on new node with ip: {node_ip}")
-            snode_api = SNodeClient(node_ip, timeout=5 * 60, retry=3)
+    if node_address:
+        if node_address != snode.api_endpoint:
+            logger.info(f"Restarting on new node with ip: {node_address}")
+            snode_api = SNodeClient(node_address, timeout=5 * 60, retry=3)
             node_info, _ = snode_api.info()
             if not node_info:
                 logger.error("Failed to get node info!")
                 return False
-            snode.api_endpoint = node_ip
-            snode.mgmt_ip = node_ip.split(":")[0]
+            snode.api_endpoint = node_address
+            snode.mgmt_ip = node_address.split(":")[0]
             data_nics = []
             for nic in snode.data_nics:
                 if_name = nic["if_name"]
@@ -2162,7 +2162,7 @@ def _restart_storage_node_impl(
                     if dev['serial_number'] in known_sn:
                         snode_api.bind_device_to_spdk(dev['address'])
         else:
-            node_ip = None
+            node_address = None
     active_tcp = False
     active_rdma = False
     fabric_tcp = cluster.fabric_tcp
@@ -2498,7 +2498,7 @@ def _restart_storage_node_impl(
             snode.nvme_devices.append(dev)
 
     snode.write_to_db(db_controller.kv_store)
-    if node_ip and len(new_devices) > 0:
+    if node_address and len(new_devices) > 0:
         # prepare devices on new node
         if snode.num_partitions_per_dev == 0 or snode.jm_percent == 0:
 

--- a/simplyblock_web/api/v1/storage_node.py
+++ b/simplyblock_web/api/v1/storage_node.py
@@ -182,7 +182,7 @@ def storage_node_restart():
         target=storage_node_ops.restart_storage_node,
         kwargs={
             "node_id": uuid,
-            "node_ip": node_ip,
+            "node_address": node_ip,
             "force": force,
             "reattach_volume": reattach_volume,
         }

--- a/simplyblock_web/api/v2/storage_node.py
+++ b/simplyblock_web/api/v2/storage_node.py
@@ -244,7 +244,7 @@ def restart(cluster: Cluster, storage_node: StorageNode, parameters: _RestartPar
         kwargs={
             "node_id": storage_node.get_id(),
             "force": parameters.force,
-            "node_ip": parameters.node_address,
+            "node_address": parameters.node_address,
             "reattach_volume": parameters.reattach_volume,
         }
     ).start()


### PR DESCRIPTION
This prepares for the TLS changes on the SNodeClient. A variable is renamed to align its name with the content (`node_address` vs. `node_ip`). Also, it introduces a single helper we go through to acquire an SNodeClient, unifying the use of `node.api_endpoint` vs `{node.mgmt_ip}:5000`.