### PR TITLE
Enable mTLS

### DIFF
--- a/simplyblock_core/models/storage_node.py
+++ b/simplyblock_core/models/storage_node.py
@@ -150,7 +150,7 @@ class StorageNode(BaseNodeObject):
         """Return API client to this node
         """
         host = self.api_endpoint
-        if Settings().tls_enabled:
+        if Settings().tls_connect != "disabled":
             port = self.api_endpoint.rsplit(":", 1)[1]
             host = f"{self._k8s_node_label()}.simplyblock-storage-node-api.{self.cr_namespace}.svc.cluster.local:{port}"
         return SNodeClient(host, **kwargs)
@@ -159,7 +159,7 @@ class StorageNode(BaseNodeObject):
         """Return rpc client to this node
         """
         host = self.mgmt_ip
-        if Settings().tls_enabled:
+        if Settings().tls_connect != "disabled":
             host = f"{self._k8s_node_label()}.simplyblock-spdk-proxy.{self.cr_namespace}.svc.cluster.local"
         return RPCClient(
             host, self.rpc_port,

--- a/simplyblock_core/rpc_client.py
+++ b/simplyblock_core/rpc_client.py
@@ -99,19 +99,21 @@ class RPCClient:
         self.host = host
         self.port = port
         settings = Settings()
-        scheme = "https" if settings.tls_enabled else "http"
+        scheme = "https" if settings.tls_connect != "disabled" else "http"
         self.url = '%s://%s:%s/' % (scheme, self.host, self.port)
         self.username = username
         self.password = password
         self.timeout = timeout
         self.session = requests.session()
-        if settings.tls_enabled:
-            self.session.verify = str(settings.certificate_authority)
+        if settings.tls_connect != "disabled":
+            self.session.verify = str(settings.tls_certificate_authority)
         self.session.auth = (self.username, self.password)
         retries = Retry(total=retry, backoff_factor=1, connect=retry, read=retry,
                         allowed_methods=self.DEFAULT_ALLOWED_METHODS)
         self.session.mount("http://", HTTPAdapter(max_retries=retries))
         self.session.mount("https://", HTTPAdapter(max_retries=retries))
+        if settings.tls_connect == "authenticated":
+            self.session.cert = (str(settings.tls_certificate), str(settings.tls_key))
 
     def _request_cached(self, method, params=None, cache_ttl=RPC_CACHE_TTL_SEC):
         """Like _request but returns a cached result if one exists within cache_ttl seconds."""

--- a/simplyblock_core/services/spdk_http_proxy_server.py
+++ b/simplyblock_core/services/spdk_http_proxy_server.py
@@ -5,7 +5,6 @@ import json
 import logging
 import os
 import socket
-import ssl
 import sys
 import threading
 import time
@@ -258,9 +257,8 @@ def run_server(host, port, user, password, is_threading_enabled=False):
         ServerHandler.key = key
         httpd = (ThreadingHTTPServer if is_threading_enabled else HTTPServer)((host, port), ServerHandler)
         settings = Settings()
-        if settings.tls_enabled:
-            context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
-            context.load_cert_chain(settings.tls_certificate, settings.tls_key)
+        context = settings.make_server_ssl_context()
+        if context is not None:
             httpd.socket = context.wrap_socket(httpd.socket, server_side=True)
         httpd.timeout = TIMEOUT
         logger.info('Started RPC http proxy server')

--- a/simplyblock_core/settings.py
+++ b/simplyblock_core/settings.py
@@ -1,19 +1,98 @@
+import ssl
 from pathlib import Path
+from typing import Annotated, Any, Literal, Optional
 
+from pydantic import BeforeValidator, Field, PlainSerializer, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+_VERIFY_MODE_TO_STR = {
+    ssl.CERT_NONE: "disabled",
+    ssl.CERT_OPTIONAL: "optional",
+    ssl.CERT_REQUIRED: "required",
+}
+_STR_TO_VERIFY_MODE = {v: k for k, v in _VERIFY_MODE_TO_STR.items()}
+
+
+def _parse_verify_mode(x: Any) -> ssl.VerifyMode:
+    if isinstance(x, str):
+        if x not in _STR_TO_VERIFY_MODE:
+            raise ValueError("Invalid input")
+        return _STR_TO_VERIFY_MODE[x]
+
+    return x
 
 
 class Settings(BaseSettings):
     model_config = SettingsConfigDict(env_prefix="sb_", case_sensitive=False)
 
+    tls_serve: Annotated[
+        bool,
+        Field(
+            description="Run servers in TLS mode. Requires certificate and key to be present."
+        ),
+    ] = False
+    tls_client_auth: Annotated[
+        ssl.VerifyMode,
+        Field(
+            description="Client authentication mode. May be 'disabled', 'optional', or 'required'"
+        ),
+        BeforeValidator(_parse_verify_mode),
+        PlainSerializer(_VERIFY_MODE_TO_STR.__getitem__, return_type=str),
+    ] = ssl.CERT_NONE
+    tls_connect: Annotated[
+        Literal["disabled", "anonymous", "authenticated"],
+        Field(description="Connect to internal services via TLS."),
+    ] = "disabled"
+    tls_provider: Annotated[
+        Optional[Literal["openshift", "cert-manager"]],
+        Field(description="Provider for TLS certificates in the cluster."),
+    ] = None
     tls_certificate: Path = Path("/etc/simplyblock/tls/tls.crt")
     tls_key: Path = Path("/etc/simplyblock/tls/tls.key")
-    certificate_authority: Path = Path("/etc/simplyblock/tls/ca.crt")
+    tls_certificate_authority: Path = Path("/etc/simplyblock/tls/ca.crt")
 
-    @property
-    def tls_enabled(self) -> bool:
-        return all([
-            self.tls_certificate.is_file(),
-            self.tls_key.is_file(),
-            self.certificate_authority.is_file(),
-        ])
+    @model_validator(mode="after")
+    def validate_tls_files(self):
+        if not self.tls_serve and self.tls_connect == "disabled":
+            return self
+
+        if self.tls_serve and (
+            missing := [
+                name
+                for name in ["tls_certificate", "tls_key"]
+                if not getattr(self, name).is_file()
+            ]
+        ):
+            raise ValueError(
+                "SB_TLS_SERVE=true requires TLS files to exist: " + ", ".join(missing)
+            )
+
+        if (
+            self.tls_connect != "disabled"
+            and not self.tls_certificate_authority.is_file()
+        ):
+            raise ValueError(
+                "SB_TLS_CONNECT != 'disabled' requires certificate authority to exist"
+            )
+
+        return self
+
+    @model_validator(mode="after")
+    def validate_tls_provider(self):
+        if self.tls_connect != "disabled" and self.tls_provider is None:
+            raise ValueError(
+                "TLS provider needs to be configured for TLS connections to be used"
+            )
+        return self
+
+    def make_server_ssl_context(self):
+        """Return an SSLContext requiring client certificates, or None if TLS is not configured."""
+        if self.tls_client_auth == "disabled":
+            return None
+
+        ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+        ctx.load_cert_chain(self.tls_certificate, self.tls_key)
+        ctx.verify_mode = self.tls_client_auth
+        ctx.load_verify_locations(self.tls_certificate_authority)
+        return ctx

--- a/simplyblock_core/snode_client.py
+++ b/simplyblock_core/snode_client.py
@@ -20,16 +20,18 @@ class SNodeClient:
 
     def __init__(self, host, timeout=300, retry=5):
         settings = Settings()
-        scheme = "https" if settings.tls_enabled else "http"
+        scheme = "https" if settings.tls_connect != "disabled" else "http"
         self.url = f'{scheme}://{host}/snode/'
         self.timeout = timeout
         self.session = requests.session()
-        if settings.tls_enabled:
-            self.session.verify = str(settings.certificate_authority)
+        if settings.tls_connect != "disabled":
+            self.session.verify = str(settings.tls_certificate_authority)
         self.session.headers['Content-Type'] = "application/json"
         retries = Retry(total=retry, backoff_factor=1, connect=retry, read=retry)
         self.session.mount("http://", HTTPAdapter(max_retries=retries))
         self.session.mount("https://", HTTPAdapter(max_retries=retries))
+        if settings.tls_connect == "authenticated":
+            self.session.cert = (str(settings.tls_certificate), str(settings.tls_key))
 
     def _request(self, method, path, payload=None):
         try:

--- a/simplyblock_web/api/internal/storage_node/kubernetes.py
+++ b/simplyblock_web/api/internal/storage_node/kubernetes.py
@@ -281,6 +281,7 @@ class SPDKParams(BaseModel):
     })}}},
 })
 def spdk_process_start(body: SPDKParams):
