### PR TITLE
KMS: parameterise transit mount, KV mount and cert role

### DIFF
--- a/docs/kms/README.md
+++ b/docs/kms/README.md
@@ -50,40 +50,40 @@ kubectl -n vault exec -it vault-0 -- env VAULT_ADDR=https://vault.vault:8200/ VA
 Using this shell, configure the vault. Note that the certificate path needs to be adapted depending on Openbao/HCP-vault:
 ```
 # Configure auth
-$CLI policy write webappapi-policy - <<EOF
-path "transit/keys/*" {
+$CLI policy write simplyblock-webappapi-policy - <<EOF
+path "simplyblock/transit/keys/*" {
   capabilities = ["create", "update", "read", "delete"]
 }
 
-path "transit/datakey/plaintext/*" {
+path "simplyblock/transit/datakey/plaintext/*" {
   capabilities = ["create", "update"]
 }
 
-path "transit/datakey/wrapped/*" {
+path "simplyblock/transit/datakey/wrapped/*" {
   capabilities = ["create", "update"]
 }
 
-path "transit/encrypt/*" {
+path "simplyblock/transit/encrypt/*" {
   capabilities = ["create", "update"]
 }
 
-path "transit/decrypt/*" {
+path "simplyblock/transit/decrypt/*" {
   capabilities = ["create", "update"]
 }
 
-path "kv/*" {
+path "simplyblock/kv/*" {
   capabilities = ["create", "read", "update", "delete"]
 }
 EOF
 $CLI auth enable cert
-$CLI write auth/cert/certs/webappapi \
+$CLI write auth/cert/certs/simplyblock-webappapi \
     certificate=@/{openbao,vault}/tls/ca.crt \
     allowed_dns_sans="simplyblock-webappapi" \
-    token_policies=webappapi-policy \
+    token_policies=simplyblock-webappapi-policy \
     token_ttl=10m \
     token_max_ttl=30m
 
 # Enable components
-$CLI secrets enable transit
-$CLI secrets enable -version=1 kv
+$CLI secrets enable -path=simplyblock/transit transit
+$CLI secrets enable -path=simplyblock/kv kv
 ```

--- a/simplyblock_core/controllers/lvol_controller.py
+++ b/simplyblock_core/controllers/lvol_controller.py
@@ -139,7 +139,7 @@ def _create_crypto_lvol(rpc_client, lvol, cluster):
 
     with create_kms_connection(cluster) as kms:
         try:
-            original_key1, original_key2 = kms.get_data_encryption_keys(lvol.pool_uuid, name)
+            original_key1, original_key2 = kms.get_data_encryption_keys(lvol)
         except KMSException:
             logger.exception(f"Failed to get keys for lvol: {name} from KMS")
             return False
@@ -649,27 +649,20 @@ def add_lvol_ha(name, size, host_id_or_name, ha_type, pool_id_or_name, use_comp=
                 lvol.allowed_hosts,
                 bool(pool.dhchap_key) if pool.dhchap else "N/A")
 
-    lvol.write_to_db(db_controller.kv_store)
-
     if use_crypto:
         with create_kms_connection(cl) as kms:
             try:
                 if crypto_key is None:
-                    kms.create_data_encryption_keys(pool.get_id(), lvol.crypto_bdev)
+                    kms.create_data_encryption_keys(lvol)
                 else:
-                    kms.import_data_encryption_keys(pool.get_id(), lvol.crypto_bdev, crypto_key)
-                # For LocalKMS, sync keys to the in-memory lvol so subsequent
-                # write_to_db calls do not overwrite them with empty strings.
-                if not cl.hashicorp_vault_settings:
-                    lvol.crypto_key1, lvol.crypto_key2 = kms.get_data_encryption_keys(
-                        pool.get_id(), lvol.crypto_bdev
-                    )
+                    kms.import_data_encryption_keys(lvol, crypto_key)
                 logger.info("Created lvol keys")
             except KMSException:
                 msg = "Failed to create lvol keys"
                 logger.exception(msg)
-                lvol.remove(db_controller.kv_store)
                 return False, msg
+
+    lvol.write_to_db(db_controller.kv_store)
 
     if ha_type == "single":
         if host_node.status == StorageNode.STATUS_ONLINE:

