### PR TITLE
tasks_runner_port_allow: include STATUS_DOWN in candidate filtering logic

### DIFF
--- a/simplyblock_core/services/tasks_runner_port_allow.py
+++ b/simplyblock_core/services/tasks_runner_port_allow.py
@@ -27,7 +27,8 @@ def _get_lvs_leader(lvs_name, candidates, local_node_id=None):
     for candidate in candidates:
         if not candidate:
             continue
-        if candidate.get_id() != local_node_id and candidate.status != StorageNode.STATUS_ONLINE:
+        if candidate.get_id() != local_node_id and candidate.status not in [StorageNode.STATUS_ONLINE, StorageNode.STATUS_DOWN]:
+            logger.info(f"Skipping candidate {candidate.get_id()} because status is {candidate.status}",)
             continue
         try:
             if lvol_controller.is_node_leader(candidate, lvs_name):


### PR DESCRIPTION
Fix validation issue that prevents the node lvstore leader check:

`2026-04-24 22:01:26,932: 140288408576768: INFO: lVol store Info:
2026-04-24 22:01:26,960: 140288408576768: WARNING: No leader found for LVS_3636 during port_allow on 5475265e-e257-497f-ac52-eee35695355d; attempting local restore
2026-04-24 22:01:26,960: 140288408576768: DEBUG: From: 192.168.10.204, Requesting method: bdev_lvol_set_lvs_opts, params: {'lvs_name': 'LVS_3636', 'groupid': 3636, 'subsystem_port': 4432, 'role': 'primary'}
2026-04-24 22:01:26,992: 140288408576768: DEBUG: Response: status_code: 200
2026-04-24 22:01:26,992: 140288408576768: DEBUG: Response json: {"jsonrpc": "2.0", "id": 1, "result": true}
2026-04-24 22:01:26,992: 140288408576768: DEBUG: From: 192.168.10.204, Requesting method: bdev_lvol_set_leader_all, params: {'lvs_name': 'LVS_3636', 'lvs_leadership': True, 'bs_nonleadership': False}
2026-04-24 22:01:27,025: 140288408576768: DEBUG: Response: status_code: 200
2026-04-24 22:01:27,026: 140288408576768: DEBUG: Response json: {"jsonrpc": "2.0", "id": 1, "result": true}
2026-04-24 22:01:27,026: 140288408576768: WARNING: No leader available for LVS_3636, retry task`