### PR TITLE
Add missing fields for v2 API for clone

### DIFF
--- a/simplyblock_core/controllers/lvol_controller.py
+++ b/simplyblock_core/controllers/lvol_controller.py
@@ -2335,9 +2335,9 @@ def clone_lvol(lvol_id, clone_name, new_size=None, pvc_name=None):
     db_controller = DBController()
     try:
         lvol = db_controller.get_lvol_by_id(lvol_id)
-    except KeyError as e:
-        logger.error(e)
-        return False, str(e)
+    except KeyError:
+        logger.exception("Volume lookup failed for clone request: %s", lvol_id)
+        return False, "Volume not found"
 
     host_node = db_controller.get_storage_node_by_id(lvol.node_id)
     subsys_count = len(set(lv.nqn for lv in db_controller.get_lvols_by_node_id(lvol.node_id)))

--- a/simplyblock_core/controllers/snapshot_controller.py
+++ b/simplyblock_core/controllers/snapshot_controller.py
@@ -47,9 +47,9 @@ def _rollback_lvol_creation(lvol, node_ids):
 def add(lvol_id, snapshot_name, backup=False, lock=True):
     try:
         lvol = db_controller.get_lvol_by_id(lvol_id)
-    except KeyError as e:
-        logger.error(e)
-        return False, str(e)
+    except KeyError:
+        logger.exception("Volume lookup failed for snapshot request: %s", lvol_id)
+        return False, "Volume not found"
 
     # Reject snapshot creation on an lvol that is being deleted. SPDK's
     # blobstore reuses the lvol's metadata for the snapshot's parent
@@ -547,9 +547,9 @@ def clone(snapshot_id, clone_name, new_size=0, pvc_name=None, pvc_namespace=None
           lock=True, namespaced=True):
     try:
         snap = db_controller.get_snapshot_by_id(snapshot_id)
-    except KeyError as e:
-        logger.error(e)
-        return False, str(e)
+    except KeyError:
+        logger.exception("Snapshot lookup failed for clone request: %s", snapshot_id)
+        return False, "Snapshot not found"
 
     # Reject cloning a snapshot that is in pending deletion. If a prior
     # clone-create failed (e.g. an SPDK duplicate-name collision on the

--- a/simplyblock_web/api/v2/volume.py
+++ b/simplyblock_web/api/v2/volume.py
@@ -57,6 +57,9 @@ class _CloneParams(BaseModel):
     name: str
     snapshot_id: Annotated[Optional[str], Field(pattern=core_utils.UUID_PATTERN)]
     size: util.Size = 0
+    pvc_name: Optional[str] = None
+    pvc_namespace: Optional[str] = None
+    delete_snap_on_lvol_delete: bool = False
 
 
 @api.post('/', name='clusters:storage-pools:volumes:create', status_code=201, responses={201: {"content": None}})
@@ -104,6 +107,9 @@ def add(
             data.snapshot_id,
             data.name,
             data.size if data.size is not None else 0,
+            pvc_name=data.pvc_name,
+            pvc_namespace=data.pvc_namespace,
+            delete_snap_on_lvol_delete=data.delete_snap_on_lvol_delete,
         )
     else:
         raise AssertionError('unreachable')
@@ -332,5 +338,16 @@ def resume(cluster: Cluster, pool: StoragePool, volume: Volume) -> bool:
     return lvol_controller.resume_lvol(volume.get_id())
 
 @instance_api.get('/clone', name='clusters:storage-pools:volumes:clone')
-def clone(cluster: Cluster, pool: StoragePool, volume: Volume, clone_name: str) -> bool:
-    return lvol_controller.clone_lvol(volume.get_id(), clone_name)
+def clone(
+        cluster: Cluster, pool: StoragePool, volume: Volume,
+        clone_name: str,
+        new_size: Optional[str] = None,
+        pvc_name: Optional[str] = None,
+) -> bool:
+    size = None
+    if new_size is not None:
+        try:
+            size = core_utils.parse_size(new_size)
+        except Exception:
+            raise HTTPException(400, f'Invalid new_size value: {new_size!r}')
+    return lvol_controller.clone_lvol(volume.get_id(), clone_name, size, pvc_name)


### PR DESCRIPTION
With the current goal of migrating the API to use V2 API on the CSI driver. 

Few parameters are missing in the clone API

POST request
```
    pvc_name: Optional[str] = None
    pvc_namespace: Optional[str] = None
    delete_snap_on_lvol_delete: bool = False
``` 



In the GET `/volumes/{id}/clone`

`new_size` and `pvc_name`. But these fields are not present in the v2 API for clone. 

So adding them as query parameters