### PR TITLE
fix security scan CVEs

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,7 @@ FROM simplyblock/simplyblock:base_image
 
 USER root
 
-RUN dnf install -y iproute procps-ng libcap-2.69-7.el10_1.1 openssh-9.9p1-14.el10_1 systemd-257-13.el10_1.3
+RUN dnf install -y iproute procps-ng libcap openssh systemd
 
 WORKDIR /app
 

--- a/docker/Dockerfile_base
+++ b/docker/Dockerfile_base
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM redhat/ubi10:10.1
+FROM registry.access.redhat.com/ubi10/ubi:10.2
 
 LABEL name="simplyblock"
 LABEL vendor="Simplyblock"
@@ -38,6 +38,8 @@ COPY requirements.txt requirements.txt
 RUN pip3 install --upgrade pip setuptools
 RUN yum remove python-urllib3 -y
 RUN pip3 install -r requirements.txt
+
+RUN dnf upgrade -y
 
 RUN dnf clean all
 


### PR DESCRIPTION
To fix failing CVEs. 

Built the base image and from the base image, have built the image this in this repo.

Have a successful scan here: 
https://github.com/simplyblock/sbcli/actions/runs/26291514948/job/77392704406
