### PR TITLE
Fix TLS file validation

### DIFF
--- a/simplyblock_core/cluster_ops.py
+++ b/simplyblock_core/cluster_ops.py
@@ -27,6 +27,7 @@ from simplyblock_core.models.nvme_device import NVMeDevice
 from simplyblock_core.models.storage_node import StorageNode
 from simplyblock_core.prom_client import PromClient
 from simplyblock_core.utils import pull_docker_image_with_retry
+from simplyblock_core.settings import Settings
 
 logger = utils.get_logger(__name__)
 
@@ -237,6 +238,9 @@ def create_cluster(blk_size, page_size_in_blocks, cli_pass,
             raise ValueError("max_fault_tolerance > 1 requires ha_type='ha'")
         if distr_npcs < 2:
             raise ValueError("max_fault_tolerance > 1 requires distr_npcs >= 2")
+
+    if (hashicorp_vault_settings is not None) and (Settings().tls_connect != "authenticated"):
+        raise ValueError("External KMS requires mTLS authentication to be used")
 
     if ingress_host_source == "dns" or ingress_host_source == "loadbalancer":
         if not dns_name:
@@ -483,6 +487,9 @@ def add_cluster(blk_size, page_size_in_blocks, cap_warn, cap_crit, prov_cap_warn
             raise ValueError("max_fault_tolerance > 1 requires ha_type='ha'")
         if distr_npcs < 2:
             raise ValueError("max_fault_tolerance > 1 requires distr_npcs >= 2")
+
+    if (hashicorp_vault_settings is not None) and (Settings().tls_connect != "authenticated"):
+        raise ValueError("External KMS requires mTLS authentication to be used")
 
     monitoring_secret = os.environ.get("MONITORING_SECRET", "")
 

--- a/simplyblock_core/controllers/pool_controller.py
+++ b/simplyblock_core/controllers/pool_controller.py
@@ -102,13 +102,13 @@ def add_pool(name, pool_max, lvol_max, max_rw_iops, max_rw_mbytes, max_r_mbytes,
         pool.dhchap_ctrlr_key = utils.generate_dhchap_key(length=32)
 
 
-    with create_kms_connection(cluster) as kms:
-        try:
+    try:
+        with create_kms_connection(cluster) as kms:
             kms.create_key_encryption_key(pool.get_id())
             logger.info("Created pool key")
-        except KMSException:
-            logger.exception("Failed to create pool key")
-            return False
+    except KMSException:
+        logger.exception("Failed to create pool key")
+        return False
 
     pool.status = "active"
     pool.write_to_db(db_controller.kv_store)

--- a/simplyblock_core/settings.py
+++ b/simplyblock_core/settings.py
@@ -58,7 +58,7 @@ class Settings(BaseSettings):
         if not self.tls_serve and self.tls_connect == "disabled":
             return self
 
-        if self.tls_serve and (
+        if (self.tls_serve or (self.tls_connect == "authenticated")) and (
             missing := [
                 name
                 for name in ["tls_certificate", "tls_key"]
@@ -66,7 +66,7 @@ class Settings(BaseSettings):
             ]
         ):
             raise ValueError(
-                "SB_TLS_SERVE=true requires TLS files to exist: " + ", ".join(missing)
+                "SB_TLS_SERVE=true/SB_TLS_CONNECT=authenticated require TLS files to exist: " + ", ".join(missing)
             )
 
         if (


### PR DESCRIPTION
This PR:
-  fixes the validation of TLS certificate files for use with mTLS
- ensures mTLS is used when an external KMS is configured
- fixes error handling on pool creation