+    settings = Settings()
     ssd_pcie_params = " ".join(" -A " + addr for addr in body.ssd_pcie) if body.ssd_pcie else "none"
     ssd_pcie_list = " ".join(body.ssd_pcie)
 
@@ -373,7 +374,10 @@ def spdk_process_start(body: SPDKParams):
             'FW_PORT': body.firewall_port,
             'CPU_TOPOLOGY_ENABLED': cpu_topology_enabled,
             'RESERVED_SYSTEM_CPUS': reserved_system_cpus,
-            'TLS_ENABLED': Settings().tls_enabled,
+            'TLS_SERVE': settings.tls_serve,
+            'TLS_CONNECT': settings.tls_connect,
+            'TLS_CLIENT_AUTH': settings.model_dump()["tls_client_auth"],
+            'TLS_PROVIDER': settings.tls_provider,
         }
 
         if ubuntu_host:

--- a/simplyblock_web/app.py
+++ b/simplyblock_web/app.py
@@ -93,8 +93,10 @@ def main() -> None:
         access_log=False,
         proxy_headers=True,
         forwarded_allow_ips='192.168.1.0/24',
-        ssl_certfile=settings.tls_certificate if settings.tls_enabled else None,
-        ssl_keyfile=settings.tls_key if settings.tls_enabled else None,
+        ssl_certfile=settings.tls_certificate if settings.tls_serve else None,
+        ssl_keyfile=settings.tls_key if settings.tls_serve else None,
+        ssl_ca_certs=settings.tls_certificate_authority if settings.tls_client_auth != "disabled" else None,
+        ssl_cert_reqs=settings.tls_client_auth,
     )
     server: uvicorn.Server = uvicorn.Server(config)
     server.run()

