### PR TITLE
restart: adopt peer's hublvol on takeover instead of recreating self's

### DIFF
--- a/simplyblock_core/models/storage_node.py
+++ b/simplyblock_core/models/storage_node.py
@@ -334,6 +334,49 @@ class StorageNode(BaseNodeObject):
         logger.info(f'Secondary hublvol exposed: {nqn} on port {hublvol_port}')
         return nqn
 
+    def adopt_hublvol(self, lvs_node, cluster_nqn):
+        """Adopt a peer's hublvol during LVS takeover.
+
+        ``self`` is the new leader (the restarting node); ``lvs_node`` is the
+        offline peer whose LVS is being taken over. The hublvol bdev must be
+        created for the TAKEN-OVER lvstore (``lvs_node.lvstore``) — not
+        ``self.lvstore``, which is self's own primary — and exposed via the
+        same NQN/port/UUID as the original so existing client paths keep
+        working after failover.
+
+        Idempotent: safe to call across restart retries. Both the create and
+        the subsystem expose layer are probe-guarded (expose_bdev filters
+        out existing listeners/namespaces, and create_hublvol returns
+        EEXIST on an already-existing bdev).
+        """
+        lvstore_name = lvs_node.lvstore
+        if not lvs_node.hublvol or not lvs_node.hublvol.uuid:
+            raise RPCException(
+                f"lvs_node {lvs_node.get_id()} has no hublvol metadata for {lvstore_name}"
+            )
+
+        bdev_name = f'{lvstore_name}/hublvol'
+        logger.info('Adopting hublvol %s on %s', bdev_name, self.get_id())
+        rpc_client = self.rpc_client()
+
+        if not rpc_client.get_bdevs(bdev_name):
+            if not rpc_client.bdev_lvol_create_hublvol(lvstore_name):
+                raise RPCException(f'Failed to create adopted hublvol for {lvstore_name}')
+        else:
+            logger.info('Adopted hublvol already exists: %s', bdev_name)
+
+        nqn = self.hublvol_nqn_for_lvstore(cluster_nqn, lvstore_name)
+        self.expose_bdev(
+            nqn=nqn,
+            bdev_name=bdev_name,
+            model_number=lvs_node.hublvol.model_number,
+            uuid=lvs_node.hublvol.uuid,
+            nguid=lvs_node.hublvol.nguid,
+            port=lvs_node.hublvol.nvmf_port,
+            ana_state="optimized",
+        )
+        return nqn
+
     def recreate_hublvol(self):
         """reCreate a hublvol for this node's lvstore.
 

--- a/simplyblock_core/storage_node_ops.py
+++ b/simplyblock_core/storage_node_ops.py
@@ -5415,11 +5415,11 @@ def recreate_lvstore(snode, force=False, lvs_primary=None, activation_mode=False
             if is_takeover:
                 try:
                     cluster = db_controller.get_cluster_by_id(snode.cluster_id)
-                    snode.create_hublvol(cluster_nqn=cluster.nqn)
-                    logger.info("Created and exposed hublvol on new leader %s for %s", snode.get_id(), lvs_name)
+                    snode.adopt_hublvol(lvs_node, cluster.nqn)
+                    logger.info("Adopted hublvol on new leader %s for %s", snode.get_id(), lvs_name)
                 except Exception as e:
-                    logger.error("Error creating hublvol on new leader: %s", e)
-                    _abort_restart_and_unblock(f"create_hublvol on new leader failed: {e}")
+                    logger.error("Error adopting hublvol on new leader: %s", e)
+                    _abort_restart_and_unblock(f"adopt_hublvol on new leader failed: {e}")
             else:
                 try:
                     if not snode.recreate_hublvol():

--- a/simplyblock_core/storage_node_ops.py
+++ b/simplyblock_core/storage_node_ops.py
@@ -4376,24 +4376,44 @@ def execute_on_leader_with_failover(all_nodes, lvs_name, operation_fn):
 
 
 def _check_peer_disconnected(peer_node, lvs_peer_ids=None):
-    """Method 1: Check if a peer node is data-plane disconnected via JM quorum.
+    """Check if a peer node should be treated as disconnected for the purpose
+    of routing (takeover vs. non-leader path) and peer-port-block decisions.
 
-    Per design: we do NOT rely on node statuses anywhere in restart,
-    but solely on disconnect state and RPC behaviour.
+    Returns True if peer is disconnected (should be skipped), False otherwise.
 
-    Uses is_node_data_plane_disconnected_quorum — checks if the majority of
-    still-online nodes cannot reach the JM of peer_node.
+    Two signals, first match wins:
 
-    Returns True if peer is disconnected (should be skipped), False if connected.
+      1. Mgmt ground truth (FDB status). If FDB already says the peer is
+         OFFLINE / REMOVED / UNREACHABLE, trust it immediately — mgmt has
+         observed the peer leaving the cluster. Attempting to port-block
+         such a peer's mgmt API will only hit ECONNREFUSED and, after 5×
+         retries, abort the entire restart with a misleading "LVStore
+         recovery failed" event. IN_SHUTDOWN / RESTARTING are deliberately
+         NOT in this list — those are transient states the runner owns;
+         preempting another node's leadership during its own restart
+         would be incorrect.
+
+      2. Data-plane JM quorum (legacy path). Only reached if mgmt says
+         the peer is in an "alive" state. Useful to detect fabric
+         partitions where mgmt is still reachable but the data plane
+         isn't — the quorum reads NVMe controller state on surviving
+         peers (see storage_node_monitor::_count_data_plane_votes).
     """
     from simplyblock_core.services.storage_node_monitor import is_node_data_plane_disconnected_quorum
 
