### PR TITLE
enforce resource ownership and scope DB reads by cluster/pool

### DIFF
--- a/simplyblock_web/api/v2/backup.py
+++ b/simplyblock_web/api/v2/backup.py
@@ -70,9 +70,11 @@ def export_backups(
     if backup_id and not lvol_name_filter:
         try:
             backup = db.get_backup_by_id(backup_id)
-            lvol_name_filter = backup.lvol_name
         except KeyError:
             raise HTTPException(404, f"Backup {backup_id} not found")
+        if backup.cluster_id != cluster.get_id():
+            raise HTTPException(404, f"Backup {backup_id} not found")
+        lvol_name_filter = backup.lvol_name
     data = backup_controller.export_backups(
         cluster_id=cluster.get_id(), lvol_name=lvol_name_filter)
     return data

--- a/simplyblock_web/api/v2/device.py
+++ b/simplyblock_web/api/v2/device.py
@@ -32,9 +32,12 @@ instance_api = APIRouter(prefix='/{device_id}')
 
 def _lookup_device(storage_node: StorageNode, device_id: UUID) -> NVMeDevice:
     try:
-        return db.get_storage_device_by_id(str(device_id))
+        device = db.get_storage_device_by_id(str(device_id))
     except KeyError as e:
         raise HTTPException(404, str(e))
+    if device.node_id != storage_node.get_id():
+        raise HTTPException(404, f'Device {device_id} not found in storage node {storage_node.get_id()}')
+    return device
 
 
 Device = Annotated[NVMeDevice, Depends(_lookup_device)]

--- a/simplyblock_web/api/v2/migration.py
+++ b/simplyblock_web/api/v2/migration.py
@@ -52,12 +52,22 @@ def get_migration(cluster: Cluster, migration_id: str) -> MigrationDTO:
         migration = db.get_migration_by_id(migration_id)
     except KeyError as e:
         raise HTTPException(404, str(e))
+    if migration.cluster_id != cluster.get_id():
+        raise HTTPException(404, f'Migration {migration_id} not found in cluster {cluster.get_id()}')
     return MigrationDTO.from_model(migration)
 
 
 @instance_api.post('/cancel', name='clusters:migrations:cancel', status_code=200)
 def cancel_migration(cluster: Cluster, migration_id: str):
+    from simplyblock_core.db_controller import DBController
     from simplyblock_core.controllers import migration_controller
+    db = DBController()
+    try:
+        migration = db.get_migration_by_id(migration_id)
+    except KeyError as e:
+        raise HTTPException(404, str(e))
+    if migration.cluster_id != cluster.get_id():
+        raise HTTPException(404, f'Migration {migration_id} not found in cluster {cluster.get_id()}')
     ok, error = migration_controller.cancel_migration(migration_id)
     if not ok:
         raise HTTPException(400, error)

--- a/simplyblock_web/api/v2/pool.py
+++ b/simplyblock_web/api/v2/pool.py
@@ -21,13 +21,12 @@ db = DBController()
 @api.get('/', name='clusters:storage-pools:list')
 def list(cluster: Cluster) -> List[StoragePoolDTO]:
     data = []
-    for pool in db.get_pools():
-        if pool.cluster_id == cluster.get_id():
-            stat_obj = None
-            ret = db.get_pool_stats(pool, 1)
-            if ret:
-                stat_obj = ret[0]
-            data.append(StoragePoolDTO.from_model(pool, stat_obj))
+    for pool in db.get_pools(cluster.get_id()):
+        stat_obj = None
+        ret = db.get_pool_stats(pool, 1)
+        if ret:
+            stat_obj = ret[0]
+        data.append(StoragePoolDTO.from_model(pool, stat_obj))
     return data
 
 
@@ -68,11 +67,14 @@ def add(request: Request, cluster: Cluster, parameters: StoragePoolParams) -> Re
 instance_api = APIRouter(prefix='/{pool_id}')
 
 
-def _lookup_storage_pool(pool_id: UUID) -> PoolModel:
+def _lookup_storage_pool(pool_id: UUID, cluster: Cluster) -> PoolModel:
     try:
-        return db.get_pool_by_id(str(pool_id))
+        pool = db.get_pool_by_id(str(pool_id))
     except KeyError as e:
         raise HTTPException(404, str(e))
+    if pool.cluster_id != cluster.get_id():
+        raise HTTPException(404, f'Storage pool {pool_id} not found in cluster {cluster.get_id()}')
+    return pool
 
 
 StoragePool = Annotated[PoolModel, Depends(_lookup_storage_pool)]

--- a/simplyblock_web/api/v2/snapshot.py
+++ b/simplyblock_web/api/v2/snapshot.py
@@ -20,7 +20,7 @@ def list(request: Request, cluster: Cluster, pool: StoragePool) -> List[Snapshot
     return [
         SnapshotDTO.from_model(snapshot, request, cluster_id=cluster.get_id(), pool_id=pool.get_id())
         for snapshot
-        in db.get_snapshots()
+        in db.get_snapshots(cluster_id=cluster.get_id())
         if snapshot.pool_uuid == pool.get_id()
     ]
 
@@ -28,11 +28,14 @@ def list(request: Request, cluster: Cluster, pool: StoragePool) -> List[Snapshot
 instance_api = APIRouter(prefix='/{snapshot_id}')
 
 
-def _lookup_snapshot(snapshot_id: UUID) -> SnapshotModel:
+def _lookup_snapshot(snapshot_id: UUID, pool: StoragePool) -> SnapshotModel:
     try:
-        return db.get_snapshot_by_id(str(snapshot_id))
+        snapshot = db.get_snapshot_by_id(str(snapshot_id))
     except KeyError as e:
         raise HTTPException(404, str(e))
+    if snapshot.pool_uuid != pool.get_id():
+        raise HTTPException(404, f'Snapshot {snapshot_id} not found in pool {pool.get_id()}')
+    return snapshot
 
 
 Snapshot = Annotated[SnapshotModel, Depends(_lookup_snapshot)]
@@ -44,7 +47,7 @@ def get(request: Request, cluster: Cluster, pool: StoragePool, snapshot: Snapsho
 
 
 @instance_api.delete('/', name='clusters:storage-pools:snapshots:delete', status_code=204, responses={204: {"content": None}})
-def delete(cluster: Cluster, pool: StoragePool, snapshot: Snapshot) -> Response:
+def delete(snapshot: Snapshot) -> Response:
     if not snapshot_controller.delete(snapshot.get_id()):
         raise ValueError('Failed to delete snapshot')
 

--- a/simplyblock_web/api/v2/volume.py
+++ b/simplyblock_web/api/v2/volume.py
@@ -127,11 +127,14 @@ def add(
 instance_api = APIRouter(prefix='/{volume_id}')
 
 
-def _lookup_volume(volume_id: UUID) -> LVol:
+def _lookup_volume(volume_id: UUID, pool: StoragePool) -> LVol:
     try:
-        return db.get_lvol_by_id(str(volume_id))
+        volume = db.get_lvol_by_id(str(volume_id))
     except KeyError as e:
         raise HTTPException(404, str(e))
+    if volume.pool_uuid != pool.get_id():
+        raise HTTPException(404, f'Volume {volume_id} not found in pool {pool.get_id()}')
+    return volume
 
 
 Volume = Annotated[LVol, Depends(_lookup_volume)]
@@ -279,7 +282,7 @@ def snapshot(request: Request, cluster: Cluster, pool: StoragePool, volume: Volu
     return [
         SnapshotDTO.from_model(snapshot, request, cluster_id=cluster.get_id(), pool_id=pool.get_id(), volume_id=volume.get_id())
         for snapshot
-        in db.get_snapshots()
+        in db.get_snapshots(cluster_id=cluster.get_id())
         if snapshot.lvol is not None and snapshot.lvol.get_id() == volume.get_id()
     ]
 


### PR DESCRIPTION
At the moment, a caller with a valid token can supply a pool ID from a different cluster and get results. 

The changes here fixes this by adding checks in the FastAPI dependencies to make the following ownership present in the URLs is always followed. 

```
Cluster -->  StoragePool --> Volume
                         -->  Snapshot
```