### PR TITLE
restart: data-plane quorum uses NVMe ctrlr state, not JM sync flag

### DIFF
--- a/simplyblock_core/services/storage_node_monitor.py
+++ b/simplyblock_core/services/storage_node_monitor.py
@@ -296,6 +296,21 @@ def is_node_data_plane_disconnected_quorum(node, lvs_peer_ids=None):
 def _count_data_plane_votes(node):
     """Query all other online storage nodes for *node*'s JM connectivity.
 
+    For each online peer, check the state of its NVMe controller that points
+    at *node*'s JM subsystem (controller name = ``remote_jm_{node_id}``).
+    A peer reports "connected" only if the controller exists AND is in the
+    ``enabled`` SPDK state (``deleting``/``failed``/``resetting``/
+    ``reconnect_is_delayed``/``disabled`` all count as disconnected).
+
+    Peers that never attached a controller for *node* (no topology link)
+    are ignored — they don't have a meaningful vote.
+
+    Why not ``jc_get_jm_status``: that RPC reads ``mjm_stat``, a sync-health
+    map updated only by the JC's replication/leveling state machine. It is
+    never flipped to ``false`` when the underlying NVMe controller is lost
+    (bdev-remove / keep-alive timeout / peer death), so a quietly-dead peer
+    perpetually votes "connected" and the quorum gets stuck.
+
     Returns (disconnected_count, total_peers_checked).
     """
     node_id = node.get_id()
@@ -312,27 +327,62 @@ def _count_data_plane_votes(node):
         logger.debug("No online peers to verify data plane for %s", node_id)
         return 0, 0
 
-    remote_jm_key = f"remote_jm_{node_id}n1"
+    ctrl_name = f"remote_jm_{node_id}"
+    bdev_name = f"{ctrl_name}n1"
     disconnected = 0
     total = 0
 
     for peer in online_peers:
-        try:
-            ret = peer.rpc_client(timeout=5, retry=1).jc_get_jm_status(peer.jm_vuid)
-            if not ret or remote_jm_key not in ret:
-                logger.debug("Data-plane check: peer %s has no status for %s JM; ignoring vote",
-                             peer.get_id(), node_id)
-                continue
+        peer_rpc = peer.rpc_client(timeout=5, retry=1)
 
-            total += 1
-            if ret[remote_jm_key] is True:
-                logger.info("Data-plane check: peer %s still sees %s JM as connected",
-                            peer.get_id(), node_id)
-            else:
-                disconnected += 1
+        # Fast path: does the namespace bdev still exist on the peer?
+        # A missing bdev means the controller has been torn down / is being
+        # torn down, which is unambiguously "disconnected". We check this
+        # first because bdev_get_bdevs is a pure registry lookup and can't
+        # block on a degraded controller's internal state, whereas
+        # bdev_nvme_get_controllers on a `resetting` / `reconnect_is_delayed`
+        # ctrlr can sit on locks during reset.
+        try:
+            bdevs = peer_rpc.get_bdevs(bdev_name)
         except Exception as e:
-            logger.debug("jc_get_jm_status on peer %s failed: %s", peer.get_id(), e)
+            logger.debug("get_bdevs(%s) on peer %s failed: %s", bdev_name, peer.get_id(), e)
             continue
+
+        if not bdevs:
+            # If the peer never had a topology link to this node, it never
+            # created this bdev either. We can't distinguish "never had it"
+            # from "had it and it's gone" just from a missing bdev, so abstain
+            # -- callers that know the topology (lvs_peer_ids) are the right
+            # place to assert "this peer SHOULD have seen it".
+            logger.debug("Data-plane check: peer %s has no %s bdev; abstaining",
+                         peer.get_id(), bdev_name)
+            continue
+
+        # Bdev exists -> controller must exist too. Now check its state.
+        try:
+            ret = peer_rpc.bdev_nvme_controller_list(ctrl_name)
+        except Exception as e:
+            logger.debug("bdev_nvme_controller_list(%s) on peer %s failed: %s",
+                         ctrl_name, peer.get_id(), e)
+            continue
+
+        total += 1
+        if not ret:
+            logger.info("Data-plane check: peer %s has %s bdev but no controller -> disconnected",
+                        peer.get_id(), bdev_name)
+            disconnected += 1
+            continue
+
+        paths = ret[0].get("ctrlrs") or []
+        enabled = any((p.get("state") == "enabled") for p in paths)
+        if enabled:
+            logger.info("Data-plane check: peer %s sees %s controller enabled",
+                        peer.get_id(), node_id)
+        else:
+            states = [p.get("state") for p in paths] or ["no-paths"]
+            logger.info("Data-plane check: peer %s reports %s controller state=%s -> disconnected",
+                        peer.get_id(), node_id, states)
+            disconnected += 1
 
     logger.info("Data-plane check for %s: %d/%d peers report disconnected", node_id, disconnected, total)
     return disconnected, total