+    if peer_node.status in (StorageNode.STATUS_OFFLINE,
+                            StorageNode.STATUS_REMOVED,
+                            StorageNode.STATUS_UNREACHABLE):
+        logger.info("Peer %s mgmt status is %s — treating as disconnected",
+                    peer_node.get_id(), peer_node.status)
+        return True
+
     if is_node_data_plane_disconnected_quorum(peer_node, lvs_peer_ids=lvs_peer_ids):
-        logger.info("Peer %s is data-plane disconnected (JM quorum confirmed), will skip",
+        logger.info("Peer %s is data-plane disconnected (NVMe-ctrlr quorum confirmed), will skip",
                      peer_node.get_id())
         return True
 
-    logger.info("Peer %s is data-plane connected (JM quorum check)", peer_node.get_id())
+    logger.info("Peer %s is data-plane connected (NVMe-ctrlr quorum check)", peer_node.get_id())
     return False
 
 
@@ -4628,14 +4648,21 @@ def recreate_lvstore_on_non_leader(snode, leader_node, primary_node, activation_
         # racing into a half-reconstructed lvstore. Silently skipping the
         # block (as we used to do on ConnectionRefused) lets the leader
         # keep serving reads/writes while we examine — which has produced
-        # CRC mismatches and lvol drops on the restarting peer. So retry
-        # aggressively and, if it still can't land, abort the restart
-        # unless force=True.
+        # CRC mismatches and lvol drops on the restarting peer. So retry,
+        # and if it still can't land, abort the restart unless force=True.
+        #
+        # Budget: 3 attempts × FirewallClient(timeout=3, retry=1) × 1s sleep
+        # between attempts → worst-case ~15s abort. Previously 5× ×
+        # (timeout=5, retry=5) × 2s = ~140s, which made every iteration
+        # against a dead-mgmt leader stall the restart task for minutes.
+        # The FDB-status short-circuit in _check_peer_disconnected should
+        # already route such peers to the takeover path before we reach
+        # here; keeping a short local budget protects against stragglers.
         last_err = None
-        attempts = 5
+        attempts = 3
         for attempt in range(1, attempts + 1):
             try:
-                fw_api = FirewallClient(leader_node, timeout=5, retry=5)
+                fw_api = FirewallClient(leader_node, timeout=3, retry=1)
                 fw_api.firewall_set_port(leader_lvs_port, port_type, "block", leader_node.rpc_port)
                 tcp_ports_events.port_deny(leader_node, leader_lvs_port)
                 leader_port_blocked = True
@@ -4647,7 +4674,7 @@ def recreate_lvstore_on_non_leader(snode, leader_node, primary_node, activation_
                     "Port-block attempt %d/%d failed for leader %s on %s: %s",
                     attempt, attempts, leader_node.get_id(), primary_node.lvstore, e)
                 if attempt < attempts:
-                    time.sleep(2)
+                    time.sleep(1)
         if not leader_port_blocked:
             msg = (f"Failed to block leader {leader_node.get_id()} port "
                    f"{leader_lvs_port} after {attempts} attempts for "
@@ -4828,10 +4855,10 @@ def recreate_lvstore_on_non_leader(snode, leader_node, primary_node, activation_
         # after our attempts so another retry loop keeps trying.
         if leader_port_blocked:
             unblocked = False
-            attempts = 5
+            attempts = 3
             for attempt in range(1, attempts + 1):
                 try:
-                    fw_api = FirewallClient(leader_node, timeout=5, retry=5)
+                    fw_api = FirewallClient(leader_node, timeout=3, retry=1)
                     fw_api.firewall_set_port(leader_lvs_port, port_type, "allow", leader_node.rpc_port)
                     tcp_ports_events.port_allowed(leader_node, leader_lvs_port)
                     unblocked = True
@@ -4841,7 +4868,7 @@ def recreate_lvstore_on_non_leader(snode, leader_node, primary_node, activation_
                         "Port-unblock attempt %d/%d failed for leader %s on %s: %s",
                         attempt, attempts, leader_node.get_id(), primary_node.lvstore, e)
                     if attempt < attempts:
-                        time.sleep(2)
+                        time.sleep(1)
             if not unblocked:
                 logger.error(
                     "Failed to unblock leader %s port %s for %s after %d attempts; "

--- a/tests/test_failover_failback_combinations.py
+++ b/tests/test_failover_failback_combinations.py
@@ -1266,8 +1266,17 @@ class TestRecreateLvstoreNonLeaderPortBlockFailure(unittest.TestCase):
             self, mock_db_cls, mock_create_bdev, mock_rpc_cls, mock_fw_cls,
             mock_snode_client, mock_set_status, mock_tasks, mock_tcp_events,
             mock_storage_events, _mock_disc, _mock_phase, _mock_handle, _mock_sleep):
-        """All 5 port-block attempts fail → restart aborts, leader kept
-        untouched, node goes offline. No continuing with an unblocked leader."""
+        """All port-block attempts fail → restart aborts, leader kept
+        untouched, node goes offline. No continuing with an unblocked leader.
+
+        The attempt budget was tightened from 5 to 3 (PR #996) — an aborted
+        iteration now costs ~15 s instead of ~140 s, giving the outer retry
+        loop more chances to re-evaluate _check_peer_disconnected after
+        NVMe-TCP keep-alive propagates. The FDB-status short-circuit in
+        _check_peer_disconnected should route dead-mgmt peers to takeover
+        before we ever reach this code; the reduced budget protects the
+        remaining fabric-partition-while-mgmt-reachable case.
+        """
         secondary, primary, _rpc, fw = self._setup(
             mock_rpc_cls, mock_db_cls, mock_create_bdev, mock_fw_cls,
             fw_set_port_side_effect=ConnectionRefusedError("Connection refused"),
@@ -1277,8 +1286,8 @@ class TestRecreateLvstoreNonLeaderPortBlockFailure(unittest.TestCase):
             recreate_lvstore_on_non_leader(
                 secondary, leader_node=primary, primary_node=primary, force=False)
         self.assertIn("Failed to block leader", str(cm.exception))
-        # All 5 attempts must have been tried
-        self.assertEqual(fw.firewall_set_port.call_count, 5)
+        # All 3 attempts must have been tried
+        self.assertEqual(fw.firewall_set_port.call_count, 3)
         # Abort path sets the restarting node offline
         mock_set_status.assert_any_call(secondary.get_id(), StorageNode.STATUS_OFFLINE)
 
@@ -1300,8 +1309,9 @@ class TestRecreateLvstoreNonLeaderPortBlockFailure(unittest.TestCase):
             self, mock_db_cls, mock_create_bdev, mock_rpc_cls, mock_fw_cls,
             mock_snode_client, mock_set_status, mock_tasks, mock_tcp_events,
             mock_storage_events, _mock_disc, _mock_phase, _mock_handle, _mock_sleep):
-        """With force=True, 5 failed block attempts don't abort — restart
-        proceeds despite the race risk (operator explicit choice)."""
+        """With force=True, all failed block attempts don't abort — restart
+        proceeds despite the race risk (operator explicit choice). Attempt
+        count was tightened from 5 to 3 (PR #996)."""
         secondary, primary, _rpc, fw = self._setup(
             mock_rpc_cls, mock_db_cls, mock_create_bdev, mock_fw_cls,
             fw_set_port_side_effect=ConnectionRefusedError("Connection refused"),
@@ -1313,7 +1323,7 @@ class TestRecreateLvstoreNonLeaderPortBlockFailure(unittest.TestCase):
         result = recreate_lvstore_on_non_leader(
             secondary, leader_node=primary, primary_node=primary, force=True)
         self.assertTrue(result)
-        self.assertEqual(fw.firewall_set_port.call_count, 5)
+        self.assertEqual(fw.firewall_set_port.call_count, 3)
 
     @patch("simplyblock_core.storage_node_ops.time.sleep", return_value=None)
     @patch("simplyblock_core.storage_node_ops._check_peer_disconnected",

--- a/tests/test_hublvol_unit.py
+++ b/tests/test_hublvol_unit.py
@@ -268,6 +268,125 @@ class TestRecreateHublvolUnit(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
+# TestAdoptHublvolUnit
+# ---------------------------------------------------------------------------
+
+class TestAdoptHublvolUnit(unittest.TestCase):
+    """adopt_hublvol — takeover leader creates hub bdev for the taken-over LVS
+    and re-exposes it under the same NQN/port/UUID as the original primary.
+
+    The bug this pins:
+      - ``create_hublvol`` on the takeover node used ``self.lvstore`` (self's
+        OWN primary), not the taken-over lvstore → EEXIST against self's
+        already-present primary hublvol bdev, and wrong bdev name if it had
+        not been there.
+      - No probe-before-create, so the second restart retry was guaranteed to
+        hit EEXIST on the adopted bdev.
+
+    adopt_hublvol must (a) target ``lvs_node.lvstore``, (b) reuse
+    ``lvs_node.hublvol`` metadata so clients see the same NQN/port/UUID,
+    (c) probe before creating, (d) be safely re-entrant across retries.
+    """
+
+    _TAKEOVER_LVS = "LVS_remote"
+
+    def setUp(self):
+        # Takeover node has its own primary lvstore (LVS_self) and a
+        # separate adopted lvstore (LVS_remote).
+        self.takeover_node = _make_node(_PRIMARY_IP, "LVS_self", jm_vuid=100)
+        self.takeover_node.hublvol = _make_hublvol("LVS_self", _PRIMARY_PORT)
+
+        # The offline peer whose LVS is being taken over.
+        self.offline_peer = _make_node(_SECONDARY_IP, self._TAKEOVER_LVS, jm_vuid=200)
+        self.offline_peer.hublvol = _make_hublvol(self._TAKEOVER_LVS, 4431)
+
+        self.rpc = _mock_rpc()
+        patcher = patch(
+            'simplyblock_core.models.storage_node.RPCClient',
+            return_value=self.rpc,
+        )
+        self.addCleanup(patcher.stop)
+        patcher.start()
+
+    def test_creates_bdev_for_taken_over_lvstore_not_self(self):
+        """bdev_lvol_create_hublvol must target the peer's lvstore, not self's."""
+        self.rpc.get_bdevs.return_value = []  # bdev absent
+        self.takeover_node.adopt_hublvol(self.offline_peer, _CLUSTER_NQN)
+        self.rpc.bdev_lvol_create_hublvol.assert_called_once_with(self._TAKEOVER_LVS)
+
+    def test_skips_create_when_bdev_already_exists(self):
+        """Idempotent: probe succeeds → no create call, no EEXIST."""
+        self.rpc.get_bdevs.return_value = [
+            {'name': f'{self._TAKEOVER_LVS}/hublvol'}
+        ]
+        self.takeover_node.adopt_hublvol(self.offline_peer, _CLUSTER_NQN)
+        self.rpc.bdev_lvol_create_hublvol.assert_not_called()
+
+    def test_exposes_with_peer_hublvol_metadata(self):
+        """Subsystem must be exposed with the peer's existing UUID/port so
+        that surviving clients don't see a new NQN and keep their paths."""
+        self.rpc.get_bdevs.return_value = [{}]
+        self.takeover_node.adopt_hublvol(self.offline_peer, _CLUSTER_NQN)
+        listener_calls = self.rpc.listeners_create.call_args_list
+        assert listener_calls, "listeners_create must be called"
+        for c in listener_calls:
+            kwargs = c.kwargs
+            args = c.args
+            trsvcid = kwargs.get('trsvcid', args[3] if len(args) > 3 else None)
+            assert trsvcid == self.offline_peer.hublvol.nvmf_port, (
+                f"Adopted hublvol must use peer port "
+                f"{self.offline_peer.hublvol.nvmf_port}; got {trsvcid}"
+            )
+        add_ns_call = self.rpc.nvmf_subsystem_add_ns.call_args
+        assert add_ns_call is not None
+        called_uuid = add_ns_call.kwargs.get('uuid')
+        assert called_uuid == self.offline_peer.hublvol.uuid, (
+            "Adopted namespace must reuse peer hublvol UUID for client continuity"
+        )
+
+    def test_exposes_under_shared_nqn_for_lvs(self):
+        """NQN must be the deterministic shared hublvol NQN for the taken-over
+        lvstore — not self's primary NQN."""
+        self.rpc.get_bdevs.return_value = [{}]
+        self.takeover_node.adopt_hublvol(self.offline_peer, _CLUSTER_NQN)
+        expected = f"{_CLUSTER_NQN}:hublvol:{self._TAKEOVER_LVS}"
+        create_call = self.rpc.subsystem_create.call_args
+        called_nqn = create_call.kwargs.get('nqn') or create_call.args[0]
+        assert called_nqn == expected, f"NQN must be {expected}; got {called_nqn}"
+
+    def test_exposes_with_optimized_ana(self):
+        """Takeover leader is the NEW primary for the adopted LVS → ANA optimized."""
+        self.rpc.get_bdevs.return_value = [{}]
+        self.takeover_node.adopt_hublvol(self.offline_peer, _CLUSTER_NQN)
+        listener_calls = self.rpc.listeners_create.call_args_list
+        assert listener_calls
+        for c in listener_calls:
+            kwargs = c.kwargs
+            args = c.args
+            ana_state = kwargs.get('ana_state', args[4] if len(args) > 4 else None)
+            assert ana_state == 'optimized', (
+                f"Adopted hublvol must have ana_state=optimized; got {ana_state}"
+            )
+
+    def test_does_not_mutate_self_hublvol(self):
+        """Takeover runs in addition to self's own primary — self.hublvol
+        (self's own lvstore's hub) must not be overwritten by adoption."""
+        self.rpc.get_bdevs.return_value = []
+        original_self_hublvol = self.takeover_node.hublvol
+        self.takeover_node.adopt_hublvol(self.offline_peer, _CLUSTER_NQN)
+        assert self.takeover_node.hublvol is original_self_hublvol
+
+    def test_raises_when_peer_has_no_hublvol_metadata(self):
+        """If the offline peer has no hublvol metadata in FDB, adopt must
+        fail loudly — silent no-op would leave IO unreachable."""
+        from simplyblock_core.rpc_client import RPCException
+        self.offline_peer.hublvol = None
+        with self.assertRaises(RPCException):
+            self.takeover_node.adopt_hublvol(self.offline_peer, _CLUSTER_NQN)
+        self.rpc.bdev_lvol_create_hublvol.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
 # TestConnectToHublvolUnit
 # ---------------------------------------------------------------------------
 

--- a/tests/test_peer_disconnect.py
+++ b/tests/test_peer_disconnect.py
@@ -1,0 +1,108 @@
+# coding=utf-8
+"""
+test_peer_disconnect.py — regression tests for the FDB-status short-circuit
+added to ``simplyblock_core.storage_node_ops._check_peer_disconnected``.
+
+Background: the restart path uses ``_check_peer_disconnected(peer_node)`` to
+decide between the takeover path (recreate as leader for an offline peer's
+LVS) and the non-leader path (port-block the leader and recreate as
+secondary). Before this change, only the data-plane quorum — which reads
+stale NVMe-controller state on surviving peers — decided. In practice,
+when mgmt had already observed a peer leaving the cluster (status flipped
+to OFFLINE in FDB), the quorum still reported "connected" for ~10-30 s
+until NVMe-TCP keep-alive propagated on surviving peers. During that
+window the code went into the non-leader path, tried to port-block the
+dead peer's mgmt (ECONNREFUSED), retried 5×, and aborted the restart with
+a misleading ``"LVStore recovery failed"`` event.
+
+This test pins: ``_check_peer_disconnected`` now short-circuits to True
+for ``OFFLINE`` / ``REMOVED`` / ``UNREACHABLE`` in FDB, without reaching
+the data-plane quorum. Transient states that the runner owns
+(``IN_SHUTDOWN`` / ``RESTARTING``) deliberately fall through to the
+quorum — preempting another node's leadership during its own restart
+would be incorrect.
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from simplyblock_core.models.storage_node import StorageNode
+
+
+def _node(uuid="peer-1", status=StorageNode.STATUS_ONLINE):
+    n = MagicMock(spec=StorageNode)
+    n.get_id.return_value = uuid
+    n.status = status
+    return n
+
+
+class TestCheckPeerDisconnected(unittest.TestCase):
+
+    def _run(self, status, quorum_result=False):
+        # _check_peer_disconnected imports ``is_node_data_plane_disconnected_quorum``
+        # locally from the services module at call time, so the patch must target
+        # the source module (where the symbol lives).
+        from simplyblock_core import storage_node_ops as mod
+        peer = _node(status=status)
+        with patch(
+            "simplyblock_core.services.storage_node_monitor.is_node_data_plane_disconnected_quorum",
+            return_value=quorum_result) as q:
+            return mod._check_peer_disconnected(peer), q
+
+    # -----------------------------------------------------------------
+    # Short-circuit branches — FDB says the peer is gone
+    # -----------------------------------------------------------------
+
+    def test_offline_short_circuits_to_disconnected(self):
+        # FDB OFFLINE is the canonical "mgmt confirmed peer left" state.
+        # Must return True without calling the data-plane quorum.
+        disconnected, mock_quorum = self._run(StorageNode.STATUS_OFFLINE)
+        self.assertTrue(disconnected)
+        mock_quorum.assert_not_called()
+
+    def test_removed_short_circuits_to_disconnected(self):
+        disconnected, mock_quorum = self._run(StorageNode.STATUS_REMOVED)
+        self.assertTrue(disconnected)
+        mock_quorum.assert_not_called()
+
+    def test_unreachable_short_circuits_to_disconnected(self):
+        disconnected, mock_quorum = self._run(StorageNode.STATUS_UNREACHABLE)
+        self.assertTrue(disconnected)
+        mock_quorum.assert_not_called()
+
+    # -----------------------------------------------------------------
+    # Transient states — do NOT short-circuit, fall through to quorum
+    # -----------------------------------------------------------------
+
+    def test_in_shutdown_falls_through_to_quorum(self):
+        # Another node is actively being shut down. That's brief — quorum
+        # decides whether to preempt.
+        disconnected, mock_quorum = self._run(StorageNode.STATUS_IN_SHUTDOWN,
+                                              quorum_result=False)
+        self.assertFalse(disconnected)
+        mock_quorum.assert_called_once()
+
+    def test_restarting_falls_through_to_quorum(self):
+        disconnected, mock_quorum = self._run(StorageNode.STATUS_RESTARTING,
+                                              quorum_result=False)
+        self.assertFalse(disconnected)
+        mock_quorum.assert_called_once()
+
+    def test_online_falls_through_to_quorum(self):
+        disconnected, mock_quorum = self._run(StorageNode.STATUS_ONLINE,
+                                              quorum_result=False)
+        self.assertFalse(disconnected)
+        mock_quorum.assert_called_once()
+
+    def test_online_with_quorum_disconnect_returns_true(self):
+        # Mgmt says ONLINE but data-plane quorum confirms the peer is gone
+        # (classic fabric partition where mgmt is still reachable). Function
+        # must respect the quorum result.
+        disconnected, mock_quorum = self._run(StorageNode.STATUS_ONLINE,
+                                              quorum_result=True)
+        self.assertTrue(disconnected)
+        mock_quorum.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_secondary_promotion.py
+++ b/tests/test_secondary_promotion.py
@@ -231,6 +231,7 @@ class TestSecondaryPromotion(unittest.TestCase):
         for n in [secondary, tertiary, primary]:
             n.rpc_client = MagicMock(return_value=mock_rpc)
             n.create_hublvol = MagicMock()
+            n.adopt_hublvol = MagicMock()
             n.create_secondary_hublvol = MagicMock()
             n.recreate_hublvol = MagicMock()
             n.connect_to_hublvol = MagicMock()
@@ -249,8 +250,17 @@ class TestSecondaryPromotion(unittest.TestCase):
         # Should have called set_leader with leader=True
         mock_rpc.bdev_lvol_set_leader.assert_called_with("LVS_100", leader=True)
 
-        # In takeover, snode creates a primary hublvol (it's becoming leader)
-        secondary.create_hublvol.assert_called_once()
+        # In takeover, snode adopts the offline primary's hublvol under the
+        # original primary's lvstore name/NQN/port (same-name invariant) —
+        # NOT create_hublvol on self's own primary.
+        secondary.adopt_hublvol.assert_called_once()
+        secondary.create_hublvol.assert_not_called()
+        # Adoption must pass the offline primary node (so lvs_node.lvstore
+        # drives the bdev name, keeping the primary→takeover hublvol name
+        # identical).
+        adopt_args = secondary.adopt_hublvol.call_args
+        adopted_peer = adopt_args.args[0] if adopt_args.args else adopt_args.kwargs.get("lvs_node")
+        self.assertIs(adopted_peer, primary)
 
     @patch("simplyblock_core.storage_node_ops._check_peer_disconnected", return_value=False)
     @patch("simplyblock_core.storage_node_ops._set_restart_phase")


### PR DESCRIPTION
## Summary

Fix takeover path in recreate_lvstore(is_takeover=True) — was calling ``snode.create_hublvol()`` which uses ``self.lvstore`` (takeover node's OWN primary), not the taken-over lvstore. EEXIST against self's primary hublvol, abort.

Bug was latent until PR #996 — see commit message for history (pre-PR #993 stale quorum hid it; pre-#996 port-block abort hid it).

New ``StorageNode.adopt_hublvol(lvs_node, cluster_nqn)``:
- bdev name ``{lvs_node.lvstore}/hublvol`` — **identical** to the offline primary's
- NQN from same shared scheme, UUID/NGUID/model/port reused from peer's FDB record
- probe-before-create (idempotent across retries)
- does NOT mutate self.hublvol (self's own primary coexists)

Depends on: #996.

## Test plan
- [x] 7 new TestAdoptHublvolUnit cases
- [x] 67 related tests passing
- [ ] Hotfix deploy to live cluster
- [ ] Next restart reaches COMPLETED phase

🤖 Generated with [Claude Code](https://claude.com/claude-code)