--- a/simplyblock_web/node_webapp.py
+++ b/simplyblock_web/node_webapp.py
@@ -44,5 +44,4 @@ if __name__ == '__main__':
         app.register_api(internal_api.storage_node.kubernetes.api)
 
     settings = Settings()
-    ssl_ctx = (settings.tls_certificate, settings.tls_key) if settings.tls_enabled else None
-    app.run(host='0.0.0.0', debug=constants.LOG_WEB_DEBUG, ssl_context=ssl_ctx)
+    app.run(host='0.0.0.0', debug=constants.LOG_WEB_DEBUG, ssl_context=settings.make_server_ssl_context())

--- a/simplyblock_web/node_webapp.py
+++ b/simplyblock_web/node_webapp.py
@@ -5,7 +5,6 @@ import argparse
 
 from flask_openapi3 import OpenAPI
 
-from simplyblock_core import constants
 from simplyblock_core.settings import Settings
 from simplyblock_web import utils
 from simplyblock_web.api import internal as internal_api
@@ -44,4 +43,4 @@ if __name__ == '__main__':
         app.register_api(internal_api.storage_node.kubernetes.api)
 
     settings = Settings()
-    app.run(host='0.0.0.0', debug=constants.LOG_WEB_DEBUG, ssl_context=settings.make_server_ssl_context())
+    app.run(host='0.0.0.0', debug=False, ssl_context=settings.make_server_ssl_context())

