### PR TITLE
pip python kubernetes client version to 35.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ py-cpuinfo
 pytest
 mock
 flask
-kubernetes
+kubernetes==35.0.0
 PyYAML
 urllib3
 graypy==2.1.0


### PR DESCRIPTION
using the latest version of kubernetes is causing this error
```
2026-05-25 12:15:55,153: 140538749599360: DEBUG: response body: b'{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"Unauthorized","reason":"Unauthorized","code":401}\n'
Traceback (most recent call last):
  File "/app/simplyblock_core/services/mgmt_node_monitor.py", line 99, in <module>
    reachable_ips = set(backend.get_reachable_nodes())
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/simplyblock_core/services/mgmt_node_monitor.py", line 49, in get_reachable_nodes
    nodes = self.v1.list_node().items
            ^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/kubernetes/client/api/core_v1_api.py", line 21591, in list_node
    return self.list_node_with_http_info(**kwargs)  # noqa: E501
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/kubernetes/client/api/core_v1_api.py", line 21736, in list_node_with_http_info
    return self.api_client.call_api(
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/kubernetes/client/api_client.py", line 374, in call_api
    return self.__call_api(resource_path, method,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/kubernetes/client/api_client.py", line 191, in __call_api
    raise e
  File "/usr/local/lib/python3.12/site-packages/kubernetes/client/api_client.py", line 184, in __call_api
    response_data = self.request(
                    ^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/kubernetes/client/api_client.py", line 400, in request
    return self.rest_client.GET(url,
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/kubernetes/client/rest.py", line 246, in GET
    return self.request("GET", url,
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/kubernetes/client/rest.py", line 229, in request
    raise UnauthorizedException(http_resp=r)
kubernetes.client.exceptions.UnauthorizedException: (401)
Reason: Unauthorized
HTTP response headers: HTTPHeaderDict({'Audit-Id': '285b1417-d8ad-4f9c-a66c-d4e1654f145e', 'Cache-Control': 'no-cache, private', 'Content-Type': 'application/json', 'Date': 'Mon, 25 May 2026 12:15:55 GMT', 'Content-Length': '129'})
HTTP response body: {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"Unauthorized","reason":"Unauthorized","code":401}
```

This is happening because latest version of kubernetes=36.0.0 released on may 20. 

In kubernetes=35.0.0, `load_incluster_config()` looks for `apikey["authorization"]` but in newer version it checks for `apikey["apiKey"]`

In kubernetes==36.0.0, the generated client auth path checks api_key["BearerToken"], while load_incluster_config() is still populating api_key["authorization"]. Because api_key["BearerToken"] is missing, no Authorization header is sent, and the API server returns 401.

