### PR TITLE
Dockerfile: dnf install the latest version of libcap openssh systemd

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,7 @@ FROM simplyblock/simplyblock:base_image
 
 USER root
 
-RUN dnf install -y iproute procps-ng libcap-2.69-7.el10_2.1 openssh-9.9p1-23.el10_2 systemd-257-23.el10_2.1
+RUN dnf install -y iproute procps-ng libcap openssh systemd
 
 WORKDIR /app
 


### PR DESCRIPTION
This passes the security scan: https://github.com/simplyblock/sbcli/actions/runs/26956558489/job/79535246351

where the one from latest main does:
https://github.com/simplyblock/sbcli/actions/runs/26956376328/job/79534600898

as it complains with error:
```
4.087 No match for argument: systemd-257-23.el10_2.1
4.100 Error: Unable to find a match: systemd-257-23.el10_2.1
------
```
