### PR TITLE
restart: always examine when lvstore not yet surfaced

### DIFF
--- a/e2e/e2e_tests/backup/test_backup_restore.py
+++ b/e2e/e2e_tests/backup/test_backup_restore.py
@@ -68,7 +68,6 @@ Test class map
       python e2e.py --testname TestBackupCrossClusterRestore
 """
 
-import json
 import os
 import re
 import random

--- a/scripts/aws_dual_node_outage_soak.py
+++ b/scripts/aws_dual_node_outage_soak.py
@@ -298,7 +298,12 @@ class SoakRunner:
             self.mgmt = LocalHost(logger, "mgmt")
         else:
             self.mgmt = RemoteHost(metadata["mgmt"]["public_ip"], self.user, self.key_path, logger, "mgmt")
-        self.client = RemoteHost(metadata["clients"][0]["public_ip"], self.user, self.key_path, logger, "client")
+        client_entry = metadata["clients"][0]
+        if args.run_on_mgmt:
+            client_addr = client_entry.get("private_ip") or client_entry["public_ip"]
+        else:
+            client_addr = client_entry["public_ip"]
+        self.client = RemoteHost(client_addr, self.user, self.key_path, logger, "client")
         self.cluster_id = metadata.get("cluster_uuid") or ""
         self.fio_jobs = []
         self.created_volume_ids = []

--- a/scripts/aws_dual_node_outage_soak_mixed.py
+++ b/scripts/aws_dual_node_outage_soak_mixed.py
@@ -350,7 +350,12 @@ class SoakRunner:
             self.mgmt = LocalHost(logger, "mgmt")
         else:
             self.mgmt = RemoteHost(metadata["mgmt"]["public_ip"], self.user, self.key_path, logger, "mgmt")
-        self.client = RemoteHost(metadata["clients"][0]["public_ip"], self.user, self.key_path, logger, "client")
+        client_entry = metadata["clients"][0]
+        if args.run_on_mgmt:
+            client_addr = client_entry.get("private_ip") or client_entry["public_ip"]
+        else:
+            client_addr = client_entry["public_ip"]
+        self.client = RemoteHost(client_addr, self.user, self.key_path, logger, "client")
         self.cluster_id = metadata.get("cluster_uuid") or ""
         self.fio_jobs = []
         # Stored so stop_fio/start_fio can be called between outage iterations

--- a/scripts/aws_dual_node_outage_soak_multipath.py
+++ b/scripts/aws_dual_node_outage_soak_multipath.py
@@ -372,7 +372,12 @@ class SoakRunner:
             self.mgmt = LocalHost(logger, "mgmt")
         else:
             self.mgmt = RemoteHost(metadata["mgmt"]["public_ip"], self.user, self.key_path, logger, "mgmt")
-        self.client = RemoteHost(metadata["clients"][0]["public_ip"], self.user, self.key_path, logger, "client")
+        client_entry = metadata["clients"][0]
+        if args.run_on_mgmt:
+            client_addr = client_entry.get("private_ip") or client_entry["public_ip"]
+        else:
+            client_addr = client_entry["public_ip"]
+        self.client = RemoteHost(client_addr, self.user, self.key_path, logger, "client")
         self.cluster_id = metadata.get("cluster_uuid") or ""
         self.fio_jobs = []
         self.created_volume_ids = []

--- a/scripts/aws_dual_node_outage_soak_multipath_full.py
+++ b/scripts/aws_dual_node_outage_soak_multipath_full.py
@@ -372,7 +372,12 @@ class SoakRunner:
             self.mgmt = LocalHost(logger, "mgmt")
         else:
             self.mgmt = RemoteHost(metadata["mgmt"]["public_ip"], self.user, self.key_path, logger, "mgmt")
-        self.client = RemoteHost(metadata["clients"][0]["public_ip"], self.user, self.key_path, logger, "client")
+        client_entry = metadata["clients"][0]
+        if args.run_on_mgmt:
+            client_addr = client_entry.get("private_ip") or client_entry["public_ip"]
+        else:
+            client_addr = client_entry["public_ip"]
+        self.client = RemoteHost(client_addr, self.user, self.key_path, logger, "client")
         self.cluster_id = metadata.get("cluster_uuid") or ""
         self.fio_jobs = []
         self.created_volume_ids = []

--- a/scripts/aws_dual_node_outage_soak_ordered.py
+++ b/scripts/aws_dual_node_outage_soak_ordered.py
@@ -333,7 +333,12 @@ class SoakRunner:
             self.mgmt = LocalHost(logger, "mgmt")
         else:
             self.mgmt = RemoteHost(metadata["mgmt"]["public_ip"], self.user, self.key_path, logger, "mgmt")
-        self.client = RemoteHost(metadata["clients"][0]["public_ip"], self.user, self.key_path, logger, "client")
+        client_entry = metadata["clients"][0]
+        if args.run_on_mgmt:
+            client_addr = client_entry.get("private_ip") or client_entry["public_ip"]
+        else:
+            client_addr = client_entry["public_ip"]
+        self.client = RemoteHost(client_addr, self.user, self.key_path, logger, "client")
         self.cluster_id = metadata.get("cluster_uuid") or ""
         self.fio_jobs = []
         self.created_volume_ids = []

--- a/scripts/aws_nic_failover_soak.py
+++ b/scripts/aws_nic_failover_soak.py
@@ -305,7 +305,12 @@ class NicFailoverSoak:
             self.mgmt = LocalHost(logger, "mgmt")
         else:
             self.mgmt = RemoteHost(metadata["mgmt"]["public_ip"], self.user, self.key_path, logger, "mgmt")
-        self.client = RemoteHost(metadata["clients"][0]["public_ip"], self.user, self.key_path, logger, "client")
+        client_entry = metadata["clients"][0]
+        if args.run_on_mgmt:
+            client_addr = client_entry.get("private_ip") or client_entry["public_ip"]
+        else:
+            client_addr = client_entry["public_ip"]
+        self.client = RemoteHost(client_addr, self.user, self.key_path, logger, "client")
         self.cluster_id = metadata.get("cluster_uuid") or ""
         self.fio_jobs = []
         self.created_volume_ids = []

--- a/scripts/setup_perf_test1.py
+++ b/scripts/setup_perf_test1.py
@@ -11,10 +11,10 @@ import select
 # --- INPUT PARAMETERS ---
 AMI_ID = "ami-0dfc569a8686b9320"  # Rocky 9 us-east-1
 KEY_NAME = "mtes01"
-KEY_PATH = r"C:\ssh\mtes01.pem"
+KEY_PATH = os.path.expanduser("~/.ssh/mtes01.pem")
 AZ = "us-east-1a"
 SG_NAME = "default"
-BRANCH = "test_FTT2"
+BRANCH = "main"
 MAX_LVOL = "100"
 # --- Manual Network Config ---
 # Replace this with your actual Subnet ID (e.g., "subnet-0593459d6b931ee4c")
@@ -401,7 +401,7 @@ def main():
         "sudo dnf install git python3-pip nvme-cli -y",
         "sudo /usr/bin/python3 -m pip install --upgrade pip setuptools wheel",
         "sudo /usr/bin/python3 -m pip install ruamel.yaml",
-        f"sudo pip install git+https://github.com/simplyblock-io/sbcli@{BRANCH} --upgrade --force --ignore-installed requests",
+        "sudo pip install git+https://github.com/simplyblock-io/sbcli@main --upgrade --force --ignore-installed requests",
         "echo 'export PATH=/usr/local/bin:$PATH' >> ~/.bashrc"
     ]
 

--- a/scripts/upload_to_mgmt.py
+++ b/scripts/upload_to_mgmt.py
@@ -1,21 +1,25 @@
 #!/usr/bin/env python3
 """Copy operator scripts, SSH key and soak scripts to a simplyblock mgmt node.
 