--- a/simplyblock_core/controllers/snapshot_controller.py
+++ b/simplyblock_core/controllers/snapshot_controller.py
@@ -736,21 +736,17 @@ def clone(snapshot_id, clone_name, new_size=0, pvc_name=None, pvc_namespace=None
             logger.error(msg)
             return False, msg
 
-    lvol.write_to_db(db_controller.kv_store)
-
     if snap.lvol.crypto_bdev:
         with create_kms_connection(cluster) as kms:
             try:
-                key1, key2 = kms.get_data_encryption_keys(snap.lvol.pool_uuid, snap.lvol.crypto_bdev)
-                kms.import_data_encryption_keys(lvol.pool_uuid, lvol.crypto_bdev, (key1, key2))
-                if not cluster.hashicorp_vault_settings:
-                    lvol.crypto_key1, lvol.crypto_key2 = key1, key2
-                    lvol.write_to_db(db_controller.kv_store)
+                key1, key2 = kms.get_data_encryption_keys(snap.lvol)
+                kms.import_data_encryption_keys(lvol, (key1, key2))
             except KMSException:
                 msg = f"Failed to copy encryption keys for clone {lvol.crypto_bdev}"
                 logger.exception(msg)
-                lvol.remove(db_controller.kv_store)
                 return False, msg
+
+    lvol.write_to_db(db_controller.kv_store)
 
     if lvol.ha_type == "single":
         lvol_bdev, error = lvol_controller.add_lvol_on_node(lvol, snode)

--- a/simplyblock_core/kms/__init__.py
+++ b/simplyblock_core/kms/__init__.py
@@ -29,10 +29,14 @@ def create_kms_connection(cluster: Cluster) -> KMS:
         if not path.is_file()
     }):
         raise KMSException("Missing certificates: " + ", ".join(map(str, missing)))
+    vault = cluster.hashicorp_vault_settings
     return HCPClient(
-        cluster.hashicorp_vault_settings.base_url,
+        vault.base_url,
         settings.tls_certificate_authority,
         settings.tls_certificate,
         settings.tls_key,
         cluster.get_id(),
+        transit_mount=vault.transit_mount,
+        kv_mount=vault.kv_mount,
+        cert_role=vault.cert_role,
     )

--- a/simplyblock_core/kms/_base.py
+++ b/simplyblock_core/kms/_base.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 from abc import abstractmethod
 from contextlib import AbstractContextManager
 from types import TracebackType
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from simplyblock_core.models.lvol_model import LVol
 
 
 class KMS(AbstractContextManager):
@@ -15,13 +19,16 @@ class KMS(AbstractContextManager):
         return None
 
     @abstractmethod
-    def create_data_encryption_keys(self, kek_name: str, name: str) -> None: ...
+    def create_data_encryption_keys(self, lvol: "LVol") -> None:
+        raise NotImplementedError
 
     @abstractmethod
-    def import_data_encryption_keys(self, kek_name: str, name: str, keys: tuple[str, str]) -> None: ...
+    def import_data_encryption_keys(self, lvol: "LVol", keys: tuple[str, str]) -> None:
+        pass
 
     @abstractmethod
-    def get_data_encryption_keys(self, kek_name: str, name: str) -> tuple[str, str]: ...
+    def get_data_encryption_keys(self, lvol: "LVol") -> tuple[str, str]:
+        pass
 
     @abstractmethod
     def delete_data_encryption_keys(self, name: str) -> None: ...

--- a/simplyblock_core/kms/_fdb.py
+++ b/simplyblock_core/kms/_fdb.py
@@ -30,16 +30,13 @@ class LocalKMS(KMS):
         except StopIteration:
             raise KMSException(f"No LVol found for key {name}")
 
-    def create_data_encryption_keys(self, kek_name: str, name: str) -> None:
-        self.import_data_encryption_keys(kek_name, name, (generate_hex_string(32), generate_hex_string(32)))
+    def create_data_encryption_keys(self, lvol: LVol) -> None:
+        self.import_data_encryption_keys(lvol, (generate_hex_string(32), generate_hex_string(32)))
 
-    def import_data_encryption_keys(self, kek_name: str, name: str, keys: tuple[str, str]) -> None:
-        lvol = self._lvol_by_data_encryption_key_name(name)
+    def import_data_encryption_keys(self, lvol: LVol, keys: tuple[str, str]) -> None:
         lvol.crypto_key1, lvol.crypto_key2 = keys
-        lvol.write_to_db(self._db_controller.kv_store)
 
-    def get_data_encryption_keys(self, kek_name: str, name: str) -> tuple[str, str]:
-        lvol = self._lvol_by_data_encryption_key_name(name)
+    def get_data_encryption_keys(self, lvol: LVol) -> tuple[str, str]:
         return lvol.crypto_key1, lvol.crypto_key2
 
     def delete_data_encryption_keys(self, name: str) -> None:

