### PR TITLE
cross cluster restore: fix issue with source-switch to local

### DIFF
--- a/simplyblock_core/controllers/backup_controller.py
+++ b/simplyblock_core/controllers/backup_controller.py
@@ -202,8 +202,8 @@ def create_s3_bdev(node, backup_config):
         return False
 
     try:
-        ret = rpc_client.bdev_s3_add_bucket_name(s3_bdev_name, bucket_name)
-        if not ret:
+        ret, err = rpc_client.bdev_s3_add_bucket_name(s3_bdev_name, bucket_name)
+        if not ret and not (err and err.get("code") == -17):
             logger.warning(f"Failed to set bucket name on S3 bdev {s3_bdev_name}")
             return False
         logger.info(f"S3 bdev bucket set: {bucket_name} on {s3_bdev_name}")
@@ -752,8 +752,8 @@ def switch_backup_source(cluster_id, source_cluster_id):
                 node.mgmt_ip, node.rpc_port,
                 node.rpc_username, node.rpc_password)
             s3_bdev_name = f"s3_{node.lvstore}"
-            ret = rpc_client.bdev_s3_add_bucket_name(s3_bdev_name, bucket_name)
-            if not ret:
+            ret, err = rpc_client.bdev_s3_add_bucket_name(s3_bdev_name, bucket_name)
+            if not ret and not (err and err.get("code") == -17):
                 errors.append(f"Node {node.get_id()}: failed to set bucket")
             else:
                 logger.info(f"Switched S3 bucket to {bucket_name} on node {node.get_id()}")

--- a/simplyblock_core/rpc_client.py
+++ b/simplyblock_core/rpc_client.py
@@ -1528,8 +1528,9 @@ class RPCClient:
         Args:
             name: S3 bdev name (e.g. 's3_LVS_1234')
             bucket_name: S3/MinIO bucket name to use for data storage
+        Returns (result, error) tuple.
         """
-        return self._request("bdev_s3_add_bucket_name", {
+        return self._request2("bdev_s3_add_bucket_name", {
             "name": name,
             "bucket_name": bucket_name,
         })

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -281,7 +281,7 @@ class TestCreateS3Bdev(unittest.TestCase):
     def test_success(self, MockRPC, mock_boto3_client):
         mock_rpc = MockRPC.return_value
         mock_rpc.bdev_s3_create.return_value = True
-        mock_rpc.bdev_s3_add_bucket_name.return_value = True
+        mock_rpc.bdev_s3_add_bucket_name.return_value = (True, None)
         mock_rpc.bdev_lvol_s3_bdev.return_value = True
         mock_s3 = mock_boto3_client.return_value
         mock_s3.head_bucket.return_value = {}
@@ -328,7 +328,7 @@ class TestCreateS3Bdev(unittest.TestCase):
     def test_bucket_name_fails(self, MockRPC, mock_boto3_client):
         mock_rpc = MockRPC.return_value
         mock_rpc.bdev_s3_create.return_value = True
-        mock_rpc.bdev_s3_add_bucket_name.return_value = None
+        mock_rpc.bdev_s3_add_bucket_name.return_value = (None, {"code": -1, "message": "error"})
         mock_s3 = mock_boto3_client.return_value
         mock_s3.head_bucket.return_value = {}
 
@@ -343,7 +343,7 @@ class TestCreateS3Bdev(unittest.TestCase):
     def test_attach_fails(self, MockRPC, mock_boto3_client):
         mock_rpc = MockRPC.return_value
         mock_rpc.bdev_s3_create.return_value = True
-        mock_rpc.bdev_s3_add_bucket_name.return_value = True
+        mock_rpc.bdev_s3_add_bucket_name.return_value = (True, None)
         mock_rpc.bdev_lvol_s3_bdev.return_value = None
         mock_s3 = mock_boto3_client.return_value
         mock_s3.head_bucket.return_value = {}
@@ -358,7 +358,7 @@ class TestCreateS3Bdev(unittest.TestCase):
     def test_local_testing_params(self, MockRPC, mock_boto3_client):
         mock_rpc = MockRPC.return_value
         mock_rpc.bdev_s3_create.return_value = True
-        mock_rpc.bdev_s3_add_bucket_name.return_value = True
+        mock_rpc.bdev_s3_add_bucket_name.return_value = (True, None)
         mock_rpc.bdev_lvol_s3_bdev.return_value = True
         mock_s3 = mock_boto3_client.return_value
         mock_s3.head_bucket.return_value = {}
@@ -1001,8 +1001,8 @@ class TestImportBackups(unittest.TestCase):
 
         from simplyblock_core.controllers.backup_controller import import_backups
         count = import_backups([
-            {"backup_id": "b-1", "lvol_id": "l-1"},
-            {"backup_id": "b-2", "lvol_id": "l-1"},
+            {"backup_id": "b-1", "lvol_id": "l-1", "cluster_id": "cluster-1"},
+            {"backup_id": "b-2", "lvol_id": "l-1", "cluster_id": "cluster-1"},
         ])
 
         self.assertEqual(count, 1)


### PR DESCRIPTION
when I ran `sbctl backup source-switch local` after restore, I get the below error

```
Error: Node 89e67cb5: failed to set bucket; Node d2cd0bdb: failed to set bucket; Node f739a297: failed to set bucket

```

This is because `bdev_s3_add_bucket_name` RPC returned `{"error": {"code": -17, "message": "File exists"}}` on all 3 nodes when switching back to the local source. The fix treats `-17 (EXIST)` as success since the bucket is already registered on the node, which is the correct state.


### testing

and the switch to local
```
# sbctl backup source-switch local
/usr/local/lib/python3.9/site-packages/boto3/compat.py:89: PythonDeprecationWarning: Boto3 will no longer support Python 3.9 starting April 29, 2026. To continue receiving service updates, bug fixes, and security updates please upgrade to Python 3.10 or later. More information can be found here: https://aws.amazon.com/blogs/developer/python-support-policy-updates-for-aws-sdks-and-tools/
  warnings.warn(warning, PythonDeprecationWarning)
2026-04-27 13:28:26,793: 139792146289408: INFO: Switched S3 bucket to simplyblock-backup-81932010-8c06-4acd-b14a-51f5c3fca425 on node 89e67cb5-7541-43c3-b06a-67c33a4cd6dd
2026-04-27 13:28:26,802: 139792146289408: INFO: Switched S3 bucket to simplyblock-backup-81932010-8c06-4acd-b14a-51f5c3fca425 on node d2cd0bdb-1380-40aa-8075-f8a983a522e3
2026-04-27 13:28:26,810: 139792146289408: INFO: Switched S3 bucket to simplyblock-backup-81932010-8c06-4acd-b14a-51f5c3fca425 on node f739a297-bc99-4c48-8762-8d7c327abb28
Switched to local backup source
True
/app#
```