### PR TITLE
fix cross cluster backup restore

### DIFF
--- a/simplyblock_core/controllers/backup_controller.py
+++ b/simplyblock_core/controllers/backup_controller.py
@@ -627,15 +627,16 @@ def import_backups(s3_metadata_list, cluster_id=None):
         if not backup_id:
             continue
 
-        # Check if already exists
-        try:
-            db_controller.get_backup_by_id(backup_id)
-            continue  # already imported
-        except KeyError:
-            pass
-
         source_cluster = meta.get("cluster_id", "")
         target_cluster = cluster_id or source_cluster
+
+        # Skip only if already registered for the target cluster
+        try:
+            existing = db_controller.get_backup_by_id(backup_id)
+            if existing.cluster_id == target_cluster:
+                continue  # already imported for this cluster
+        except KeyError:
+            pass
 
         backup = Backup()
         backup.uuid = backup_id


### PR DESCRIPTION
currently when I have 2 cluster and when I import an backup into a target cluster I get this error

```
# sbctl backup import /app/backup1.json --cluster-id 81932010-8c06-4acd-b14a-51f5c3fca425
Imported 0 backup(s)
True
```

### testing

```
# export SRC_CLUSTER=bfa260ce-06a7-4bcb-a843-813d0be633af
# export TARGET_CLUSTER=81932010-8c06-4acd-b14a-51f5c3fca425


/app# sbctl backup export --lvol pvc-7fe87aa9-c6c3-4dc6-9baf-94696b6ccec7 --cluster  $SRC_CLUSTER -o backup1.json
Exported 1 backup(s) to backup1.json
True
/app# sbctl backup import /app/backup1.json --cluster-id $TARGET_CLUSTER
Imported 1 backup(s)
True
/app# 
```
