### PR TITLE
POST volume: return 422 when invalid node ID is passed

### DIFF
--- a/simplyblock_core/controllers/lvol_controller.py
+++ b/simplyblock_core/controllers/lvol_controller.py
@@ -416,7 +416,7 @@ def add_lvol_ha(name, size, host_id_or_name, ha_type, pool_id_or_name, use_comp=
             if len(nodes) > 0:
                 host_node = nodes[0]
             else:
-                return False, f"Can not find storage node: {host_id_or_name}"
+                raise KeyError(f"Can not find storage node: {host_id_or_name}")
         if host_node.lvol_sync_del():
             logger.info(f"LVol sync delete task on node: {host_node.get_id()}, proceeding anyway")
 

--- a/simplyblock_web/api/v2/cluster/storage_pool/volume/__init__.py
+++ b/simplyblock_web/api/v2/cluster/storage_pool/volume/__init__.py
@@ -113,7 +113,7 @@ def add(
         raise AssertionError('unreachable')
 
     if volume_id_or_false == False:  # noqa
-        raise ValueError(error)
+        raise HTTPException(422, error)
 
     return util.creation_response(
         request, response_format,

--- a/simplyblock_web/api/v2/cluster/storage_pool/volume/__init__.py
+++ b/simplyblock_web/api/v2/cluster/storage_pool/volume/__init__.py
@@ -75,31 +75,34 @@ def add(
         pass
 
     if isinstance(data, _CreateParams):
-        volume_id_or_false, error = lvol_controller.add_lvol_ha(
-            name=data.name,
-            size=data.size,
-            pool_id_or_name=pool.get_id(),
-            use_crypto=data.encrypt,
-            max_size=0,
-            max_rw_iops=data.max_rw_iops,
-            max_rw_mbytes=data.max_rw_mbytes,
-            max_r_mbytes=data.max_r_mbytes,
-            max_w_mbytes=data.max_w_mbytes,
-            host_id_or_name=data.host_id,
-            ha_type=data.ha_type if data.ha_type is not None else 'default',
-            use_comp=False,
-            distr_vuid=0,
-            lvol_priority_class=data.priority_class,
-            namespaced=data.namespaced,
-            pvc_name=data.pvc_name,
-            ndcs=data.ndcs,
-            npcs=data.npcs,
-            allowed_hosts=data.allowed_hosts,
-            fabric=data.fabric,
-            max_namespace_per_subsys=data.max_namespace_per_subsys,
-            do_replicate=data.do_replicate,
-            replication_cluster_id=data.replication_cluster_id,
-        )
+        try:
+            volume_id_or_false, error = lvol_controller.add_lvol_ha(
+                name=data.name,
+                size=data.size,
+                pool_id_or_name=pool.get_id(),
+                use_crypto=data.encrypt,
+                max_size=0,
+                max_rw_iops=data.max_rw_iops,
+                max_rw_mbytes=data.max_rw_mbytes,
+                max_r_mbytes=data.max_r_mbytes,
+                max_w_mbytes=data.max_w_mbytes,
+                host_id_or_name=data.host_id,
+                ha_type=data.ha_type if data.ha_type is not None else 'default',
+                use_comp=False,
+                distr_vuid=0,
+                lvol_priority_class=data.priority_class,
+                namespaced=data.namespaced,
+                pvc_name=data.pvc_name,
+                ndcs=data.ndcs,
+                npcs=data.npcs,
+                allowed_hosts=data.allowed_hosts,
+                fabric=data.fabric,
+                max_namespace_per_subsys=data.max_namespace_per_subsys,
+                do_replicate=data.do_replicate,
+                replication_cluster_id=data.replication_cluster_id,
+            )
+        except KeyError as e:
+            raise HTTPException(404, str(e))
     elif isinstance(data, _CloneParams):
         volume_id_or_false, error = snapshot_controller.clone(
             data.snapshot_id,

--- a/tests/unit/web/api/v2/test_volume_endpoints.py
+++ b/tests/unit/web/api/v2/test_volume_endpoints.py
@@ -78,6 +78,16 @@ class TestCreateVolume:
         )
         lvol_controller.add_lvol_ha.assert_not_called()
 
+    def test_missing_host_node_returns_404(self, client, db, pool, lvol_controller):
+        db.get_lvol_by_name.side_effect = KeyError('LVol not found')
+        lvol_controller.add_lvol_ha.side_effect = KeyError('Can not find storage node: bogus-id')
+
+        response = client.post(
+            f'{BASE}/', json={'name': 'volume-1', 'size': '10G', 'host_id': 'bogus-id'},
+        )
+
+        assert response.status_code == 404
+
     def test_existing_name_returns_409(self, client, db, pool, volume, lvol_controller):
         db.get_lvol_by_name.return_value = volume
 


### PR DESCRIPTION
When I passed incorrect storage-node-id as a part of volume create, it failed with 500 error. So handling this gracefully. 

```
26-06-08 08:36:41,704: 140277069612736: INFO: Adding LVol: pvc-4709f037-654b-416f-8d80-74ee13b041b0
ERROR:    Exception in ASGI application
Traceback (most recent call last):
  File "/usr/local/lib/python3.12/site-packages/uvicorn/protocols/http/h11_impl.py", line 415, in run_asgi
    result = await app(  # type: ignore[func-returns-value]
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/uvicorn/middleware/proxy_headers.py", line 62, in __call__
    return await self.app(scope, receive, send)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/fastapi/applications.py", line 1159, in __call__
    await super().__call__(scope, receive, send)
  File "/usr/local/lib/python3.12/site-packages/starlette/applications.py", line 90, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/usr/local/lib/python3.12/site-packages/starlette/middleware/errors.py", line 186, in __call__
    raise exc
  File "/usr/local/lib/python3.12/site-packages/starlette/middleware/errors.py", line 164, in __call__
    await self.app(scope, receive, _send)
  File "/usr/local/lib/python3.12/site-packages/starlette/middleware/base.py", line 191, in __call__
    with recv_stream, send_stream, collapse_excgroups():
                                   ^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.12/contextlib.py", line 158, in __exit__
    self.gen.throw(value)
  File "/usr/local/lib/python3.12/site-packages/starlette/_utils.py", line 87, in collapse_excgroups
    raise exc
  File "/usr/local/lib/python3.12/site-packages/starlette/middleware/base.py", line 193, in __call__
    response = await self.dispatch_func(request, call_next)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/simplyblock_web/app.py", line 49, in dispatch
    response = await call_next(request)
               ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/starlette/middleware/base.py", line 168, in call_next
    raise app_exc from app_exc.__cause__ or app_exc.__context__
  File "/usr/local/lib/python3.12/site-packages/starlette/middleware/base.py", line 144, in coro
    await self.app(scope, receive_or_disconnect, send_no_error)
  File "/usr/local/lib/python3.12/site-packages/starlette/middleware/exceptions.py", line 63, in __call__
    await wrap_app_handling_exceptions(self.app, conn)(scope, receive, send)
  File "/usr/local/lib/python3.12/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
    raise exc
  File "/usr/local/lib/python3.12/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app
    await app(scope, receive, sender)
  File "/usr/local/lib/python3.12/site-packages/fastapi/middleware/asyncexitstack.py", line 18, in __call__
    await self.app(scope, receive, send)
  File "/usr/local/lib/python3.12/site-packages/starlette/routing.py", line 660, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/usr/local/lib/python3.12/site-packages/starlette/routing.py", line 680, in app
    await route.handle(scope, receive, send)
  File "/usr/local/lib/python3.12/site-packages/starlette/routing.py", line 276, in handle
    await self.app(scope, receive, send)
  File "/usr/local/lib/python3.12/site-packages/fastapi/routing.py", line 134, in app
    await wrap_app_handling_exceptions(app, request)(scope, receive, send)
  File "/usr/local/lib/python3.12/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
    raise exc
  File "/usr/local/lib/python3.12/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app
    await app(scope, receive, sender)
  File "/usr/local/lib/python3.12/site-packages/fastapi/routing.py", line 120, in app
    response = await f(request)
               ^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/fastapi/routing.py", line 674, in app
    raw_response = await run_endpoint_function(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/fastapi/routing.py", line 330, in run_endpoint_function
    return await run_in_threadpool(dependant.call, **values)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/starlette/concurrency.py", line 32, in run_in_threadpool
    return await anyio.to_thread.run_sync(func)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/anyio/to_thread.py", line 63, in run_sync
    return await get_async_backend().run_sync_in_worker_thread(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/anyio/_backends/_asyncio.py", line 2518, in run_sync_in_worker_thread
    return await future
           ^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/anyio/_backends/_asyncio.py", line 1002, in run
    result = context.run(func, *args)
             ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/simplyblock_web/api/v2/volume.py", line 113, in add
    raise ValueError(error)
ValueError: Can not find storage node: 11b5520f-af61-4c7c-b714-c8ca20954e4c
```