### PR TITLE
tls: update condition in Unicorn SSL configuration

### DIFF
--- a/simplyblock_web/app.py
+++ b/simplyblock_web/app.py
@@ -2,6 +2,7 @@
 # encoding: utf-8
 
 import logging
+import ssl
 import sys
 import time
 
@@ -110,7 +111,7 @@ def main() -> None:
         forwarded_allow_ips='192.168.1.0/24',
         ssl_certfile=settings.tls_certificate if settings.tls_serve else None,
         ssl_keyfile=settings.tls_key if settings.tls_serve else None,
-        ssl_ca_certs=settings.tls_certificate_authority if settings.tls_client_auth != "disabled" else None,
+        ssl_ca_certs=settings.tls_certificate_authority if settings.tls_client_auth != ssl.CERT_NONE else None,
         ssl_cert_reqs=settings.tls_client_auth,
     )
     server: uvicorn.Server = uvicorn.Server(config)


### PR DESCRIPTION
The `settings.tls_client_auth` is of type `ssl.VerifyMode` but in the condition we are doing check against a string value of `"disabled"` 

They are of different types so they will never be equal. 

Fixing this by passing the value properly. 