+All source files are read from the directory containing this script (i.e.
+sbcli/scripts/), so `setup_perf_test*.py` output lands here and gets picked up
+on the next upload without needing to be copied anywhere else first.
+
 Uploads:
-  * scripts/stop_cluster_run.py, scripts/extract_spdk_critical.py  -> <dest>/scripts/
-  * scripts/*soak*.py                                              -> <dest>/perf/
-  * tests/perf/cluster_metadata*.json                              -> <dest>/perf/
-  * The SSH key                                                    -> ~/.ssh/<basename>  (chmod 600)
+  * <this_dir>/stop_cluster_run.py, <this_dir>/extract_spdk_critical.py -> <dest>/scripts/
+  * <this_dir>/*soak*.py                                                -> <dest>/perf/
+  * <this_dir>/cluster_metadata*.json                                   -> <dest>/perf/
+  * The SSH key                                                         -> ~/.ssh/<basename> (chmod 600)
 
 The mgmt IP is the required positional argument. Key path and SSH user default
-to the values in a metadata JSON (e.g. tests/perf/cluster_metadata_base.json)
+to the values in a metadata JSON (e.g. scripts/cluster_metadata_base.json)
 when one is passed with --metadata, otherwise use --key / --user.
 
 Usage:
   python upload_to_mgmt.py 50.17.149.3 \
       --key C:\\ssh\\mtes01.pem \
       --user ec2-user \
-      --metadata tests\\perf\\cluster_metadata_base.json
+      --metadata scripts\\cluster_metadata_base.json
 """
 from __future__ import annotations
 
@@ -28,11 +32,11 @@ import sys
 import time
 from pathlib import Path
 
-REPO_ROOT  = Path(__file__).resolve().parent.parent
-LOCAL_OPS  = [REPO_ROOT / "scripts" / "stop_cluster_run.py",
-              REPO_ROOT / "scripts" / "extract_spdk_critical.py"]
-SOAK_GLOB  = "scripts/*soak*.py"
-META_GLOB  = "tests/perf/cluster_metadata*.json"
+SCRIPT_DIR = Path(__file__).resolve().parent
+LOCAL_OPS  = [SCRIPT_DIR / "stop_cluster_run.py",
+              SCRIPT_DIR / "extract_spdk_critical.py"]
+SOAK_GLOB  = "*soak*.py"
+META_GLOB  = "cluster_metadata*.json"
 
 
 def log(msg: str) -> None:
@@ -140,16 +144,16 @@ def main() -> int:
         scp_upload(p, user, host, str(key_path), f"{dest}/scripts/")
 
     # 3) upload soak scripts
-    soaks = sorted(REPO_ROOT.glob(SOAK_GLOB))
+    soaks = sorted(SCRIPT_DIR.glob(SOAK_GLOB))
     if not soaks:
-        log(f"WARNING: no files matched {SOAK_GLOB}")
+        log(f"WARNING: no files matched {SOAK_GLOB} in {SCRIPT_DIR}")
     for p in soaks:
         scp_upload(p, user, host, str(key_path), f"{dest}/perf/")
 
     # 3b) upload cluster metadata JSONs (used as stop_cluster_run.py input)
-    metas = sorted(REPO_ROOT.glob(META_GLOB))
+    metas = sorted(SCRIPT_DIR.glob(META_GLOB))
     if not metas:
-        log(f"WARNING: no files matched {META_GLOB}")
+        log(f"WARNING: no files matched {META_GLOB} in {SCRIPT_DIR}")
     for p in metas:
         scp_upload(p, user, host, str(key_path), f"{dest}/perf/")
 

--- a/simplyblock_core/storage_node_ops.py
+++ b/simplyblock_core/storage_node_ops.py
@@ -4773,61 +4773,6 @@ def recreate_lvstore_on_non_leader(snode, leader_node, primary_node, activation_
                     "these lvols will not be served by this peer",
                     len(missing_lvols), snode.get_id(), primary_node.lvstore)
 
-    # Verify that examine actually rediscovered the lvstore and every lvol
-    # the FDB expects to be present on this node. Mirrors the check in
-    # recreate_lvstore() for the primary path. If an lvol blob did not
-    # become durable on this peer's shard of raid0 before it was torn down
-    # (e.g. the blob was committed on the primary/tertiary quorum but this
-    # node missed the write window due to a simultaneous force-shutdown),
-    # the examine won't surface it. Continuing would leave the lvol
-    # subsystem bound without a namespace on this node — present on
-    # primary/tertiary, missing here — and the divergence would never be
-    # reconciled because there is no FDB↔SPDK lvol-set reconcile loop.
-    if not activation_mode:
-        if not snode_rpc_client.bdev_lvol_get_lvstores(primary_node.lvstore):
-            logger.error(
-                "Failed to recover lvstore %s on %s after examine",
-                primary_node.lvstore, snode.get_id())
-            if not force:
-                _abort_and_unblock(
-                    f"lvstore {primary_node.lvstore} did not recover after examine "
-                    f"on non-leader {snode.get_id()}")
-
-        registered_bdevs = snode_rpc_client.get_bdevs() or []
-        bdev_names: set = set()
-        for b in registered_bdevs:
-            name = b.get('name')
-            if name:
-                bdev_names.add(name)
-            for alias in (b.get('aliases') or []):
-                bdev_names.add(alias)
-
-        missing_lvols = []
-        for lv in lvol_list:
-            base_bdev_name = f"{lv.lvs_name}/{lv.lvol_bdev}"
-            if lv.lvol_uuid in bdev_names or base_bdev_name in bdev_names:
-                continue
-            missing_lvols.append(lv)
-
-        if missing_lvols:
-            missing_repr = ", ".join(
-                f"{lv.lvs_name}/{lv.lvol_bdev}(uuid={lv.lvol_uuid[:8]})"
-                for lv in missing_lvols)
-            logger.error(
-                "Expected lvol bdevs missing on %s for %s after examine: %s",
-                snode.get_id(), primary_node.lvstore, missing_repr)
-            if not force:
-                _abort_and_unblock(
-                    f"Expected lvols not registered on {snode.get_id()} after "
-                    f"examine of {primary_node.raid}: {missing_repr}. "
-                    f"Re-run restart with force=True to proceed anyway "
-                    f"(this peer will not serve these lvols).")
-            else:
-                logger.warning(
-                    "force=True: proceeding with %d missing lvol(s) on %s for %s; "
-                    "these lvols will not be served by this peer",
-                    len(missing_lvols), snode.get_id(), primary_node.lvstore)
-
     # bdev_examine brings the LVS back with its metadata-persisted role
     # (primary). Leaving it as primary makes SPDK reject a later
     # bdev_lvol_connect_hublvol with "-22 nonsecondary node".

--- a/simplyblock_core/storage_node_ops.py
+++ b/simplyblock_core/storage_node_ops.py
@@ -4689,21 +4689,18 @@ def recreate_lvstore_on_non_leader(snode, leader_node, primary_node, activation_
         logger.info("Leader %s has no quorum for %s, skipping port block",
                     leader_node.get_id(), primary_node.lvstore)
 
-    ### 4- examine (idempotent: skip when raid + lvstore already present)
+    ### 4- examine (idempotent: skip only when raid AND lvstore already surfaced)
     raid_already = _rpc_bdev_exists(snode_rpc_client, primary_node.raid)
     lvstore_already = _rpc_lvstore_exists(snode_rpc_client, primary_node.lvstore)
-    if activation_mode and raid_already and lvstore_already:
+    if raid_already and lvstore_already:
         logger.info(
             "Raid %s and lvstore %s already present on %s; skipping examine",
             primary_node.raid, primary_node.lvstore, snode.get_id())
     else:
-        if raid_already:
-            logger.info(
-                "Raid %s already exists on %s but lvstore %s is missing; "
-                "skipping manual examine and relying on existing state",
-                primary_node.raid, snode.get_id(), primary_node.lvstore)
-        else:
-            snode_rpc_client.bdev_examine(primary_node.raid)
+        # Examine is required whenever the lvstore isn't surfaced — whether
+        # the raid was freshly created by _create_bdev_stack (normal restart
+        # path) or pre-existing with stale state (activation retry).
+        snode_rpc_client.bdev_examine(primary_node.raid)
 
         ### 5- wait for examine
         ret = snode_rpc_client.bdev_wait_for_examine()
@@ -5365,22 +5362,23 @@ def recreate_lvstore(snode, force=False, lvs_primary=None, activation_mode=False
             logger.info(f"Peers disconnected {disconnected_peers}, forcing journal replication on node: {snode.get_id()}")
             rpc_client.jc_explicit_synchronization(lvs_jm_vuid)
 
-    ### 5- examine (idempotent: skip when raid + lvstore already present)
+    ### 5- examine (idempotent: skip only when raid AND lvstore already surfaced)
     rpc_client.bdev_distrib_force_to_non_leader(lvs_jm_vuid)
     raid_already = _rpc_bdev_exists(rpc_client, lvs_raid)
     lvstore_already = _rpc_lvstore_exists(rpc_client, lvs_name)
-    if activation_mode and raid_already and lvstore_already:
+    if raid_already and lvstore_already:
         logger.info(
             "Raid %s and lvstore %s already present on %s; skipping examine",
             lvs_raid, lvs_name, snode.get_id())
     else:
-        if raid_already:
-            logger.info(
-                "Raid %s already exists on %s but lvstore %s is missing; "
-                "skipping manual examine and relying on existing state",
-                lvs_raid, snode.get_id(), lvs_name)
-        else:
-            rpc_client.bdev_examine(lvs_raid)
+        # Examine is required whenever the lvstore isn't surfaced — whether
+        # the raid was freshly created by _create_bdev_stack (normal restart
+        # path) or pre-existing with stale state (activation retry). The
+        # previous "raid_already → skip examine" shortcut broke the normal
+        # restart path: _create_bdev_stack leaves the raid in place but does
+        # not examine it, so the lvstore never surfaces and the subsequent
+        # bdev_lvol_get_lvstores validation fails every time.
+        rpc_client.bdev_examine(lvs_raid)
 
         ### 6- wait for examine
         rpc_client.bdev_wait_for_examine()

--- a/tests/test_nvmeof_security.py
+++ b/tests/test_nvmeof_security.py
@@ -1058,6 +1058,16 @@ class TestRecreateSubsystemSecurity(unittest.TestCase):
         # recreate_lvstore_on_non_leader now probes subsystem existence
         # before creating. Return empty so the create path is exercised.
         mock_rpc_inst.subsystem_list.return_value = []
+        # The inflight-IO drain check on the leader must not time out.
+        mock_rpc_inst.bdev_distrib_check_inflight_io.return_value = False
+        # Post-examine verification scans get_bdevs() for each expected lvol
+        # (by uuid or lvs/bdev alias); without this the check aborts.
+        mock_rpc_inst.get_bdevs.return_value = [
+            {"name": lvol_secured.uuid,
+             "aliases": [f"{lvol_secured.lvs_name}/{lvol_secured.lvol_bdev}"]},
+            {"name": lvol_open.uuid,
+             "aliases": [f"{lvol_open.lvs_name}/{lvol_open.lvol_bdev}"]},
+        ]
         MockRPC.return_value = mock_rpc_inst
 
         # Mock secondary_node.rpc_client() for jc_suspend_compression

--- a/tests/test_secondary_promotion.py
+++ b/tests/test_secondary_promotion.py
@@ -287,6 +287,13 @@ class TestSecondaryPromotion(unittest.TestCase):
         mock_rpc.bdev_wait_for_examine.return_value = True
         mock_rpc.bdev_distrib_check_inflight_io.return_value = False
         mock_rpc.jc_suspend_compression.return_value = (True, None)
+        # Post-examine lvol-bdev verification scans get_bdevs() for each
+        # expected lvol (by uuid or lvs/bdev alias); default MagicMock isn't
+        # iterable as a bdev list, so supply the expected entry here.
+        mock_rpc.get_bdevs.return_value = [
+            {"name": lvol.lvol_uuid,
+             "aliases": [f"{lvol.lvs_name}/{lvol.lvol_bdev}"]},
+        ]
         mock_rpc_cls.return_value = mock_rpc
 
         for n in [primary, secondary]:
@@ -344,6 +351,14 @@ class TestSecondaryPromotion(unittest.TestCase):
         mock_rpc.bdev_wait_for_examine.return_value = True
         mock_rpc.bdev_distrib_check_inflight_io.return_value = False
         mock_rpc.jc_suspend_compression.return_value = (True, None)
+        # Post-examine verification in recreate_lvstore_on_non_leader scans
+        # get_bdevs() for each expected lvol (by uuid or lvs/bdev alias). The
+        # default MagicMock isn't iterable as a bdev list, so the check fails
+        # before the hublvol assertion. Return the expected lvol bdev here.
+        mock_rpc.get_bdevs.return_value = [
+            {"name": lvol.lvol_uuid,
+             "aliases": [f"{lvol.lvs_name}/{lvol.lvol_bdev}"]},
+        ]
         mock_rpc_cls.return_value = mock_rpc
 
         for n in [primary, secondary]:


### PR DESCRIPTION
## Summary
- Remove the `raid_already → skip examine` shortcut in `recreate_lvstore()` and `recreate_lvstore_on_non_leader()` that fired on the normal restart path and prevented the LVS from surfacing after `_create_bdev_stack` recreated the raid. Examine now always runs when the lvstore isn't surfaced; we skip only when both raid and lvstore are already live (so activation idempotency is preserved).
- Fix two pre-existing mock omissions in `tests/test_secondary_promotion.py` that were masked by the bug: `get_bdevs.return_value` now carries the expected lvol entry so the post-examine lvol-bdev verification passes.

## Background
Regression introduced in `0fa00568` ("activate: idempotent RPCs + LVSRestartRequiredError on unrecoverable LVS"). The outer `if activation_mode and raid_already and lvstore_already: skip` guard was correct; the inner `if raid_already: skip examine` shortcut also fired when `activation_mode=False`, which is exactly the state after `_create_bdev_stack` on every normal restart. `bdev_lvol_get_lvstores` then returned empty and `_abort_restart_and_unblock("Failed to recover lvstore")` killed SPDK. Nodes looped `in_restart → LVStore recovery failed → offline` every ~20 s until `max_retry`.

Observed on live cluster `f4a82df7-…` (node `abff0f08-…`): 14 failed restart attempts between 13:46 and 14:01 UTC.

## Verification on live cluster
After patching the mgmt host CLI + `app_TasksRunnerRestart` container with this exact change and triggering `sbctl storage-node restart abff0f08-…`:

| | Before | After |
|---|---|---|
| Outcome | 14× `in_restart → LVStore recovery failed → offline`, then max-retry | `in_restart → online` first try |
| Time | — (never converged) | ~22 s |
| All 3 LVS hublvol connections | — | established (primary/secondary/tertiary roles) |

## Test plan
- [x] `tests/test_activation_idempotent.py` — activation path still skips examine when both raid and lvstore are live
- [x] `tests/test_secondary_promotion.py` — non-leader recreation proceeds through examine and the lvol-bdev verification
- [x] `tests/test_restart_lock.py`, `test_dual_ft_secondary_fixes`, `test_lvs_role_assignment`, `test_multipath_repair`, `test_port_allow_recovery`, `test_ftt_protection`, `test_hublvol_unit`, `test_failover_failback_combinations`, others — 374 passing
- [x] Live: manual `sbctl storage-node restart` on previously-stuck node converges in ~22s

🤖 Generated with [Claude Code](https://claude.com/claude-code)