--- a/simplyblock_web/templates/storage_deploy_spdk.yaml.j2
+++ b/simplyblock_web/templates/storage_deploy_spdk.yaml.j2
@@ -56,8 +56,12 @@ spec:
     - name: dockercontainerlogdirectory
       hostPath:
         path: /var/log/pods
-    {% if TLS_ENABLED %}
+    {% if TLS_SERVE or TLS_CONNECT != "disabled" %}
     - name: tls
+    {% if TLS_PROVIDER == "cert-manager" %}
+      secret:
+        secretName: simplyblock-spdk-proxy-tls
+    {% else %}
       projected:
         sources:
           - secret:
@@ -67,6 +71,7 @@ spec:
               items:
                 - key: service-ca.crt
                   path: ca.crt
+    {% endif %}
     {% endif %}
 
   containers:
@@ -137,7 +142,7 @@ spec:
       volumeMounts:
         - name: socket-dir
           mountPath: /mnt/ramdisk
-        {% if TLS_ENABLED %}
+        {% if TLS_SERVE or TLS_CONNECT != "disabled" %}
         - name: tls
           mountPath: /etc/simplyblock/tls
           readOnly: true
@@ -155,6 +160,14 @@ spec:
           value: "True"
         - name: TIMEOUT
           value: "300"
+        - name: SB_TLS_SERVE
+          value: "{{ TLS_SERVE }}"
+        - name: SB_TLS_CONNECT
+          value: "{{ TLS_CONNECT }}"
+        - name: SB_TLS_CLIENT_AUTH
+          value: "{{ TLS_CLIENT_AUTH }}"
+        - name: SB_TLS_PROVIDER
+          value: "{{ TLS_PROVIDER }}"
       {% if CPU_TOPOLOGY_ENABLED %}
       resources:
         limits:

--- a/simplyblock_web/templates/storage_init_job.yaml.j2
+++ b/simplyblock_web/templates/storage_init_job.yaml.j2
@@ -21,6 +21,11 @@ spec:
         - name: host-proc
           hostPath:
             path: /proc
+        {% if TLS_CONNECT == "authenticated" %}
+        - name: tls
+          secret:
+            secretName: simplyblock-spdk-proxy-tls
+        {% endif %}
       containers:
         - name: init-setup
           image: simplyblock/alpine-tools:3.21.3
@@ -29,6 +34,11 @@ spec:
           volumeMounts:
             - name: host-proc
               mountPath: /proc
+            {% if TLS_CONNECT == "authenticated" %}
+            - name: tls
+              mountPath: /etc/simplyblock/tls
+              readOnly: true
+            {% endif %}
           command: ["/bin/sh", "-c"]
           args:
             - |
@@ -47,7 +57,17 @@ spec:
 
               echo "--- Sending config to $NODE_IP ---"
               if [ "$OS_ID" != "talos" ]; then
-                RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" -X POST {% if TLS_ENABLED %}-k https{% else %}http{% endif %}://$NODE_IP:5000/snode/apply_config -H "Content-Type: application/json" -d '{}')
+                {% if TLS_CONNECT == "disabled" %}
+                {% set SCHEME = "http" %}
+                {% set CURL_TLS_FLAGS = "" %}
+                {% elif TLS_CONNECT == "anonymous" %}
+                {% set SCHEME = "https" %}
+                {% set CURL_TLS_FLAGS = "-k" %}
+                {% else %}
+                {% set SCHEME = "https" %}
+                {% set CURL_TLS_FLAGS = "-k --cert /etc/simplyblock/tls/tls.crt --key /etc/simplyblock/tls/tls.key" %}
+                {% endif %}
+                RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" -X POST {{ CURL_TLS_FLAGS }} {{ SCHEME }}://$NODE_IP:5000/snode/apply_config -H "Content-Type: application/json" -d '{}')
                 echo "HTTP status: $RESPONSE"
                 if [ "$RESPONSE" -lt 200 ] || [ "$RESPONSE" -ge 300 ]; then
                   echo "Failed to apply config"

