### PR TITLE
Bump indicated minimum python version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,7 @@ console_scripts = list(set(console_scripts))
 setup(
     name=COMMAND_NAME,
     version=VERSION,
-    requires_python='>= 3.9',
+    requires_python='>= 3.13',
     packages=find_packages(exclude=["e2e*"]),
     url='https://www.simplyblock.io/',
     author='Hamdy',


### PR DESCRIPTION
Recently b44cbc8a0 updated the version images are built with. This PR bumps the indicated version of this project accordingly.