### PR TITLE
Fix Lvol connect API response

### DIFF
--- a/simplyblock_cli/clibase.py
+++ b/simplyblock_cli/clibase.py
@@ -606,7 +606,9 @@ class CLIWrapperBase:
         if args.host_nqn:
             kwargs['host_nqn'] = args.host_nqn
 
-        data = lvol_controller.connect_lvol(args.volume_id, **kwargs)
+        data, err = lvol_controller.connect_lvol(args.volume_id, **kwargs)
+        if err:
+            return err
         if data:
             return "\n".join(con['connect'] for con in data)
 

--- a/simplyblock_core/controllers/lvol_controller.py
+++ b/simplyblock_core/controllers/lvol_controller.py
@@ -1637,16 +1637,15 @@ def connect_lvol(uuid, ctrl_loss_tmo=constants.LVOL_NVME_CONNECT_CTRL_LOSS_TMO, 
     db_controller = DBController()
     try:
         lvol = db_controller.get_lvol_by_id(uuid)
-    except KeyError as e:
-        logger.error(e)
-        return False
+    except KeyError:
+        logger.exception("Failed to get lvol by id: %s", uuid)
+        return False, "Failed to find volume"
 
     # Look up host entry for secrets when host_nqn is provided
     host_entry = None
     if lvol.allowed_hosts:
         if not host_nqn:
-            logger.error(f"Volume {uuid} has allowed hosts configured; --host-nqn is required")
-            return False
+            return False, f"Volume {uuid} has allowed hosts configured; --host-nqn is required"
         for h in lvol.allowed_hosts:
             if h["nqn"] == host_nqn:
                 host_entry = h
@@ -1667,8 +1666,7 @@ def connect_lvol(uuid, ctrl_loss_tmo=constants.LVOL_NVME_CONNECT_CTRL_LOSS_TMO, 
                 # only sets keys the host_entry doesn't already have.
                 break
         if not host_entry:
-            logger.error(f"Host NQN {host_nqn} not found in allowed hosts for volume {uuid}")
-            return False
+            return False, f"Host NQN {host_nqn} not found in allowed hosts for volume {uuid}"
     elif host_nqn:
         # host_nqn provided but no allowed_hosts — volume allows any host,
         # so just pass host_nqn through without secrets
@@ -1758,7 +1756,7 @@ def connect_lvol(uuid, ctrl_loss_tmo=constants.LVOL_NVME_CONNECT_CTRL_LOSS_TMO, 
                 entry["allowed_hosts"] = [h["nqn"] for h in lvol.allowed_hosts]
 
             out.append(entry)
-    return out
+    return out, None
 
 
 def resize_lvol(id, new_size):

--- a/simplyblock_web/api/v1/lvol.py
+++ b/simplyblock_web/api/v1/lvol.py
@@ -278,7 +278,9 @@ def connect_lvol(uuid):
     except KeyError as e:
         return utils.get_response_error(str(e), 404)
 
-    ret = lvol_controller.connect_lvol(uuid)
+    ret, err = lvol_controller.connect_lvol(uuid)
+    if err:
+        return utils.get_response_error(err, 400)
     return utils.get_response(ret)
 
 

--- a/simplyblock_web/api/v2/volume.py
+++ b/simplyblock_web/api/v2/volume.py
@@ -243,10 +243,10 @@ def replication_stop(cluster: Cluster, pool: StoragePool, volume: Volume) -> Res
 
 @instance_api.get('/connect', name='clusters:storage-pools:volumes:connect')
 def connect(cluster: Cluster, pool: StoragePool, volume: Volume):
-    details_or_false = lvol_controller.connect_lvol(volume.get_id())
-    if details_or_false == False:  # noqa
-        raise ValueError('Failed to query connection details')
-    return details_or_false
+    details, err = lvol_controller.connect_lvol(volume.get_id())
+    if err:
+        raise ValueError(err)
+    return details
 
 
 @instance_api.get('/capacity', name='clusters:storage-pools:volumes:capacity')


### PR DESCRIPTION
return the actual error message as a part of the response API


Without this change this is what we see on the CSI driver side
```
oner is provisioning volume for claim "default/spdkcsi-pvc"
  Warning  ProvisioningFailed    4s (x5 over 11s)  csi.simplyblock.io_manohar-exra-node-1_b19c2b1d-d063-492f-a7bd-e76027ac06d0  failed to provision volume with StorageClass "simplyblock-simplyblock-cluster-pool4": rpc error: code = Internal desc = json: cannot unmarshal bool into Go value of type []*util.LvolConnectResp
```

Now this is the response

```
{"error":"Volume 4f533b12-dedc-452d-afaf-a507acce6705 has allowed hosts configured; --host-nqn is required","results":[],"status":false}
```



