### PR TITLE
rebuild base image daily

### DIFF
--- a/.github/workflows/docker-base-image.yml
+++ b/.github/workflows/docker-base-image.yml
@@ -2,7 +2,7 @@ name: Docker Base Image Build
 
 on:
   schedule:
-    - cron: '0 5 * * SUN'  # Sundays at 5am
+    - cron: '0 5 * * *'  # Daily at 5am
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
`dnf update -y` is run as a part of the base image. 

currently its this base image is being built weekly.  making daily so that we don't have grype vulnerability scan failure. 