### PR TITLE
reject duplicate pool name only in the current namespace

### DIFF
--- a/simplyblock_core/controllers/pool_controller.py
+++ b/simplyblock_core/controllers/pool_controller.py
@@ -31,7 +31,7 @@ def add_pool(name, pool_max, lvol_max, max_rw_iops, max_rw_mbytes, max_r_mbytes,
 
     pool_list = db_controller.get_pools()
     for p in pool_list:
-        if p.pool_name == name:
+        if p.pool_name == name and p.cluster_id == cluster_id:
             logger.error(f"Pool found with the same name: {name}")
             return False
 
@@ -209,7 +209,7 @@ def set_pool(uuid, pool_max=0, lvol_max=0, max_rw_iops=0,
 
     if name and name != pool.pool_name:
         for p in db_controller.get_pools():
-            if p.pool_name == name:
+            if p.pool_name == name and p.cluster_id == pool.cluster_id:
                 msg = f"Pool found with the same name: {name}"
                 logger.error(msg)
                 return False, msg

--- a/simplyblock_web/api/v2/pool.py
+++ b/simplyblock_web/api/v2/pool.py
@@ -47,12 +47,9 @@ class StoragePoolParams(BaseModel):
 
 @api.post('/', name='clusters:storage-pools:create', status_code=201, responses={201: {"content": None}})
 def add(request: Request, cluster: Cluster, parameters: StoragePoolParams) -> Response:
-    try:
-        db.get_pool_by_name(parameters.name)
-        # FIXME: Names are deployment unique, this should be changed
-        raise HTTPException(409, f'Pool {parameters.name} already exists')
-    except KeyError:
-        pass
+    for pool in db.get_pools(cluster.get_id()):
+        if pool.pool_name == parameters.name:
+            raise HTTPException(409, f'Pool {parameters.name} already exists')
 
     id_or_false =  pool_controller.add_pool(
         parameters.name, parameters.pool_max, parameters.volume_max_size, parameters.max_rw_iops, parameters.max_rw_mbytes,


### PR DESCRIPTION
currently when I try to create a pool with same but in a different cluster, I get this error: 

```
Pool pool1 already exists
```

To fix this add a check against clusterID. 


tested this as a part of: https://github.com/simplyblock/simplyblock-operator/pull/120