--- a/tests/test_storage_deploy_template.py
+++ b/tests/test_storage_deploy_template.py
@@ -1,0 +1,59 @@
+import unittest
+from pathlib import Path
+
+from jinja2 import Environment, FileSystemLoader
+
+
+TEMPLATE_DIR = Path(__file__).resolve().parents[1] / "simplyblock_web" / "templates"
+
+
+def _render_storage_deploy(tls_provider: str) -> str:
+    env = Environment(
+        loader=FileSystemLoader(str(TEMPLATE_DIR)),
+        trim_blocks=True,
+        lstrip_blocks=True,
+    )
+    template = env.get_template("storage_deploy_spdk.yaml.j2")
+    return template.render(
+        SPDK_IMAGE="spdk:test",
+        L_CORES="0-1",
+        SPDK_MEM=1024,
+        CORES=2,
+        SERVER_IP="10.0.0.10",
+        RPC_PORT=8080,
+        RPC_USERNAME="admin",
+        RPC_PASSWORD="secret",
+        HOSTNAME="node-a",
+        NAMESPACE="simplyblock",
+        SIMPLYBLOCK_DOCKER_IMAGE="proxy:test",
+        GRAYLOG_SERVER_IP="10.0.0.20",
+        MODE="kubernetes",
+        CLUSTER_ID="cluster1",
+        SSD_PCIE="none",
+        PCI_ALLOWED="",
+        TOTAL_HP="",
+        NSOCKET=0,
+        FW_PORT=50001,
+        CPU_TOPOLOGY_ENABLED=False,
+        MEM_MEGA=1536,
+        MEM2_MEGA=1024,
+        TLS_ENABLED=True,
+        TLS_PROVIDER=tls_provider,
+    )
+
+
+class TestStorageDeployTemplate(unittest.TestCase):
+
+    def test_openshift_uses_service_ca_key(self):
+        rendered = _render_storage_deploy("openshift")
+        self.assertIn("key: service-ca.crt", rendered)
+        self.assertIn('name: SB_TLS_PROVIDER', rendered)
+        self.assertIn('value: "openshift"', rendered)
+
+    def test_cert_manager_mounts_secret_directly(self):
+        rendered = _render_storage_deploy("cert-manager")
+        self.assertIn("secretName: simplyblock-spdk-proxy-tls", rendered)
+        self.assertNotIn("simplyblock-certificate-authority", rendered)
+        self.assertNotIn("projected:", rendered)
+        self.assertIn('name: SB_TLS_PROVIDER', rendered)
+        self.assertIn('value: "cert-manager"', rendered)


### PR DESCRIPTION
This allows allow services to require mTLS authentication to be used. Additional configuration settings are introduced:
- `SB_TLS_CONNECT`: may now also be `authenticated`, which will send client certificates along with all requests
- `SB_TLS_CLIENT_AUTH`: `disabled`/`optional`/`required`: Configures server components (WebAppAPI, SNodeAPI, SPDKProxy) to reject, allow, or require client certificates
- `SB_TLS_PROVIDER`: The provider for certificates. This is required because the SNodeAPI spawns SPDK Pods, which depend on whether certificates are provided via OpenShift or cert-manager. This also introduces an extension mechanism that may be used in the future for other environments, e.g. in docker.

This PR corresponds to https://github.com/simplyblock/simplyblock-operator/pull/72 and https://github.com/simplyblock/simplyblock-csi/pull/320