### PR TITLE
Fix comparison for TLS auth check 

### DIFF
--- a/simplyblock_core/settings.py
+++ b/simplyblock_core/settings.py
@@ -88,7 +88,7 @@ class Settings(BaseSettings):
 
     def make_server_ssl_context(self):
         """Return an SSLContext requiring client certificates, or None if TLS is not configured."""
-        if self.tls_client_auth == "disabled":
+        if self.tls_client_auth == ssl.CERT_NONE:
             return None
 
         ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)

--- a/simplyblock_core/settings.py
+++ b/simplyblock_core/settings.py
@@ -47,6 +47,7 @@ class Settings(BaseSettings):
     tls_provider: Annotated[
         Optional[Literal["openshift", "cert-manager"]],
         Field(description="Provider for TLS certificates in the cluster."),
+        BeforeValidator(lambda x: None if x == "None" else x),
     ] = None
     tls_certificate: Path = Path("/etc/simplyblock/tls/tls.crt")
     tls_key: Path = Path("/etc/simplyblock/tls/tls.key")


### PR DESCRIPTION
The comparison `== "disabled"` was always `False` because the field holds `ssl.CERT_NONE` (integer 0), not the string. Now with == ssl.CERT_NONE, the function correctly returns `None` when no client auth is configured, and Flask receives no SSL context.


### issue
```
kubectl logs -f simplyblock-storage-node-ds-simplyblock-cluster-mgcc9 -c s-node-api-container --previous
Traceback (most recent call last):
  File "/app/simplyblock_web/node_webapp.py", line 46, in <module>
    app.run(host='0.0.0.0', debug=False, ssl_context=settings.make_server_ssl_context())
                                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/simplyblock_core/settings.py", line 95, in make_server_ssl_context
    ctx.load_cert_chain(self.tls_certificate, self.tls_key)
FileNotFoundError: [Errno 2] No such file or directory
```

But I initially setup the cluster, didn't enable SSL at all.


## testing

the cluster starts with this change. 
```
kubectl get pods
NAME                                                    READY   STATUS    RESTARTS   AGE
simplyblock-storage-node-ds-simplyblock-cluster-6zwlc   1/1     Running   0          22s
simplyblock-storage-node-ds-simplyblock-cluster-gbh6t   1/1     Running   0          22s
simplyblock-storage-node-ds-simplyblock-cluster-xcgf4   1/1     Running   0          22s
```
