### PR TITLE
setup LVOL status as restore_failed on failed restore

### DIFF
--- a/simplyblock_core/controllers/backup_events.py
+++ b/simplyblock_core/controllers/backup_events.py
@@ -37,6 +37,11 @@ def backup_restore_completed(cluster_id, node_id, backup, lvol_name, caused_by=e
                   f"Backup restored: {backup.uuid} -> {lvol_name}", caused_by, ec.EVENT_STATUS_CHANGE)
 
 
+def backup_restore_failed(cluster_id, node_id, backup, lvol_name, reason, caused_by=ec.CAUSED_BY_CLI):
+    _backup_event(cluster_id, node_id, backup,
+                  f"Backup restore failed: {backup.uuid} -> {lvol_name}: {reason}", caused_by, ec.EVENT_STATUS_CHANGE)
+
+
 def backup_merge_completed(cluster_id, node_id, backup, old_backup_id, caused_by=ec.CAUSED_BY_CLI):
     _backup_event(cluster_id, node_id, backup,
                   f"Backup merged: {old_backup_id} into {backup.uuid}", caused_by, ec.EVENT_STATUS_CHANGE)

--- a/simplyblock_core/models/lvol_model.py
+++ b/simplyblock_core/models/lvol_model.py
@@ -14,6 +14,7 @@ class LVol(BaseModel):
     STATUS_IN_DELETION = 'in_deletion'
     STATUS_RESTORING = 'restoring'
     STATUS_DELETED = 'deleted'
+    STATUS_RESTORE_FAILED = 'restore_failed'
 
     _STATUS_CODE_MAP = {
         STATUS_ONLINE: 1,
@@ -22,6 +23,7 @@ class LVol(BaseModel):
         STATUS_IN_CREATION: 4,
         STATUS_RESTORING: 5,
         STATUS_DELETED: 6,
+        STATUS_RESTORE_FAILED: 7,
     }
 
     base_bdev: str = ""

--- a/simplyblock_core/services/tasks_runner_backup.py
+++ b/simplyblock_core/services/tasks_runner_backup.py
@@ -152,6 +152,22 @@ def _set_lvol_online(task):
         logger.warning(f"Restored lvol {lvol_id} not found in DB")
 
 
+def _set_lvol_restore_failed(task, reason):
+    """Mark restored lvol as restore_failed after exhausting all retries."""
+    lvol_id = task.function_params.get("lvol_id")
+    if not lvol_id:
+        return
+    try:
+        from simplyblock_core.models.lvol_model import LVol
+        lvol = db.get_lvol_by_id(lvol_id)
+        if lvol.status == LVol.STATUS_RESTORING:
+            lvol.status = LVol.STATUS_RESTORE_FAILED
+            lvol.write_to_db()
+            logger.error(f"Restore of lvol {lvol_id} failed: {reason}")
+    except KeyError:
+        logger.warning(f"Restored lvol {lvol_id} not found in DB")
+
+
 def _run_restore(task):
     backup_id = task.function_params.get("backup_id")
     lvol_name = task.function_params.get("lvol_name")
@@ -240,8 +256,18 @@ def _run_restore(task):
         elif state == "Failed":
             fail_count = task.function_params.get("fail_count", 0) + 1
             task.function_params["fail_count"] = fail_count
-            task.function_result = f"Restore failed on data plane (attempt {fail_count})"
+            reason = f"S3 transfer failed on data plane (attempt {fail_count})"
+            task.function_result = reason
             if fail_count >= 3:
+                _set_lvol_restore_failed(task, reason)
+                try:
+                    backup = db.get_backup_by_id(backup_id)
+                    backup_events.backup_restore_failed(
+                        task.cluster_id, node_id, backup, lvol_name, reason)
+                except KeyError:
+                    logger.warning(
+                        "Backup %s not found in DB; restore-failed event skipped for lvol %s",
+                        backup_id, lvol_name)
                 task.status = JobSchedule.STATUS_DONE
             else:
                 task.retry += 1


### PR DESCRIPTION
currently inside the condition `if fail_count >= 3:` of simplyblock_core/services/tasks_runner_backup.py we simply set the task status as DONE. But this will make the errors during backup restore difficult to see. 

Sometimes the restore fails with this error on the SPDK side and the RPC fails
```
S3 transfer timeout with outstanding io 2, state 12
```

So Introduce new status for LVOL called: `restore_failed` Which will be reached when a LVOL restore fails. 

Currently we restore an LVOL from a backup we run this command
```
sbctl backup restore 9d33240e-b23c-4068-935e-3e94be8069c6 \
  --lvol new-lvol-name \
  --pool testing1 \
  --cluster-id $TARGET_CLUSTER
```

### testing

So `sbctl lvol get new-lvol-name` will show `status: restore_failed` and the event log will have 
```
Backup restore failed: 9d33240e → new-lvol-name: S3 transfer failed on data plane (attempt 3).
```