### PR TITLE
lvol delete: delete DEK only when lvol.crypto_bdev is present

### DIFF
--- a/simplyblock_core/controllers/lvol_controller.py
+++ b/simplyblock_core/controllers/lvol_controller.py
@@ -1427,12 +1427,13 @@ def delete_lvol(id_or_name, force_delete=False):
 
     cl = db_controller.get_cluster_by_id(snode.cluster_id)
 
-    with create_kms_connection(cl) as kms:
-        try:
-            kms.delete_data_encryption_keys(lvol.crypto_bdev)
-            logger.info("Deleted lvol key")
-        except KMSException:
-            logger.exception("Failed to delete lvol key")
+    if lvol.crypto_bdev:
+        with create_kms_connection(cl) as kms:
+            try:
+                kms.delete_data_encryption_keys(lvol.crypto_bdev)
+                logger.info("Deleted lvol key")
+            except KMSException:
+                logger.exception("Failed to delete lvol key")
 
     logger.info("Done")
     return True


### PR DESCRIPTION
Fixes the exception:

```
2026-05-21 13:00:27,415: 139833633324544: ERROR: Failed to delete lvol key
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/simplyblock_core/controllers/lvol_controller.py", line 1432, in delete_lvol
    kms.delete_data_encryption_keys(lvol.crypto_bdev)
  File "/usr/local/lib/python3.9/site-packages/simplyblock_core/kms/_fdb.py", line 46, in delete_data_encryption_keys
    lvol = self._lvol_by_data_encryption_key_name(name)
  File "/usr/local/lib/python3.9/site-packages/simplyblock_core/kms/_fdb.py", line 21, in _lvol_by_data_encryption_key_name
    raise KMSException("Key name does not match expectations")
simplyblock_core.kms._exceptions.KMSException: Key name does not match expectations
2026-05-21 13:00:27,416: 139833633324544: INFO: Done
True
```

