### PR TITLE
fixed collection of docker control plane service logs

### DIFF
--- a/simplyblock_core/scripts/collect_logs.py
+++ b/simplyblock_core/scripts/collect_logs.py
@@ -1057,7 +1057,7 @@ def main():
         total_cp_lines = 0
         for svc in cp_services:
             out_f = cp_dir / f"{svc}.log"
-            gl_q = f'{gl_cname_field}:"{svc}"'
+            gl_q = f'{gl_cname_field}:/.*{_gl_escape(svc)}.*/'
             n = fetch(
                 gl_query=gl_q,
                 os_container=svc,
@@ -1154,7 +1154,7 @@ def main():
                     out_f = node_dir / fname
                     gl_q = (
                         f'kubernetes_pod_name:{_gl_escape(pod_name)} '
-                        f'AND kubernetes_container_name:{_gl_escape(cname)}'
+                        f'AND kubernetes_container_name:"{cname}"'
                     )
                     n = fetch(
                         gl_query=gl_q,

--- a/simplyblock_core/scripts/collect_logs.py
+++ b/simplyblock_core/scripts/collect_logs.py
@@ -1154,7 +1154,7 @@ def main():
                     out_f = node_dir / fname
                     gl_q = (
                         f'kubernetes_pod_name:{_gl_escape(pod_name)} '
-                        f'AND kubernetes_container_name:"{cname}"'
+                        f'AND kubernetes_container_name:/.*{_gl_escape(cname)}.*/'
                     )
                     n = fetch(
                         gl_query=gl_q,


### PR DESCRIPTION
Tested and Below is the output 

```
[root@vm11 ~]# python3 collect_logs.py "2026-05-31T10:00:00" 1
================================================================
  Simplyblock Log Collector
================================================================
  Window : 2026-05-31T10:00:00.000Z  →  2026-05-31T10:01:00.000Z  (1 min)
  Deploy : docker
  Mode   : Graylog REST API

[1] Retrieving cluster info …
    Cluster UUID : 5165d748-6e30-42c5-ad2d-d4f3c000b776
    Secret       : ********…  (len=20)

[2] Resolving management node …
    Management IP : 192.168.10.91  (1 node(s) total)

[3] Retrieving storage nodes …
    Found 3 storage node(s).

[4] Checking Graylog at http://192.168.10.91/graylog/api …
    OK  (version 5.0.13+083613e)

[5] Collecting control-plane logs (26 services, mode=docker) …
    total entries: 76
  WebAppAPI                                        76 lines
    total entries: 0
  fdb-server                                        0 lines
    total entries: 0
  fdb-backup-agent                                  0 lines
    total entries: 1211
  StorageNodeMonitor                            1,211 lines
    total entries: 117
  MgmtNodeMonitor                                 117 lines
    total entries: 6522
  LVolStatsCollector                            6,522 lines
    total entries: 352
  MainDistrEventCollector                         352 lines
    total entries: 3514
  CapacityAndStatsCollector                     3,514 lines
    total entries: 24
  CapacityMonitor                                  24 lines
    total entries: 420
  HealthCheck                                     420 lines
    total entries: 0
  DeviceMonitor                                     0 lines
    total entries: 12876
  LVolMonitor                                  12,876 lines
    total entries: 4220
  SnapshotMonitor                               4,220 lines
    total entries: 0
  TasksRunnerRestart                                0 lines
    total entries: 0
  TasksRunnerMigration                              0 lines
    total entries: 0
  TasksRunnerLVolMigration                          0 lines
    total entries: 0
  TasksRunnerFailedMigration                        0 lines
    total entries: 0
  TasksRunnerClusterStatus                          0 lines
    total entries: 0
  TasksRunnerNewDeviceMigration                     0 lines
    total entries: 0
  TasksNodeAddRunner                                0 lines
    total entries: 0
  TasksRunnerPortAllow                              0 lines
    total entries: 0
  TasksRunnerJCCompResume                           0 lines
    total entries: 0
  TasksRunnerLVolSyncDelete                         0 lines
    total entries: 0
  TasksRunnerBackup                                 0 lines
    total entries: 0
  TasksRunnerBackupMerge                            0 lines
    total entries: 0
  HAProxy                                           0 lines
  Control-plane total                          29,332 lines


```