--- a/simplyblock_core/kms/_hcp.py
+++ b/simplyblock_core/kms/_hcp.py
@@ -11,9 +11,6 @@ from ._exceptions import KMSException
 
 logger = logging.getLogger(__name__)
 
-_CERT_ROLE_NAME = "webappapi"
-
-
 class HCPClient(KMS):
     def __init__(
         self,
@@ -22,10 +19,15 @@ class HCPClient(KMS):
         tls_certificate: Path,
         tls_key: Path,
         cluster_id: UUID,
+        transit_mount: str,
+        kv_mount: str,
+        cert_role: str,
         timeout: int = 300,
         retry: int = 5,
     ):
         self.cluster_id = cluster_id
+        self.transit_mount = transit_mount
+        self.kv_mount = kv_mount
         self.client = hvac.Client(
             url=base_url,
             cert=(str(tls_certificate), str(tls_key)),
@@ -33,7 +35,7 @@ class HCPClient(KMS):
             timeout=timeout,
         )
         try:
-            self.client.auth.cert.login(name=_CERT_ROLE_NAME)
+            self.client.auth.cert.login(name=cert_role)
         except hvac.exceptions.VaultError as e:
             raise KMSException("Authentication failed") from e
 
@@ -46,7 +48,7 @@ class HCPClient(KMS):
     def _create_data_encryption_key(self, kek_name: str) -> str:
         try:
             return self.client.secrets.transit.generate_data_key(
-                name=kek_name, key_type='wrapped'
+                name=kek_name, key_type='wrapped', mount_point=self.transit_mount,
             )['data']['ciphertext']
         except hvac.exceptions.VaultError as e:
             raise KMSException("Request failed") from e
@@ -55,7 +57,7 @@ class HCPClient(KMS):
         plaintext_b64 = base64.b64encode(bytes.fromhex(plaintext_hex)).decode()
         try:
             return self.client.secrets.transit.encrypt_data(
-                name=kek_name, plaintext=plaintext_b64
+                name=kek_name, plaintext=plaintext_b64, mount_point=self.transit_mount,
             )['data']['ciphertext']
         except hvac.exceptions.VaultError as e:
             raise KMSException("Request failed") from e
@@ -63,7 +65,7 @@ class HCPClient(KMS):
     def _decrypt(self, kek_name: str, ciphertext: str) -> str:
         try:
             plaintext_b64 = self.client.secrets.transit.decrypt_data(
-                name=kek_name, ciphertext=ciphertext
+                name=kek_name, ciphertext=ciphertext, mount_point=self.transit_mount,
             )['data']['plaintext']
         except hvac.exceptions.VaultError as e:
             raise KMSException("Request failed") from e
@@ -71,36 +73,36 @@ class HCPClient(KMS):
 
     def create_data_encryption_keys(self, kek_name: str, name: str) -> None:
         try:
-            self.client.secrets.kv.v1.create_or_update_secret(
+            self.client.secrets.kv.v2.create_or_update_secret(
                 path=f"{self.cluster_id}/{name}",
                 secret={"keys": [
                     self._create_data_encryption_key(kek_name),
                     self._create_data_encryption_key(kek_name),
                 ]},
-                mount_point="kv",
+                mount_point=self.kv_mount,
             )
         except hvac.exceptions.VaultError as e:
             raise KMSException("Request failed") from e
 
     def import_data_encryption_keys(self, kek_name: str, name: str, keys: tuple[str, str]) -> None:
         try:
-            self.client.secrets.kv.v1.create_or_update_secret(
+            self.client.secrets.kv.v2.create_or_update_secret(
                 path=f"{self.cluster_id}/{name}",
                 secret={"keys": [
                     self._encrypt(kek_name, keys[0]),
                     self._encrypt(kek_name, keys[1]),
                 ]},
-                mount_point="kv",
+                mount_point=self.kv_mount,
             )
         except hvac.exceptions.VaultError as e:
             raise KMSException("Request failed") from e
 
     def get_data_encryption_keys(self, kek_name: str, name: str) -> tuple[str, str]:
         try:
-            encrypted_key1, encrypted_key2 = self.client.secrets.kv.v1.read_secret(
+            encrypted_key1, encrypted_key2 = self.client.secrets.kv.v2.read_secret_version(
                 path=f"{self.cluster_id}/{name}",
-                mount_point="kv",
-            )['data']['keys']
+                mount_point=self.kv_mount,
+            )['data']['data']['keys']
             return (
                 self._decrypt(kek_name, encrypted_key1),
                 self._decrypt(kek_name, encrypted_key2),
@@ -110,9 +112,9 @@ class HCPClient(KMS):
 
     def delete_data_encryption_keys(self, name: str) -> None:
         try:
-            self.client.secrets.kv.v1.delete_secret(
+            self.client.secrets.kv.v2.delete_metadata_and_all_versions(
                 path=f"{self.cluster_id}/{name}",
-                mount_point="kv",
+                mount_point=self.kv_mount,
             )
         except hvac.exceptions.VaultError as e:
             raise KMSException("Request failed") from e
@@ -120,16 +122,17 @@ class HCPClient(KMS):
     def create_key_encryption_key(self, name: str) -> None:
         try:
             self.client.secrets.transit.create_key(
-                name=name, key_type='aes256-gcm96', exportable=False
+                name=name, key_type='aes256-gcm96', exportable=False,
+                mount_point=self.transit_mount,
             )
             self.client.secrets.transit.update_key_configuration(
-                name=name, deletion_allowed=True
+                name=name, deletion_allowed=True, mount_point=self.transit_mount,
             )
         except hvac.exceptions.VaultError as e:
             raise KMSException("Request failed") from e
 
     def delete_key_encryption_key(self, name: str) -> None:
         try:
-            self.client.secrets.transit.delete_key(name=name)
+            self.client.secrets.transit.delete_key(name=name, mount_point=self.transit_mount)
         except hvac.exceptions.VaultError as e:
             raise KMSException("Request failed") from e

--- a/simplyblock_core/kms/_hcp.py
+++ b/simplyblock_core/kms/_hcp.py
@@ -71,7 +71,8 @@ class HCPClient(KMS):
             raise KMSException("Request failed") from e
         return base64.b64decode(plaintext_b64).hex()
 
-    def create_data_encryption_keys(self, kek_name: str, name: str) -> None:
+    def create_data_encryption_keys(self, lvol) -> None:
+        kek_name, name = str(lvol.pool_uuid), lvol.crypto_bdev
         try:
             self.client.secrets.kv.v2.create_or_update_secret(
                 path=f"{self.cluster_id}/{name}",
@@ -84,7 +85,8 @@ class HCPClient(KMS):
         except hvac.exceptions.VaultError as e:
             raise KMSException("Request failed") from e
 
-    def import_data_encryption_keys(self, kek_name: str, name: str, keys: tuple[str, str]) -> None:
+    def import_data_encryption_keys(self, lvol, keys: tuple[str, str]) -> None:
+        kek_name, name = str(lvol.pool_uuid), lvol.crypto_bdev
         try:
             self.client.secrets.kv.v2.create_or_update_secret(
                 path=f"{self.cluster_id}/{name}",
@@ -97,7 +99,8 @@ class HCPClient(KMS):
         except hvac.exceptions.VaultError as e:
             raise KMSException("Request failed") from e
 
-    def get_data_encryption_keys(self, kek_name: str, name: str) -> tuple[str, str]:
+    def get_data_encryption_keys(self, lvol) -> tuple[str, str]:
+        kek_name, name = str(lvol.pool_uuid), lvol.crypto_bdev
         try:
             encrypted_key1, encrypted_key2 = self.client.secrets.kv.v2.read_secret_version(
                 path=f"{self.cluster_id}/{name}",

--- a/simplyblock_core/models/cluster.py
+++ b/simplyblock_core/models/cluster.py
@@ -7,6 +7,9 @@ from simplyblock_core.models.base_model import BaseModel
 
 class HashicorpVaultSettings(BaseModel):
     base_url: str = ""
+    transit_mount: str = "simplyblock/transit"
+    kv_mount: str = "simplyblock/kv"
+    cert_role: str = "simplyblock-webappapi"
 
 
 class Cluster(BaseModel):

--- a/simplyblock_web/api/v2/cluster.py
+++ b/simplyblock_web/api/v2/cluster.py
@@ -43,6 +43,9 @@ class BackupConfigParams(BaseModel):
 
 class HashicorpVaultSettings(BaseModel):
     base_url: Optional[Annotated[AnyUrl, UrlConstraints(allowed_schemes=["https"])]] = None
+    transit_mount: str = "simplyblock/transit"
+    kv_mount: str = "simplyblock/kv"
+    cert_role: str = "simplyblock-webappapi"
 
 
 class ClusterParams(BaseModel):


### PR DESCRIPTION
2 changes:
* parameterise transit mount, KV mount and cert role and use `simplyblock/` as prefix
* KMS: pass the lvol object to {import,export}_data_encryption_keys function

Related PR on the helm-charts: https://github.com/simplyblock/helm-charts/pull/8


