### PR TITLE
hugepages: preserve user's pre-existing reservation per NUMA node

### DIFF
--- a/simplyblock_core/storage_node_ops.py
+++ b/simplyblock_core/storage_node_ops.py
@@ -2598,6 +2598,7 @@ def _restart_storage_node_impl(
                     snode.ssd_pcie.append(new_ssd)
 
         fdb_connection = cluster.db_connection
+        snode_api.set_hugepages()
         results, err = snode_api.spdk_process_start(
             snode.l_cores, snode.spdk_mem, snode.spdk_image, spdk_debug, cluster_ip, fdb_connection,
             snode.namespace, snode.mgmt_ip, snode.rpc_port, snode.rpc_username, snode.rpc_password,
@@ -4071,7 +4072,8 @@ def start_storage_node_api_container(node_ip, cluster_ip=None):
             # /mnt/ramdisk/spdk_<port>/spdk.sock. Without this, the endpoint
             # has to fall through to dockerd, which can stall for 60-80s
             # during post-outage Swarm reconciliation (incident 2026-04-24).
-            '/mnt/ramdisk:/mnt/ramdisk'],
+            '/mnt/ramdisk:/mnt/ramdisk',
+            '/tmp/simplyblock:/tmp/simplyblock'],
         restart_policy={"Name": "always"},
         environment=[
             f"DOCKER_IP={node_ip}",

--- a/simplyblock_core/utils/__init__.py
+++ b/simplyblock_core/utils/__init__.py
@@ -1989,6 +1989,42 @@ def format_device_with_4k(pci_device):
         logger.error(f"Failed to format device with 4K {e}")
 
 
+_HUGEPAGES_BASELINE_DIR = "/tmp/simplyblock"
+
+
+def _get_user_hugepages_baseline(node, current_hugepages):
+    """Return the per-NUMA user hugepage baseline, persisted across calls within a boot.
+
+    On first call for a given NUMA node (no baseline file), the current allocatable
+    hugepage count is the user's reservation — simplyblock hasn't touched it yet.
+    That value is written to /tmp/simplyblock/hugepages_baseline_node{N}.
+    On subsequent calls the file is read directly; /tmp/simplyblock is cleared on
+    reboot (host tmpfs / Docker/K8s hostPath volume) so the baseline is always
+    fresh after a reboot.
+    """
+    baseline_file = os.path.join(_HUGEPAGES_BASELINE_DIR, f"hugepages_baseline_node{node}")
+
+    if os.path.exists(baseline_file):
+        try:
+            with open(baseline_file) as f:
+                val = int(f.read().strip())
+            logger.debug(f"Node {node}: hugepage baseline from cache: {val}")
+            return val
+        except Exception as e:
+            logger.warning(f"Node {node}: could not read baseline file {baseline_file}: {e}")
+
+    # First call this boot — current value is the pre-simplyblock baseline.
+    try:
+        os.makedirs(_HUGEPAGES_BASELINE_DIR, exist_ok=True)
+        with open(baseline_file, "w") as f:
+            f.write(str(current_hugepages))
+        logger.info(f"Node {node}: saved hugepage baseline: {current_hugepages} -> {baseline_file}")
+    except Exception as e:
+        logger.warning(f"Node {node}: could not save hugepage baseline to {baseline_file}: {e}")
+
+    return current_hugepages
+
+
 def set_hugepages_if_needed(node, hugepages_needed, page_size_kb=2048):
     """Set hugepages for a specific NUMA node if current number is less than needed."""
     hugepage_path = f"/sys/devices/system/node/node{node}/hugepages/hugepages-{page_size_kb}kB/nr_hugepages"
@@ -1997,14 +2033,17 @@ def set_hugepages_if_needed(node, hugepages_needed, page_size_kb=2048):
         with open(hugepage_path, "r") as f:
             current_hugepages = int(f.read().strip())
 
-        if current_hugepages >= hugepages_needed:
-            logger.debug(f"Node {node}: already has {current_hugepages} hugepages, no change needed.")
+        user_baseline = _get_user_hugepages_baseline(node, current_hugepages)
+        required = user_baseline + hugepages_needed
+
+        if current_hugepages >= required:
+            logger.debug(f"Node {node}: already has {current_hugepages} hugepages >= required {required}, no change needed.")
         else:
-            hugepages_needed = adjust_hugepages(hugepages_needed)
-            logger.debug(f"Node {node}: has {current_hugepages} hugepages, setting to {hugepages_needed}...")
-            cmd = f"echo {hugepages_needed} | sudo tee /sys/devices/system/node/node{node}/hugepages/hugepages-2048kB/nr_hugepages"
+            required = adjust_hugepages(required)
+            logger.debug(f"Node {node}: setting to {required} (user baseline={user_baseline} + simplyblock={hugepages_needed})...")
+            cmd = f"echo {required} | sudo tee /sys/devices/system/node/node{node}/hugepages/hugepages-2048kB/nr_hugepages"
             subprocess.run(cmd, shell=True, check=True)
-            logger.debug(f"Node {node}: hugepages updated to {hugepages_needed}.")
+            logger.debug(f"Node {node}: hugepages updated to {required}.")
 
     except FileNotFoundError:
         logger.error(f"Node {node}: Hugepage path not found. Is hugepage support enabled?")

--- a/simplyblock_web/templates/storage_deploy_spdk.yaml.j2
+++ b/simplyblock_web/templates/storage_deploy_spdk.yaml.j2
@@ -39,6 +39,10 @@ spec:
     - name: etc-simplyblock
       hostPath:
         path: /var/simplyblock
+    - name: tmp-simplyblock
+      hostPath:
+        path: /tmp/simplyblock
+        type: DirectoryOrCreate
     - name: host-modules
       hostPath:
         path: /lib/modules
@@ -142,6 +146,8 @@ spec:
       volumeMounts:
         - name: socket-dir
           mountPath: /mnt/ramdisk
+        - name: tmp-simplyblock
+          mountPath: /tmp/simplyblock
         {% if TLS_SERVE or TLS_CONNECT != "disabled" %}
         - name: tls
           mountPath: /etc/simplyblock/tls

--- a/simplyblock_web/templates/storage_init_job.yaml.j2
+++ b/simplyblock_web/templates/storage_init_job.yaml.j2
@@ -21,6 +21,10 @@ spec:
         - name: host-proc
           hostPath:
             path: /proc
+        - name: tmp-simplyblock
+          hostPath:
+            path: /tmp/simplyblock
+            type: DirectoryOrCreate
         {% if TLS_CONNECT == "authenticated" %}
         - name: tls
           secret:
@@ -34,6 +38,8 @@ spec:
           volumeMounts:
             - name: host-proc
               mountPath: /proc
+            - name: tmp-simplyblock
+              mountPath: /tmp/simplyblock
             {% if TLS_CONNECT == "authenticated" %}
             - name: tls
               mountPath: /etc/simplyblock/tls
@@ -54,6 +60,23 @@ spec:
 
               echo "--- Checking OS ---"
               OS_ID="$(cat /proc/version | awk '{print $3}' | awk -F'-' '{print $NF}')"
+
+              echo "--- Capturing hugepage baseline per NUMA node ---"
+              for numa_dir in /sys/devices/system/node/node*/; do
+                node_id=$(basename "$numa_dir" | sed 's/node//')
+                case "$node_id" in ''|*[!0-9]*) continue ;; esac
+                hp_path="${numa_dir}hugepages/hugepages-2048kB/nr_hugepages"
+                if [ -f "$hp_path" ]; then
+                  hp_count=$(cat "$hp_path")
+                  baseline_file="/tmp/simplyblock/hugepages_baseline_node${node_id}"
+                  if [ ! -f "$baseline_file" ]; then
+                    echo "$hp_count" > "$baseline_file"
+                    echo "[INFO] NUMA ${node_id}: wrote hugepage baseline ${hp_count}"
+                  else
+                    echo "[INFO] NUMA ${node_id}: baseline already exists ($(cat $baseline_file)), skipping"
+                  fi
+                fi
+              done
 
               echo "--- Sending config to $NODE_IP ---"
               if [ "$OS_ID" != "talos" ]; then


### PR DESCRIPTION
  set_hugepages_if_needed now captures the allocatable hugepage count
  for each NUMA node before simplyblock allocates anything, persisting
  it to /tmp/simplyblock/hugepages_baseline_node{N}. On subsequent calls
  within the same boot the cached value is used, so simplyblock's own
  allocations don't inflate the baseline. After reboot /tmp/simplyblock
  is cleared and the baseline is re-sampled from scratch.

  required = user_baseline_per_numa + simplyblock_needed

  Add /tmp/simplyblock hostPath volume to the SNodeAPI Docker container
  and the SPDK pod template so the baseline files live on the host and
  survive container restarts within the same boot.