### PR TITLE
add-node: add --spdk-sys-mem option to override minimum system memory

### DIFF
--- a/simplyblock_cli/cli-reference.yaml
+++ b/simplyblock_cli/cli-reference.yaml
@@ -261,6 +261,10 @@ commands:
             type: int
             default: 5000
             private: true
+          - name: "--spdk-sys-mem"
+            help: "System memory reserved for non-SPDK use (e.g. 2G, 4096M). Overrides the auto-calculated minimum_sys_memory. If not set, the value is derived from the node configuration."
+            dest: spdk_sys_mem
+            type: str
           - name: "--spdk-proxy-image"
             help: "The SPDK proxy image URI."
             dest: spdk_proxy_image

--- a/simplyblock_cli/cli.py
+++ b/simplyblock_cli/cli.py
@@ -149,6 +149,7 @@ class CLIWrapper(CLIWrapperBase):
             argument = subcommand.add_argument('--id-device-by-nqn', help='Use the device NQN instead of the serial number for identification. Default: `false`.', dest='id_device_by_nqn', action='store_true')
         if self.developer_mode:
             argument = subcommand.add_argument('--max-snap', help='The max snapshot per storage node. Default: `5000`.', type=int, default=5000, dest='max_snap')
+        argument = subcommand.add_argument('--spdk-sys-mem', help='System memory reserved for non-SPDK use (e.g. 2G, 4096M). Overrides the auto-calculated minimum_sys_memory. If not set, the value is derived from the node configuration.', type=str, dest='spdk_sys_mem')
         if self.developer_mode:
             argument = subcommand.add_argument('--spdk-proxy-image', help='The SPDK proxy image URI.', type=str, dest='spdk_proxy_image')
 

--- a/simplyblock_cli/clibase.py
+++ b/simplyblock_cli/clibase.py
@@ -169,6 +169,7 @@ class CLIWrapperBase:
         ha_jm_count = args.ha_jm_count
         format_4k = args.format_4k
         num_partitions_per_dev = 0 if args.enable_journal_device else 1
+        spdk_sys_mem = getattr(args, 'spdk_sys_mem', None)
 
         try:
             out = storage_ops.add_node(
@@ -191,6 +192,7 @@ class CLIWrapperBase:
                 ha_jm_count=ha_jm_count,
                 format_4k=format_4k,
                 spdk_proxy_image=getattr(args, 'spdk_proxy_image', None),
+                spdk_sys_mem=spdk_sys_mem,
             )
         except Exception as e:
             print(e)

--- a/simplyblock_core/storage_node_ops.py
+++ b/simplyblock_core/storage_node_ops.py
@@ -1547,7 +1547,8 @@ def add_node(cluster_id, node_addr, iface_name, data_nics_list,
              small_bufsize=0, large_bufsize=0,
              num_partitions_per_dev=0, jm_percent=0, enable_test_device=False,
              namespace=None, enable_ha_jm=False, cr_name=None, cr_namespace=None, cr_plural=None,
-             id_device_by_nqn=False, partition_size="", ha_jm_count=None, format_4k=False, spdk_proxy_image=None):
+             id_device_by_nqn=False, partition_size="", ha_jm_count=None, format_4k=False,
+             spdk_proxy_image=None, spdk_sys_mem=None):
     snode_api = SNodeClient(node_addr)
     node_info, _ = snode_api.info()
     if node_info.get("nodes_config") and node_info["nodes_config"].get("nodes"):
@@ -1644,7 +1645,10 @@ def add_node(cluster_id, node_addr, iface_name, data_nics_list,
             return False
 
         # Calculate minimum sys memory
-        minimum_sys_memory = node_config.get("sys_memory")
+        if spdk_sys_mem:
+            minimum_sys_memory = int(utils.parse_size(spdk_sys_mem))
+        else:
+            minimum_sys_memory = node_config.get("sys_memory")
         max_lvol = node_config.get("max_lvol")
         ssd_pcie = node_config.get("ssd_pcis")
 

--- a/simplyblock_web/api/v1/storage_node.py
+++ b/simplyblock_web/api/v1/storage_node.py
@@ -268,6 +268,7 @@ def storage_node_add():
             format_4k = param == "true"
 
     spdk_proxy_image = req_data.get('spdk_proxy_image', None)
+    spdk_sys_mem = req_data.get('spdk_sys_mem', None)
     tasks_controller.add_node_add_task(cluster_id, {
         "cluster_id": cluster_id,
         "node_addr": node_addr,
@@ -286,6 +287,7 @@ def storage_node_add():
         "ha_jm_count": ha_jm_count,
         "format_4k": format_4k,
         "spdk_proxy_image": spdk_proxy_image,
+        "spdk_sys_mem": spdk_sys_mem,
     })
 
     return utils.get_response(True)

--- a/simplyblock_web/api/v2/storage_node.py
+++ b/simplyblock_web/api/v2/storage_node.py
@@ -52,6 +52,7 @@ class StorageNodeParams(BaseModel):
     ha_jm_count: Optional[int] = Field(None)
     format_4k: bool = Field(False)
     spdk_proxy_image: Optional[str] = None
+    spdk_sys_mem: Optional[str] = None
 
 
 @api.post('/', name='clusters:storage-nodes:create', status_code=201, responses={201: {"content": None}})
@@ -80,6 +81,7 @@ def add(cluster: Cluster, parameters: StorageNodeParams):
             "ha_jm_count": parameters.ha_jm_count,
             "format_4k": parameters.format_4k,
             "spdk_proxy_image": parameters.spdk_proxy_image,
+            "spdk_sys_mem": parameters.spdk_sys_mem,
         }
     )
     if not task_id_or_false:


### PR DESCRIPTION
  Add a new --spdk-sys-mem option to `sbcli sn add-node` (and the
  equivalent v1/v2 REST API parameters) that lets the caller specify the
  system memory reserved for non-SPDK use as a human-readable size
  (e.g. 2G, 4096M).

  When provided it overrides the value auto-calculated from the node
  configuration; when omitted behaviour is unchanged.