--- a/tests/test_data_plane_quorum.py
+++ b/tests/test_data_plane_quorum.py
@@ -1,0 +1,223 @@
+# coding=utf-8
+"""
+test_data_plane_quorum.py — unit tests for
+``simplyblock_core.services.storage_node_monitor._count_data_plane_votes``
+and the ``is_node_data_plane_disconnected`` /
+``is_node_data_plane_disconnected_quorum`` helpers on top of it.
+
+Background: the previous implementation queried ``jc_get_jm_status`` on
+each online peer and counted ``remote_jm_{target}n1: false`` as a
+"disconnected" vote. That ``bool`` is actually a sync-health flag
+updated only by the JC's replication/leveling state machine — it is
+not flipped to ``false`` on NVMe-TCP controller loss or bdev removal,
+so a quietly-dead peer perpetually voted "connected" and the quorum
+stayed wedged. The new implementation uses the actual NVMe controller
+state on each peer (``bdev_nvme_get_controllers``) and a pre-check of
+the namespace bdev existence (``bdev_get_bdevs``) so a degraded
+controller doesn't stall the probe.
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from simplyblock_core.models.storage_node import StorageNode
+
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+
+def _peer(uuid, status=StorageNode.STATUS_ONLINE, jm_vuid=999):
+    """Build a mock peer node with an ``rpc_client(timeout, retry)`` factory."""
+    n = MagicMock(spec=StorageNode)
+    n.get_id.return_value = uuid
+    n.status = status
+    n.jm_vuid = jm_vuid
+    n.cluster_id = "cluster-1"
+
+    n._rpc = MagicMock()
+    n.rpc_client = MagicMock(return_value=n._rpc)
+    return n
+
+
+def _target(uuid="target-node"):
+    n = MagicMock(spec=StorageNode)
+    n.get_id.return_value = uuid
+    n.cluster_id = "cluster-1"
+    return n
+
+
+def _set_peer_response(peer, bdev_present, ctrl_states):
+    """Wire a peer's RPCClient to return a bdev list and controller list.
+
+    ``bdev_present`` — True to return a bdev dict, False to return [].
+    ``ctrl_states``  — list of state strings per path, or None to return [].
+    """
+    if bdev_present:
+        peer._rpc.get_bdevs.return_value = [{"name": "ignored", "aliases": []}]
+    else:
+        peer._rpc.get_bdevs.return_value = []
+
+    if ctrl_states is None:
+        peer._rpc.bdev_nvme_controller_list.return_value = []
+    else:
+        peer._rpc.bdev_nvme_controller_list.return_value = [
+            {"name": "remote_jm_target-node",
+             "ctrlrs": [{"state": s} for s in ctrl_states]}
+        ]
+
+
+# ---------------------------------------------------------------------------
+# _count_data_plane_votes
+# ---------------------------------------------------------------------------
+
+
+class TestCountDataPlaneVotes(unittest.TestCase):
+
+    def _run(self, peers):
+        from simplyblock_core.services import storage_node_monitor as mod
+        target = _target("target-node")
+        with patch.object(mod, "db") as mock_db:
+            mock_db.get_storage_nodes_by_cluster_id.return_value = [target] + peers
+            return mod._count_data_plane_votes(target)
+
+    def test_no_online_peers_returns_zero(self):
+        # All peers offline / excluded → no votes cast.
+        p = _peer("p1", status=StorageNode.STATUS_OFFLINE)
+        disc, total = self._run([p])
+        self.assertEqual((disc, total), (0, 0))
+
+    def test_all_peers_enabled_not_disconnected(self):
+        peers = [_peer(f"p{i}") for i in range(3)]
+        for p in peers:
+            _set_peer_response(p, bdev_present=True, ctrl_states=["enabled"])
+        disc, total = self._run(peers)
+        self.assertEqual((disc, total), (0, 3))
+
+    def test_all_peers_failed_all_disconnected(self):
+        peers = [_peer(f"p{i}") for i in range(3)]
+        for p in peers:
+            _set_peer_response(p, bdev_present=True, ctrl_states=["failed"])
+        disc, total = self._run(peers)
+        self.assertEqual((disc, total), (3, 3))
+
+    def test_bdev_absent_abstains(self):
+        # Missing bdev = peer doesn't have a topology link, abstain.
+        peers = [_peer(f"p{i}") for i in range(3)]
+        _set_peer_response(peers[0], bdev_present=False, ctrl_states=None)
+        _set_peer_response(peers[1], bdev_present=True, ctrl_states=["enabled"])
+        _set_peer_response(peers[2], bdev_present=True, ctrl_states=["failed"])
+        disc, total = self._run(peers)
+        self.assertEqual((disc, total), (1, 2))  # p0 abstains; p1 connected, p2 disc
+
+    def test_bdev_present_but_controller_missing_is_disconnected(self):
+        # Inconsistent state: namespace bdev exists but controller list empty.
+        # Count as disconnected so the restart path doesn't wait for a phantom.
+        peers = [_peer("p0")]
+        _set_peer_response(peers[0], bdev_present=True, ctrl_states=None)
+        disc, total = self._run(peers)
+        self.assertEqual((disc, total), (1, 1))
+
+    def test_resetting_state_counts_as_disconnected(self):
+        peers = [_peer("p0")]
+        _set_peer_response(peers[0], bdev_present=True, ctrl_states=["resetting"])
+        disc, total = self._run(peers)
+        self.assertEqual((disc, total), (1, 1))
+
+    def test_any_path_enabled_counts_as_connected(self):
+        # Multipath: if any path reports enabled, treat controller as up.
+        peers = [_peer("p0")]
+        _set_peer_response(peers[0], bdev_present=True,
+                           ctrl_states=["failed", "enabled"])
+        disc, total = self._run(peers)
+        self.assertEqual((disc, total), (0, 1))
+
+    def test_get_bdevs_exception_skips_peer(self):
+        peers = [_peer("p0"), _peer("p1")]
+        peers[0]._rpc.get_bdevs.side_effect = Exception("rpc timeout")
+        _set_peer_response(peers[1], bdev_present=True, ctrl_states=["enabled"])
+        disc, total = self._run(peers)
+        # p0 skipped (no vote), p1 enabled
+        self.assertEqual((disc, total), (0, 1))
+
+    def test_controller_list_exception_skips_peer(self):
+        peers = [_peer("p0"), _peer("p1")]
+        peers[0]._rpc.get_bdevs.return_value = [{"name": "x"}]
+        peers[0]._rpc.bdev_nvme_controller_list.side_effect = Exception("stuck")
+        _set_peer_response(peers[1], bdev_present=True, ctrl_states=["failed"])
+        disc, total = self._run(peers)
+        # p0 skipped, p1 disconnected
+        self.assertEqual((disc, total), (1, 1))
+
+    def test_peer_without_jm_vuid_excluded(self):
+        p_no_jm = _peer("p-nojm")
+        p_no_jm.jm_vuid = None
+        _set_peer_response(p_no_jm, bdev_present=True, ctrl_states=["failed"])
+        p_ok = _peer("p-ok")
+        _set_peer_response(p_ok, bdev_present=True, ctrl_states=["enabled"])
+        disc, total = self._run([p_no_jm, p_ok])
+        self.assertEqual((disc, total), (0, 1))  # nojm excluded; ok connected
+
+    def test_bdev_lookup_uses_namespace_suffix(self):
+        # Must query for remote_jm_{node}n1, not remote_jm_{node}.
+        peers = [_peer("p0")]
+        _set_peer_response(peers[0], bdev_present=True, ctrl_states=["enabled"])
+        self._run(peers)
+        peers[0]._rpc.get_bdevs.assert_called_once()
+        (arg,), _ = peers[0]._rpc.get_bdevs.call_args
+        self.assertEqual(arg, "remote_jm_target-noden1")
+
+    def test_controller_lookup_uses_no_namespace_suffix(self):
+        peers = [_peer("p0")]
+        _set_peer_response(peers[0], bdev_present=True, ctrl_states=["enabled"])
+        self._run(peers)
+        peers[0]._rpc.bdev_nvme_controller_list.assert_called_once()
+        (arg,), _ = peers[0]._rpc.bdev_nvme_controller_list.call_args
+        self.assertEqual(arg, "remote_jm_target-node")
+
+
+# ---------------------------------------------------------------------------
+# is_node_data_plane_disconnected[_quorum]
+# ---------------------------------------------------------------------------
+
+
+class TestDataPlaneDisconnectedPredicates(unittest.TestCase):
+
+    def _run_with_votes(self, votes):
+        """Patch _count_data_plane_votes to return (disc, total) directly."""
+        from simplyblock_core.services import storage_node_monitor as mod
+        target = _target()
+        with patch.object(mod, "_count_data_plane_votes", return_value=votes):
+            return (mod.is_node_data_plane_disconnected(target),
+                    mod.is_node_data_plane_disconnected_quorum(target))
+
+    def test_no_peers_both_false(self):
+        absolute, quorum = self._run_with_votes((0, 0))
+        self.assertFalse(absolute)
+        self.assertFalse(quorum)
+
+    def test_all_disconnected_both_true(self):
+        absolute, quorum = self._run_with_votes((3, 3))
+        self.assertTrue(absolute)
+        self.assertTrue(quorum)
+
+    def test_majority_disconnected_quorum_true_absolute_false(self):
+        absolute, quorum = self._run_with_votes((2, 3))
+        self.assertFalse(absolute)
+        self.assertTrue(quorum)
+
+    def test_minority_disconnected_both_false(self):
+        absolute, quorum = self._run_with_votes((1, 3))
+        self.assertFalse(absolute)
+        self.assertFalse(quorum)
+
+    def test_exact_half_quorum_false(self):
+        # With total=2 and disc=1, 1 > 2//2 -> 1 > 1 -> False.
+        absolute, quorum = self._run_with_votes((1, 2))
+        self.assertFalse(absolute)
+        self.assertFalse(quorum)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Replace the per-peer vote in `_count_data_plane_votes` (`simplyblock_core/services/storage_node_monitor.py`) from a `jc_get_jm_status` read of the `remote_jm_{target}n1: bool` flag to an actual NVMe controller state check on each peer.
- Two-step probe on each peer: first `bdev_get_bdevs(remote_jm_{target}n1)` (empty ⇒ abstain, avoids stalling on degraded ctrlrs), then `bdev_nvme_controller_list(remote_jm_{target})` with `state == "enabled"` as the "connected" criterion.

## Why
The old signal was wrong. `ultra/DISTR_v2/.../alg_journal.cpp::mjm_stat` is a sync-health map written only by the JC's replication/leveling state machine. It is never flipped to `false` on NVMe-TCP controller loss / bdev removal / peer death — the `SPDK_BDEV_EVENT_REMOVE` handler only sets `r_jm->b_io_blocked=true`, and the network-outage detector counts `b_jm_retry_connect` without touching `mjm_stat`. Result: a quietly-dead peer perpetually votes "connected", and the quorum wedges.

Observed in a live dual-outage test: `jc_get_jm_status` on three surviving peers returned `remote_jm_470ad6cd: true` 27 minutes after `sbctl sn shutdown --force` killed 470ad6cd's SPDK. `_check_peer_disconnected` therefore said "connected", `recreate_all_lvstores` chose the non-leader path, and the subsequent `firewall_set_port` call against the dead mgmt got `ECONNREFUSED` until `_abort_and_unblock` fired and flipped the restarting node back offline. Loop repeated ~14× before the task hit `max_retry`.

## Why the two-step probe
`bdev_nvme_get_controllers` can sit on locks for a ctrlr in `resetting` / `reconnect_is_delayed`; `bdev_get_bdevs` is a pure registry lookup. Checking the namespace bdev first means a vanished controller answers fast, without risking the quorum probe stalling during a reset storm.

## Test plan
- [x] `tests/test_data_plane_quorum.py` — 17 unit tests covering: happy paths, every non-enabled state (failed/resetting/etc.), multipath (any enabled path wins), bdev-absent abstain, bdev-present + empty ctrl list (inconsistent → disconnected), RPC exceptions on either probe, correct bdev/ctrl name suffixes, both `is_node_data_plane_disconnected` (absolute) and `is_node_data_plane_disconnected_quorum` (majority) with the boundary `(1, 2)` case.
- [x] Hotfix image deployed to mgmt CLI + `app_TasksRunnerRestart` + `app_WebAppAPI` + `app_StorageNodeMonitor` on the live cluster; verified `md5 = ae327d682ab901e64b2c6638d0256eba` in all four locations and the new code path present at lines 346 (`get_bdevs`) and 363 (`bdev_nvme_controller_list`).

## Follow-up (separate, data-plane)
The root of the staleness is in `ultra`: `mjm_stat[vuid][jm_name]` should be flipped to `false` by the bdev-remove callback and/or the network-outage detector. This PR does not fix that; it makes the CP no longer depend on that flag for liveness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)