### PR TITLE
Harden failure handling & concurrency (audit items 1–3)

### DIFF
--- a/simplyblock_core/constants.py
+++ b/simplyblock_core/constants.py
@@ -98,6 +98,21 @@ RESTART_TASK_EXEC_INTERVAL_SEC = 3
 # transient peer-recovery waits without giving up prematurely.
 RESTART_TASK_EXEC_INTERVAL_MAX_SEC = 3600
 
+# A JobSchedule's lease is held by the runner host (by hostname) that last
+# touched it. Another host may only take over a task whose lease is older than
+# this — i.e. the owning runner is presumed dead. Must exceed the longest
+# single task_runner() invocation that does not write the task back (the
+# restart runner can block on RPCs for several minutes), so a live owner is
+# never falsely preempted. A runner restarting on the SAME host re-claims its
+# own tasks immediately regardless of this value (owner id is the hostname).
+TASK_LEASE_TTL_SEC = 1200
+
+# An LVol left in STATUS_IN_CREATION longer than this is treated as an orphaned
+# create (the creating process died before reaching ONLINE) and is cleaned up
+# by lvol_monitor. Must be comfortably longer than the slowest legitimate
+# create (HA multi-node registration) so an in-progress create is never killed.
+LVOL_IN_CREATION_STALE_SEC = 600
+
 SIMPLY_BLOCK_SPDK_CORE_IMAGE = "simplyblock/spdk-core:v24.05-tag-latest"
 SIMPLY_BLOCK_DOCKER_IMAGE = get_config_var(
         "SIMPLY_BLOCK_DOCKER_IMAGE","simplyblock/simplyblock:main")

--- a/simplyblock_core/controllers/device_controller.py
+++ b/simplyblock_core/controllers/device_controller.py
@@ -274,7 +274,12 @@ def _def_create_device_stack(device_obj, snode, force=False, clear_data=False):
     rpc_client = snode.rpc_client(timeout=600)
 
     bdev_names = []
-    for dev in rpc_client.get_bdevs():
+    bdevs = rpc_client.get_bdevs()
+    if bdevs is None:
+        # None is an RPC failure (timeout / non-200), not an empty bdev list;
+        # fail loudly instead of crashing on a None iteration below.
+        raise Exception(f"get_bdevs failed on node {snode.get_id()}")
+    for dev in bdevs:
         bdev_names.append(dev['name'])
 
     nvme_bdev = device_obj.nvme_bdev
@@ -1026,7 +1031,10 @@ def restart_jm_device(device_id, force=False, format_alceml=False):
     if snode.jm_device:
         rpc_client = snode.rpc_client()
         if snode.jm_device.raid_bdev:
-            bdevs_names = [d['name'] for d in rpc_client.get_bdevs()]
+            bdevs = rpc_client.get_bdevs()
+            if bdevs is None:
+                raise Exception(f"get_bdevs failed on node {snode.get_id()}")
+            bdevs_names = [d['name'] for d in bdevs]
             jm_nvme_bdevs = []
             for dev in snode.nvme_devices:
                 if dev.status not in [NVMeDevice.STATUS_ONLINE, NVMeDevice.STATUS_NEW]:

--- a/simplyblock_core/controllers/lvol_controller.py
+++ b/simplyblock_core/controllers/lvol_controller.py
@@ -1544,13 +1544,15 @@ def delete_lvol(id_or_name, force_delete=False):
     elif lvol.cloned_from_snap:
         try:
             snap = db_controller.get_snapshot_by_id(lvol.cloned_from_snap)
+            # Atomic decrement: a plain read-modify-write races a concurrent
+            # clone-create's increment and loses one update, leaving ref_count
+            # too high (snapshot leaks, never freed) or too low.
             if snap.snap_ref_id:
                 ref_snap = db_controller.get_snapshot_by_id(snap.snap_ref_id)
-                ref_snap.ref_count -= 1
-                ref_snap.write_to_db(db_controller.kv_store)
+                if ref_snap:
+                    db_controller.atomic_update(ref_snap, lambda s: setattr(s, "ref_count", s.ref_count - 1))
             else:
-                snap.ref_count -= 1
-                snap.write_to_db(db_controller.kv_store)
+                db_controller.atomic_update(snap, lambda s: setattr(s, "ref_count", s.ref_count - 1))
             if snap.deleted is True:
                 snapshot_controller.delete(snap.get_id())
         except KeyError:

--- a/simplyblock_core/controllers/snapshot_controller.py
+++ b/simplyblock_core/controllers/snapshot_controller.py
@@ -76,6 +76,23 @@ def add(lvol_id, snapshot_name, backup=False, lock=True, all_snaps=None, all_lvo
     except KeyError:
         pass
 
+    # Block while a live volume migration holds the snapshot-freeze on this
+    # source node. The migration runner freezes the source LVS to copy a
+    # consistent snapshot chain; a snapshot created mid-migration races that
+    # freeze and can corrupt the per-node snapshot plan. This enforces the
+    # one-migration-per-source-node invariant the migration controller
+    # documents but previously never checked (is_migration_active_on_node had
+    # no callers). cluster_id is omitted because LVol has no cluster_id field;
+    # the predicate matches on node_id, so an all-clusters scan is correct.
+    try:
+        if migration_controller.is_migration_active_on_node(lvol.node_id):
+            msg = (f"Cannot create snapshot: a live volume migration is active "
+                   f"on node {lvol.node_id}")
+            logger.error(msg)
+            return False, msg
+    except Exception as e:
+        logger.warning(f"Migration-active check failed for node {lvol.node_id}: {e}")
+
     pool = db_controller.get_pool_by_id(lvol.pool_uuid)
     if pool.status == Pool.STATUS_INACTIVE:
         msg = "Pool is disabled"
@@ -285,10 +302,16 @@ def add(lvol_id, snapshot_name, backup=False, lock=True, all_snaps=None, all_lvo
             if original_snap.snap_ref_id:
                 original_snap = db_controller.get_snapshot_by_id(original_snap.snap_ref_id)
 
-            original_snap.ref_count += 1
-            original_snap.write_to_db(db_controller.kv_store)
-            snap.snap_ref_id = original_snap.get_id()
-            snap.write_to_db(db_controller.kv_store)
+            # Atomic increment: a plain read-modify-write loses an increment
+            # when two clones of the same snapshot run concurrently, which can
+            # under-count ref_count and let a still-referenced snapshot be
+            # deleted (data loss).
+            if original_snap:
+                original_snap = db_controller.atomic_update(
+                    original_snap, lambda s: setattr(s, "ref_count", s.ref_count + 1))
+            if original_snap:
+                snap.snap_ref_id = original_snap.get_id()
+                snap.write_to_db(db_controller.kv_store)
 
     for sn in all_snaps:
         if sn.get_id() == snap.get_id():
@@ -882,13 +905,14 @@ def clone(snapshot_id, clone_name, new_size=0, pvc_name=None, pvc_namespace=None
     lvol.status = LVol.STATUS_ONLINE
     lvol.write_to_db(db_controller.kv_store)
 
+    # Atomic increment (see add() above): concurrent clones must not lose a
+    # ref_count bump.
     if snap.snap_ref_id:
         ref_snap = db_controller.get_snapshot_by_id(snap.snap_ref_id)
-        ref_snap.ref_count += 1
-        ref_snap.write_to_db(db_controller.kv_store)
+        if ref_snap:
+            db_controller.atomic_update(ref_snap, lambda s: setattr(s, "ref_count", s.ref_count + 1))
     else:
-        snap.ref_count += 1
-        snap.write_to_db(db_controller.kv_store)
+        db_controller.atomic_update(snap, lambda s: setattr(s, "ref_count", s.ref_count + 1))
 
     logger.info("Done")
     snapshot_events.snapshot_clone(snap, lvol)

--- a/simplyblock_core/controllers/tasks_controller.py
+++ b/simplyblock_core/controllers/tasks_controller.py
@@ -2,6 +2,7 @@
 import datetime
 import json
 import logging
+import socket
 import time
 import uuid
 
@@ -13,6 +14,60 @@ from simplyblock_core.models.storage_node import StorageNode
 
 logger = logging.getLogger()
 db = db_controller.DBController()
+
+# Identity used for task leases. Hostname (not pid) so a runner that crashes
+# and restarts on the same host re-claims its own in-flight tasks immediately.
+_RUNNER_HOST = socket.gethostname()
+
+
+def _task_lease_is_stale(task):
+    """True if the task's lease (its last write) is older than the TTL, i.e.
+    the owning runner host is presumed dead and another host may take over."""
+    if not task.updated_at:
+        return True
+    try:
+        last = datetime.datetime.fromisoformat(task.updated_at)
+    except (ValueError, TypeError):
+        return True
+    if last.tzinfo is None:
+        last = last.replace(tzinfo=datetime.timezone.utc)
+    age = (datetime.datetime.now(datetime.timezone.utc) - last).total_seconds()
+    return age > constants.TASK_LEASE_TTL_SEC
+
+
+def claim_task(task, owner=None):
+    """Atomically claim a task for this runner host before executing it.
+
+    Returns True if this host now holds the lease and may run the task, or
+    False if another still-alive host owns it (caller must skip it this cycle).
+
+    The lease is keyed by hostname and refreshed (via updated_at) on every
+    claim and on every task write. A second runner replica on a *different*
+    host is locked out until the lease goes stale (constants.TASK_LEASE_TTL_SEC),
+    which is what prevents two replicas from both executing the same
+    side-effecting task during a rolling deploy or a transient dual-manager
+    window. A runner on the *same* host always wins immediately, so the common
+    single-replica deployment is unaffected (this gate returns True).
+
+    Done/canceled tasks are never claimed.
+    """
+    owner = owner or _RUNNER_HOST
+    decision = {"won": False}
+    now = str(datetime.datetime.now(datetime.timezone.utc))
+
+    def _mutate(t):
+        if t.status == JobSchedule.STATUS_DONE or t.canceled:
+            return False  # not claimable; decision stays False
+        if t.owner and t.owner != owner and not _task_lease_is_stale(t):
+            return False  # owned by another live host
+        t.owner = owner
+        t.updated_at = now  # refresh the lease (atomic_update bypasses write_to_db)
+        decision["won"] = True
+        return True
+
+    if db.atomic_update(task, _mutate) is None:
+        return False
+    return decision["won"]
 
 
 def _validate_new_task_dev_restart(cluster_id, node_id, device_id):

--- a/simplyblock_core/db_controller.py
+++ b/simplyblock_core/db_controller.py
@@ -449,6 +449,48 @@ class DBController(metaclass=Singleton):
         transactional = fdb.transactional(DBController._release_backup_chain_locks_tx)
         transactional(self, self.kv_store, ordered_snapshot_ids)
 
+    # ---- Generic atomic read-modify-write (Single FDB Transaction) ----
+
+    def _atomic_update_tx(self, tr, key, model_cls, mutate_fn):
+        raw = tr.get(key).wait()
+        if not raw.present():
+            return None
+        obj = model_cls().from_dict(json.loads(raw))
+        if mutate_fn(obj) is False:
+            return obj
+        tr[key] = json.dumps(obj.to_dict()).encode()
+        return obj
+
+    def atomic_update(self, obj, mutate_fn):
+        """Transactional read-modify-write of a single object.
+
+        Re-reads ``obj`` fresh from FDB inside a transaction, applies
+        ``mutate_fn(fresh)`` (which must mutate the object in place), and writes
+        it back atomically. FoundationDB's serializable isolation plus the
+        automatic conflict-retry of ``fdb.transactional`` make this a true
+        compare-and-set: if another writer commits between this read and the
+        write, the whole transaction (including ``mutate_fn``) is replayed on
+        the new value. This avoids the lost-update that plain
+        ``read(); obj.x = y; obj.write_to_db()`` suffers — the latter writes the
+        entire serialized object and silently clobbers concurrent updates to
+        other fields.
+
+        IMPORTANT: ``mutate_fn`` may be invoked more than once (on conflict
+        retry), so it MUST be free of side effects other than mutating the
+        object passed to it — no RPCs, no DB writes, no event emission. Do that
+        work after this returns. Return ``False`` from ``mutate_fn`` to abort
+        the write (e.g. when a guard condition no longer holds on the fresh
+        object).
+
+        Returns the fresh, post-mutation object, or ``None`` if the object no
+        longer exists in the DB.
+        """
+        if not self.kv_store:
+            return None
+        key = obj.get_db_id().encode()
+        transactional = fdb.transactional(DBController._atomic_update_tx)
+        return transactional(self, self.kv_store, key, type(obj), mutate_fn)
+
     # ---- Pre-Restart Guard (Single FDB Transaction) ----
 
     def _try_set_node_restarting_tx(self, tr, cluster_id, node_id):

--- a/simplyblock_core/models/job_schedule.py
+++ b/simplyblock_core/models/job_schedule.py
@@ -40,6 +40,11 @@ class JobSchedule(BaseModel):
     node_id: str = ""
     retry: int = 0
     sub_tasks: list = []
+    # Hostname of the runner that currently holds this task's lease. Empty
+    # means unclaimed. Combined with updated_at (refreshed on every write) this
+    # gives a soft lease: a different host may take over only once the lease
+    # goes stale (see constants.TASK_LEASE_TTL_SEC). See tasks_controller.claim_task.
+    owner: str = ""
 
     def write_to_db(self, kv_store=None):
         self.updated_at = str(datetime.datetime.now(datetime.timezone.utc))

--- a/simplyblock_core/rpc_client.py
+++ b/simplyblock_core/rpc_client.py
@@ -93,7 +93,16 @@ _response_validator = jsonschema.validators.validator_for(_response_schema)(_res
 class RPCClient:
 
     # ref: https://spdk.io/doc/jsonrpc.html
-    DEFAULT_ALLOWED_METHODS = ["HEAD", "GET", "PUT", "DELETE", "OPTIONS", "TRACE", "POST"]
+    # POST is deliberately EXCLUDED. SPDK JSON-RPC sends every call — including
+    # non-idempotent mutations (bdev/snapshot create, resize, add_ns, transfer)
+    # — as a POST. urllib3 gates *read*-error retries (e.g. a read timeout after
+    # the request was already delivered and is executing on the node) on this
+    # set, so retrying POST here silently re-applies a mutation that may already
+    # have taken effect — e.g. a second snapshot, a re-triggered async transfer.
+    # Connection-error retries (`connect=`) are independent of this set and
+    # still apply, since a failed *connect* means the request never reached the
+    # node and is safe to resend.
+    DEFAULT_ALLOWED_METHODS = ["HEAD", "GET", "PUT", "DELETE", "OPTIONS", "TRACE"]
     RPC_NO_PRINT_OUTPUT = ["bdev_get_bdevs", "nvmf_get_subsystems", "bdev_get_iostat"]
 
     def __init__(self, host, port, username, password, timeout=180, retry=3):

--- a/simplyblock_core/services/device_monitor.py
+++ b/simplyblock_core/services/device_monitor.py
@@ -25,29 +25,36 @@ while True:
         continue
     for cluster in db.get_clusters():
         for node in db.get_storage_nodes_by_cluster_id(cluster.get_id()):
-            auto_restart_devices = []
+            # Per-node isolation: a failure (e.g. an RPC inside device_set_online)
+            # on one node must not abort the sweep over the remaining nodes and
+            # clusters for this tick.
+            try:
+                auto_restart_devices = []
 
-            if node.status != StorageNode.STATUS_ONLINE:
-                logger.warning(f"Node status is not online, id: {node.get_id()}, status: {node.status}")
-                continue
-            for dev in node.nvme_devices:
-                if dev.status not in [NVMeDevice.STATUS_ONLINE, NVMeDevice.STATUS_UNAVAILABLE,
-                                      NVMeDevice.STATUS_READONLY, NVMeDevice.STATUS_CANNOT_ALLOCATE]:
-                    logger.warning(f"Device status is not recognised, id: {dev.get_id()}, status: {dev.status}")
+                if node.status != StorageNode.STATUS_ONLINE:
+                    logger.warning(f"Node status is not online, id: {node.get_id()}, status: {node.status}")
                     continue
-                if cluster.status == Cluster.STATUS_ACTIVE:
-                    if dev.status in [NVMeDevice.STATUS_READONLY, NVMeDevice.STATUS_CANNOT_ALLOCATE]:
-                        dev_stat = db.get_device_stats(dev, 1)
-                        if dev_stat and dev_stat[0].size_util < cluster.cap_crit:
-                            device_controller.device_set_online(dev.get_id())
+                for dev in node.nvme_devices:
+                    if dev.status not in [NVMeDevice.STATUS_ONLINE, NVMeDevice.STATUS_UNAVAILABLE,
+                                          NVMeDevice.STATUS_READONLY, NVMeDevice.STATUS_CANNOT_ALLOCATE]:
+                        logger.warning(f"Device status is not recognised, id: {dev.get_id()}, status: {dev.status}")
+                        continue
+                    if cluster.status == Cluster.STATUS_ACTIVE:
+                        if dev.status in [NVMeDevice.STATUS_READONLY, NVMeDevice.STATUS_CANNOT_ALLOCATE]:
+                            dev_stat = db.get_device_stats(dev, 1)
+                            if dev_stat and dev_stat[0].size_util < cluster.cap_crit:
+                                device_controller.device_set_online(dev.get_id())
 
-                elif dev.io_error and dev.status == NVMeDevice.STATUS_UNAVAILABLE and not dev.retries_exhausted:
-                    logger.info("Adding device to auto restart")
-                    auto_restart_devices.append(dev)
+                    elif dev.io_error and dev.status == NVMeDevice.STATUS_UNAVAILABLE and not dev.retries_exhausted:
+                        logger.info("Adding device to auto restart")
+                        auto_restart_devices.append(dev)
 
-            if len(auto_restart_devices) >= 2:
-                tasks_controller.add_node_to_auto_restart(node)
-            elif len(auto_restart_devices) == 1:
-                tasks_controller.add_device_to_auto_restart(auto_restart_devices[0])
+                if len(auto_restart_devices) >= 2:
+                    tasks_controller.add_node_to_auto_restart(node)
+                elif len(auto_restart_devices) == 1:
+                    tasks_controller.add_device_to_auto_restart(auto_restart_devices[0])
+            except Exception as e:
+                logger.error(f"Device monitor failed for node {node.get_id()}: {e}")
+                logger.exception(e)
 
     time.sleep(constants.DEV_MONITOR_INTERVAL_SEC)

--- a/simplyblock_core/services/lvol_monitor.py
+++ b/simplyblock_core/services/lvol_monitor.py
@@ -230,6 +230,29 @@ def check_node(snode, all_lvols):
             continue
 
         if lvol.status == LVol.STATUS_IN_CREATION:
+            # A create that died (process killed) between writing the
+            # IN_CREATION record and the final ONLINE transition leaves a
+            # permanent zombie: nothing advances it, yet it keeps counting
+            # against pool capacity and max_lvol. Detect a stale IN_CREATION —
+            # far older than any real create — and route it through the normal
+            # force-delete so partial data-plane state is torn down and the DB
+            # record (and its reserved capacity) is freed. An in-progress
+            # create is younger than the threshold and is left untouched.
+            stale = True
+            if lvol.create_dt:
+                try:
+                    age = (datetime.now() - datetime.fromisoformat(lvol.create_dt)).total_seconds()
+                    stale = age > constants.LVOL_IN_CREATION_STALE_SEC
+                except (ValueError, TypeError):
+                    stale = True
+            if stale:
+                logger.error(
+                    f"LVol {lvol.get_id()} stuck in {LVol.STATUS_IN_CREATION} "
+                    f"since {lvol.create_dt}; cleaning up orphaned create")
+                try:
+                    lvol_controller.delete_lvol(lvol.get_id(), force_delete=True)
+                except Exception as e:
+                    logger.error(f"Failed to clean up orphaned in_creation lvol {lvol.get_id()}: {e}")
             continue
 
         if lvol.status == lvol.STATUS_IN_DELETION:

--- a/simplyblock_core/services/mgmt_node_monitor.py
+++ b/simplyblock_core/services/mgmt_node_monitor.py
@@ -101,31 +101,42 @@ while True:
         time.sleep(3)
         continue
 
-    nodes = db.get_mgmt_nodes()
-    reachable_ips = set(backend.get_reachable_nodes())
+    try:
+        nodes = db.get_mgmt_nodes()
+        reachable_ips = set(backend.get_reachable_nodes())
+    except Exception as e:
+        logger.error(f"Failed to enumerate mgmt nodes / reachable IPs: {e}")
+        time.sleep(3)
+        continue
 
     for node in nodes:
-        if node.status not in [MgmtNode.STATUS_ONLINE, MgmtNode.STATUS_UNREACHABLE]:
-            logger.info(f"Node status is: {node.status}, skipping")
-            continue
+        # Per-node isolation: a failure on one mgmt node must not abort the
+        # sweep over the remaining nodes for this tick.
+        try:
+            if node.status not in [MgmtNode.STATUS_ONLINE, MgmtNode.STATUS_UNREACHABLE]:
+                logger.info(f"Node status is: {node.status}, skipping")
+                continue
 
-        # 1- check node ping
-        ping_check = health_controller._check_node_ping(node.mgmt_ip)
-        logger.info(f"Check: ping mgmt ip {node.mgmt_ip} ... {ping_check}")
-        if not ping_check:
-            time.sleep(1)
+            # 1- check node ping
             ping_check = health_controller._check_node_ping(node.mgmt_ip)
-            logger.info(f"Check 2: ping mgmt ip {node.mgmt_ip} ... {ping_check}")
+            logger.info(f"Check: ping mgmt ip {node.mgmt_ip} ... {ping_check}")
+            if not ping_check:
+                time.sleep(1)
+                ping_check = health_controller._check_node_ping(node.mgmt_ip)
+                logger.info(f"Check 2: ping mgmt ip {node.mgmt_ip} ... {ping_check}")
 
-        if not ping_check:
-            logger.info(f"Node {node.hostname} is offline")
-            set_node_offline(node)
-            continue
+            if not ping_check:
+                logger.info(f"Node {node.hostname} is offline")
+                set_node_offline(node)
+                continue
 
-        if node.mgmt_ip in reachable_ips:
-            set_node_online(node)
-        else:
-            set_node_offline(node)
+            if node.mgmt_ip in reachable_ips:
+                set_node_online(node)
+            else:
+                set_node_offline(node)
+        except Exception as e:
+            logger.error(f"Mgmt node monitor failed for node {node.get_id()}: {e}")
+            logger.exception(e)
 
     logger.info(f"Sleeping for {constants.NODE_MONITOR_INTERVAL_SEC} seconds")
     time.sleep(constants.NODE_MONITOR_INTERVAL_SEC)

--- a/simplyblock_core/services/tasks_runner_lvol_migration.py
+++ b/simplyblock_core/services/tasks_runner_lvol_migration.py
@@ -89,7 +89,7 @@ import time
 
 from simplyblock_core import db_controller as db_mod, utils, constants
 from simplyblock_core.controllers import (
-    migration_controller, migration_events, snapshot_controller, tasks_events
+    migration_controller, migration_events, snapshot_controller, tasks_controller, tasks_events
 )
 from simplyblock_core.models.cluster import Cluster
 from simplyblock_core.models.job_schedule import JobSchedule
@@ -1625,6 +1625,12 @@ if __name__ == "__main__":
         else:
             for cl in clusters:
                 for task in db.get_active_migration_tasks(cl.get_id()):
+                    # Lease gate: skip a task another live runner host owns, so
+                    # two replicas can't both drive the same migration's
+                    # multi-phase data-plane state-machine concurrently.
+                    if not tasks_controller.claim_task(task):
+                        logger.info(f"LVol-migration task {task.uuid} owned by another runner host; skipping")
+                        continue
                     task_runner(task)
 
         time.sleep(3)

--- a/simplyblock_core/services/tasks_runner_migration.py
+++ b/simplyblock_core/services/tasks_runner_migration.py
@@ -289,6 +289,10 @@ while True:
                     elif task.status == JobSchedule.STATUS_RUNNING:
                         pass
 
+                    # Lease gate: skip a task another live runner host owns.
+                    if not tasks_controller.claim_task(task):
+                        logger.info(f"Migration task {task.uuid} owned by another runner host; skipping")
+                        continue
                     res = task_runner(task)
                     update_master_task(task)
                     if res:

--- a/simplyblock_core/services/tasks_runner_node_add.py
+++ b/simplyblock_core/services/tasks_runner_node_add.py
@@ -3,6 +3,7 @@ import time
 
 
 from simplyblock_core import db_controller, storage_node_ops, utils, constants
+from simplyblock_core.controllers import tasks_controller
 from simplyblock_core.models.job_schedule import JobSchedule
 from simplyblock_core.models.cluster import Cluster
 
@@ -71,15 +72,31 @@ while True:
             for task in tasks:
                 delay_seconds = constants.TASK_EXEC_INTERVAL_SEC
                 if task.function_name == JobSchedule.FN_NODE_ADD:
-                    while task.status != JobSchedule.STATUS_DONE:
-                        # get new task object because it could be changed from cancel task
-                        task = db.get_task_by_id(task.uuid)
-                        res = process_task(task)
-                        if res:
-                            if task.status == JobSchedule.STATUS_DONE:
+                    # Per-task isolation: a crash in process_task must not escape
+                    # to the outer `while True` and kill the node-add service.
+                    try:
+                        while task.status != JobSchedule.STATUS_DONE:
+                            # get new task object because it could be changed from cancel task
+                            task = db.get_task_by_id(task.uuid)
+                            # Lease gate: skip a task another live runner host owns.
+                            if not tasks_controller.claim_task(task):
+                                logger.info(f"Node-add task {task.uuid} owned by another runner host; skipping")
                                 break
-                        else:
-                            delay_seconds *= 2
-                        time.sleep(delay_seconds)
+                            res = process_task(task)
+                            if res:
+                                if task.status == JobSchedule.STATUS_DONE:
+                                    break
+                            else:
+                                # Cap the exponential backoff so a permanently
+                                # failing node-add can't grow the sleep without
+                                # bound and stall other node-add tasks for hours.
+                                delay_seconds = min(
+                                    delay_seconds * 2,
+                                    constants.RESTART_TASK_EXEC_INTERVAL_MAX_SEC,
+                                )
+                            time.sleep(delay_seconds)
+                    except Exception as e:
+                        logger.error(f"Node-add task {task.uuid} processing crashed: {e}")
+                        logger.exception(e)
 
     time.sleep(constants.TASK_EXEC_INTERVAL_SEC)

--- a/simplyblock_core/services/tasks_runner_port_allow.py
+++ b/simplyblock_core/services/tasks_runner_port_allow.py
@@ -544,6 +544,10 @@ def _main():
                 for task in tasks:
                     if task.function_name == JobSchedule.FN_PORT_ALLOW:
                         if task.status != JobSchedule.STATUS_DONE:
+                            # Lease gate: skip a task another live runner host owns.
+                            if not tasks_controller.claim_task(task):
+                                logger.info(f"Port-allow task {task.uuid} owned by another runner host; skipping")
+                                continue
                             exec_port_allow_task(task)
 
         time.sleep(5)

--- a/simplyblock_core/services/tasks_runner_restart.py
+++ b/simplyblock_core/services/tasks_runner_restart.py
@@ -478,18 +478,33 @@ while True:
                     # exponential backoff at RESTART_TASK_EXEC_INTERVAL_MAX_SEC
                     # so recovery time is bounded even after several retries.
                     delay_seconds = constants.RESTART_TASK_EXEC_INTERVAL_SEC
-                    while task.status != JobSchedule.STATUS_DONE:
-                        # get new task object because it could be changed from cancel task
-                        task = db.get_task_by_id(task.uuid)
-                        res = task_runner(task)
-                        if res:
-                            if task.status == JobSchedule.STATUS_DONE:
+                    # Per-task isolation: an unhandled exception in task_runner
+                    # must not escape to the outer `while True`, which would kill
+                    # the whole restart service and block recovery of every other
+                    # node. Log it and move on to the next task.
+                    try:
+                        while task.status != JobSchedule.STATUS_DONE:
+                            # get new task object because it could be changed from cancel task
+                            task = db.get_task_by_id(task.uuid)
+                            # Lease gate: refuse to drive a task another live runner
+                            # host already owns (prevents a second replica issuing a
+                            # concurrent shutdown/restart). Re-checked every iteration
+                            # so the lease stays fresh while we hold it.
+                            if not tasks_controller.claim_task(task):
+                                logger.info(f"Restart task {task.uuid} owned by another runner host; skipping")
                                 break
-                        else:
-                            delay_seconds = min(
-                                delay_seconds * 2,
-                                constants.RESTART_TASK_EXEC_INTERVAL_MAX_SEC,
-                            )
-                        time.sleep(delay_seconds)
+                            res = task_runner(task)
+                            if res:
+                                if task.status == JobSchedule.STATUS_DONE:
+                                    break
+                            else:
+                                delay_seconds = min(
+                                    delay_seconds * 2,
+                                    constants.RESTART_TASK_EXEC_INTERVAL_MAX_SEC,
+                                )
+                            time.sleep(delay_seconds)
+                    except Exception as e:
+                        logger.error(f"Restart task {task.uuid} processing crashed: {e}")
+                        logger.exception(e)
 
     time.sleep(constants.TASK_EXEC_INTERVAL_SEC)

--- a/simplyblock_core/storage_node_ops.py
+++ b/simplyblock_core/storage_node_ops.py
@@ -613,7 +613,10 @@ def get_next_physical_device_order(snode):
 
 def _search_for_partitions(rpc_client, nvme_device):
     partitioned_devices = []
-    for bdev in rpc_client.get_bdevs():
+    bdevs = rpc_client.get_bdevs()
+    if bdevs is None:
+        raise RPCException(f"get_bdevs failed on {rpc_client.host}")
+    for bdev in bdevs:
         name = bdev['name']
         if name.startswith(f"{nvme_device.nvme_bdev}p"):
             new_dev = NVMeDevice(nvme_device.to_dict())
@@ -982,7 +985,13 @@ def _prepare_cluster_devices_partitions(snode, devices):
 
     # create jm device
     jm_devices = []
-    bdevs_names = [d['name'] for d in snode.rpc_client().get_bdevs()]
+    bdevs = snode.rpc_client().get_bdevs()
+    if bdevs is None:
+        # None means the RPC failed (timeout / non-200), not "no bdevs".
+        # Without this guard the comprehension below crashes with an opaque
+        # TypeError; raise a clear, catchable error instead.
+        raise RPCException(f"get_bdevs failed on node {snode.get_id()}")
+    bdevs_names = [d['name'] for d in bdevs]
     for nvme in new_devices:
         if nvme.status in [NVMeDevice.STATUS_ONLINE, NVMeDevice.STATUS_NEW]:
             dev_part = f"{nvme.nvme_bdev[:-2]}p1"
@@ -4332,53 +4341,88 @@ def set_node_status(node_id, status, caused_by="monitor"):
 
     db_controller = DBController()
     snode = db_controller.get_storage_node_by_id(node_id)
-    if snode.status == status:
-        return True
-
-    if status == StorageNode.STATUS_ONLINE and snode.status not in _ALLOWED_PRE_STATUSES_FOR_ONLINE:
-        # Hard reject: ONLINE may only be reached from RESTARTING (restart
-        # path), IN_CREATION (add_node path), or SUSPENDED (resume path).
-        # Other paths must route through one of those states first.
-        logger.error(
-            f"Refusing illegal status transition for {node_id}: "
-            f"{snode.status} -> ONLINE. Only {_ALLOWED_PRE_STATUSES_FOR_ONLINE} -> ONLINE is allowed."
-        )
+    if snode is None:
+        logger.error(f"set_node_status: node {node_id} not found")
         return False
 
-    if (status == StorageNode.STATUS_OFFLINE
-            and snode.status == StorageNode.STATUS_RESTARTING
-            and caused_by not in _ALLOWED_CAUSED_BY_RESTARTING_TO_OFFLINE):
-        # Symmetric to the ONLINE guard above: RESTARTING is the restart
-        # impl's exclusive lock. Anything else clobbering it to OFFLINE
-        # mid-flight (HealthCheck, StorageNodeMonitor, MainDistrEventCollector,
-        # auto-restart task races) strands the node — the impl's later
-        # set_node_status(ONLINE, caused_by="restart") then hits the
-        # OFFLINE → ONLINE rejection above, returns False, and the CLI
-        # exits silently with the node parked in OFFLINE forever.
-        # Observed: incident 2026-05-20 iter 57 (forced restart of
-        # 5110e910 stuck offline for 16 min until soak gave up).
+    now = str(datetime.datetime.now(datetime.timezone.utc))
+    # verdict communicates the (single, committed) outcome of the mutator out
+    # of the transaction so the irreversible work — event emission, peer
+    # broadcast, task cancellation, error logging — happens exactly once,
+    # AFTER commit. The mutator itself must stay side-effect-free because
+    # fdb.transactional replays it on write conflicts.
+    outcome: dict = {"verdict": None, "old_status": None, "from": None}
+
+    def _mutate(n):
+        if n.status == status:
+            outcome["verdict"] = "noop"
+            return False
+        if status == StorageNode.STATUS_ONLINE and n.status not in _ALLOWED_PRE_STATUSES_FOR_ONLINE:
+            # Hard reject: ONLINE may only be reached from RESTARTING (restart
+            # path), IN_CREATION (add_node path), or SUSPENDED (resume path).
+            # Other paths must route through one of those states first.
+            outcome["verdict"] = "reject_online"
+            outcome["from"] = n.status
+            return False
+        if (status == StorageNode.STATUS_OFFLINE
+                and n.status == StorageNode.STATUS_RESTARTING
+                and caused_by not in _ALLOWED_CAUSED_BY_RESTARTING_TO_OFFLINE):
+            # Symmetric to the ONLINE guard above: RESTARTING is the restart
+            # impl's exclusive lock. Anything else clobbering it to OFFLINE
+            # mid-flight (HealthCheck, StorageNodeMonitor, MainDistrEventCollector,
+            # auto-restart task races) strands the node — the impl's later
+            # set_node_status(ONLINE, caused_by="restart") then hits the
+            # OFFLINE → ONLINE rejection above, returns False, and the CLI
+            # exits silently with the node parked in OFFLINE forever.
+            # Observed: incident 2026-05-20 iter 57 (forced restart of
+            # 5110e910 stuck offline for 16 min until soak gave up).
+            outcome["verdict"] = "reject_offline"
+            outcome["from"] = n.status
+            return False
+
+        outcome["verdict"] = "changed"
+        outcome["old_status"] = n.status
+        n.status = status
+        n.updated_at = now
+        if status == StorageNode.STATUS_ONLINE:
+            n.online_since = now
+            # The node is back ONLINE — necessarily via a deliberate restart
+            # while auto-restart was blocked, or via the normal restart path.
+            # Either way a prior deliberate-shutdown marker no longer applies;
+            # clear it so future genuine failures auto-restart this node again.
+            n.auto_restart_disabled = False
+        else:
+            n.online_since = ""
+        return True
+
+    # Atomic compare-and-set: the guard checks above are evaluated against the
+    # FRESH row inside the transaction, and the write can no longer clobber a
+    # concurrent update from another service (HealthCheck/Monitor/restart task)
+    # — the lost-update race this function's incident comments document.
+    snode = db_controller.atomic_update(snode, _mutate)
+    if snode is None:
+        logger.error(f"set_node_status: node {node_id} disappeared during update")
+        return False
+
+    verdict = outcome["verdict"]
+    if verdict == "noop":
+        return True
+    if verdict == "reject_online":
         logger.error(
             f"Refusing illegal status transition for {node_id}: "
-            f"{snode.status} -> OFFLINE from caused_by={caused_by!r}. "
+            f"{outcome['from']} -> ONLINE. Only {_ALLOWED_PRE_STATUSES_FOR_ONLINE} -> ONLINE is allowed."
+        )
+        return False
+    if verdict == "reject_offline":
+        logger.error(
+            f"Refusing illegal status transition for {node_id}: "
+            f"{outcome['from']} -> OFFLINE from caused_by={caused_by!r}. "
             f"Only {_ALLOWED_CAUSED_BY_RESTARTING_TO_OFFLINE} may flip "
             f"a RESTARTING node to OFFLINE."
         )
         return False
 
-    old_status = snode.status
-    snode.status = status
-    snode.updated_at = str(datetime.datetime.now(datetime.timezone.utc))
-    if status == StorageNode.STATUS_ONLINE:
-        snode.online_since = str(datetime.datetime.now(datetime.timezone.utc))
-        # The node is back ONLINE — necessarily via a deliberate restart while
-        # auto-restart was blocked, or via the normal restart path. Either way
-        # a prior deliberate-shutdown marker no longer applies; clear it so
-        # future genuine failures auto-restart this node again.
-        snode.auto_restart_disabled = False
-    else:
-        snode.online_since = ""
-    snode.write_to_db(db_controller.kv_store)
-    storage_events.snode_status_change(snode, snode.status, old_status, caused_by=caused_by)
+    storage_events.snode_status_change(snode, snode.status, outcome["old_status"], caused_by=caused_by)
     distr_controller.send_node_status_event(snode, status)
 
     if status == StorageNode.STATUS_ONLINE:

--- a/simplyblock_core/utils/__init__.py
+++ b/simplyblock_core/utils/__init__.py
@@ -1244,7 +1244,12 @@ def addNvmeDevices(rpc_client, snode, devs):
         if pcie in ctr_map:
             nvme_controller = ctr_map[pcie]
             nvme_bdevs = []
-            for bdev in rpc_client.get_bdevs():
+            bdevs = rpc_client.get_bdevs()
+            if bdevs is None:
+                # None is an RPC failure (timeout / non-200), not an empty
+                # list; fail loudly instead of crashing on a None iteration.
+                raise Exception(f"get_bdevs failed on {rpc_client.host}")
+            for bdev in bdevs:
                 if bdev['name'].startswith(nvme_controller):
                     nvme_bdevs.append(bdev['name'])
         else:

--- a/tests/test_restart_lock.py
+++ b/tests/test_restart_lock.py
@@ -465,6 +465,15 @@ class TestRestartingToOfflineGuard(unittest.TestCase):
         db = mock_db_cls.return_value
         db.get_storage_node_by_id.return_value = node
         db.kv_store = MagicMock()
+        # set_node_status now performs its guarded status change inside
+        # db.atomic_update (a transactional compare-and-set). The real helper
+        # re-reads the row and runs the mutator inside one FDB transaction; here
+        # we stand in with a faithful in-memory version that runs the mutator on
+        # the node and returns it, so the guard logic under test still executes.
+        def _fake_atomic_update(obj, mutate_fn):
+            mutate_fn(obj)
+            return obj
+        db.atomic_update = MagicMock(side_effect=_fake_atomic_update)
         return db
 
     @patch("simplyblock_core.storage_node_ops.distr_controller")

--- a/tests/test_rpc_retry.py
+++ b/tests/test_rpc_retry.py
@@ -1,0 +1,43 @@
+# coding=utf-8
+"""Regression tests for RPCClient HTTP retry policy.
+
+SPDK JSON-RPC sends every call (including non-idempotent mutations) as a POST.
+A read-error retry of a POST silently re-applies the mutation, so POST must be
+excluded from the urllib3 retry's allowed_methods. Connection-error retries are
+governed separately (the `connect` count) and are safe, so they must remain.
+"""
+from unittest.mock import patch
+
+from simplyblock_core.rpc_client import RPCClient
+
+
+def _make_client(retry=3, **kwargs):
+    with patch("requests.session"):
+        return RPCClient("127.0.0.1", 8081, "user", "pass", timeout=1, retry=retry, **kwargs)
+
+
+def _mounted_retries(client):
+    # session is mocked; each mount() call got (prefix, HTTPAdapter(max_retries=Retry)).
+    adapters = [call.args[1] for call in client.session.mount.call_args_list]
+    assert adapters, "expected at least one mounted adapter"
+    return [ad.max_retries for ad in adapters]
+
+
+def test_post_not_in_default_allowed_methods():
+    assert "POST" not in RPCClient.DEFAULT_ALLOWED_METHODS
+
+
+def test_mounted_retry_excludes_post_keeps_reads():
+    client = _make_client()
+    for retries in _mounted_retries(client):
+        methods = {m.upper() for m in retries.allowed_methods}
+        assert "POST" not in methods       # no read-retry of mutating calls
+        assert "GET" in methods            # idempotent reads still retried
+
+
+def test_connect_retries_preserved():
+    client = _make_client(retry=3)
+    for retries in _mounted_retries(client):
+        # Connection-level retries (request never reached the node) stay enabled
+        # even though POST read-retries are off.
+        assert retries.connect == 3

--- a/tests/test_task_lease.py
+++ b/tests/test_task_lease.py
@@ -1,0 +1,94 @@
+# coding=utf-8
+"""Unit tests for the JobSchedule task lease (tasks_controller.claim_task).
+
+These exercise the claim/staleness decision logic without a live FoundationDB
+by stubbing DBController.atomic_update with a faithful in-memory stand-in: it
+invokes the mutator on the object (in place) and returns it, mirroring the real
+helper's contract (returns the object, or None if it no longer exists).
+"""
+import datetime
+
+from simplyblock_core import constants
+from simplyblock_core.controllers import tasks_controller
+from simplyblock_core.models.job_schedule import JobSchedule
+
+
+def _now_iso(offset_sec=0):
+    return str(datetime.datetime.now(datetime.timezone.utc)
+               + datetime.timedelta(seconds=offset_sec))
+
+
+def _task(status=JobSchedule.STATUS_NEW, owner="", canceled=False, age_sec=0):
+    t = JobSchedule()
+    t.uuid = "task-1"
+    t.status = status
+    t.owner = owner
+    t.canceled = canceled
+    t.updated_at = _now_iso(-age_sec)
+    return t
+
+
+def _patch_atomic_update(monkeypatch, present=True):
+    def fake(obj, mutate_fn):
+        if not present:
+            return None
+        mutate_fn(obj)
+        return obj
+    monkeypatch.setattr(tasks_controller.db, "atomic_update", fake)
+
+
+def test_claim_unowned_task_succeeds(monkeypatch):
+    _patch_atomic_update(monkeypatch)
+    t = _task(owner="")
+    assert tasks_controller.claim_task(t, owner="hostA") is True
+    assert t.owner == "hostA"
+
+
+def test_claim_own_task_refreshes_lease(monkeypatch):
+    _patch_atomic_update(monkeypatch)
+    t = _task(owner="hostA", status=JobSchedule.STATUS_RUNNING, age_sec=10)
+    old = t.updated_at
+    assert tasks_controller.claim_task(t, owner="hostA") is True
+    assert t.owner == "hostA"
+    assert t.updated_at != old  # lease refreshed
+
+
+def test_claim_blocked_by_other_live_host(monkeypatch):
+    _patch_atomic_update(monkeypatch)
+    t = _task(owner="hostA", status=JobSchedule.STATUS_RUNNING, age_sec=5)
+    assert tasks_controller.claim_task(t, owner="hostB") is False
+    assert t.owner == "hostA"  # untouched
+
+
+def test_claim_takes_over_stale_lease(monkeypatch):
+    _patch_atomic_update(monkeypatch)
+    t = _task(owner="hostA", status=JobSchedule.STATUS_RUNNING,
+              age_sec=constants.TASK_LEASE_TTL_SEC + 60)
+    assert tasks_controller.claim_task(t, owner="hostB") is True
+    assert t.owner == "hostB"
+
+
+def test_done_task_never_claimed(monkeypatch):
+    _patch_atomic_update(monkeypatch)
+    t = _task(status=JobSchedule.STATUS_DONE, owner="")
+    assert tasks_controller.claim_task(t, owner="hostA") is False
+
+
+def test_canceled_task_never_claimed(monkeypatch):
+    _patch_atomic_update(monkeypatch)
+    t = _task(canceled=True, owner="")
+    assert tasks_controller.claim_task(t, owner="hostA") is False
+
+
+def test_missing_task_returns_false(monkeypatch):
+    _patch_atomic_update(monkeypatch, present=False)
+    t = _task(owner="")
+    assert tasks_controller.claim_task(t, owner="hostA") is False
+
+
+def test_lease_stale_helper():
+    assert tasks_controller._task_lease_is_stale(_task(age_sec=constants.TASK_LEASE_TTL_SEC + 1))
+    assert not tasks_controller._task_lease_is_stale(_task(age_sec=0))
+    empty = _task()
+    empty.updated_at = ""
+    assert tasks_controller._task_lease_is_stale(empty)


### PR DESCRIPTION
Addresses the highest-impact findings from the failure-mode / race audit of the control plane. Cherry-picked from the same fix on \`performance-optimization\`.

## Item 1 — systemic
- **\`DBController.atomic_update()\`** — transactional read-modify-write (FDB serializable isolation + \`fdb.transactional\` auto-retry = true CAS), replacing the lost-update-prone \`read(); mutate; write_to_db()\` pattern.
- Applied to **\`set_node_status\`** (FSM guards evaluated against the fresh row inside the tx; event emission / peer broadcast / task cancellation moved to after commit) and all **5 snapshot \`ref_count\` sites** (3 increments, 2 decrements).
- **Task lease**: \`JobSchedule.owner\` + \`TASK_LEASE_TTL_SEC\` + \`claim_task()\` (hostname-keyed — a same-host restart re-claims immediately; a second replica is locked out until the lease goes stale). Wired as a gate into the restart / migration / lvol_migration / port_allow / node_add runners.

## Item 2 — RPC contract (safe subset)
- Drop **POST** from the urllib3 read-retry \`allowed_methods\` so non-idempotent SPDK RPCs are no longer silently re-applied on a read timeout; connection-error retries are preserved.
- Guard the 5 \`for d in get_bdevs()\` sites: a \`None\` (RPC-failure) return now raises a clear, catchable error instead of an opaque \`TypeError\`.
- *(The broader \`_request\`-raises-on-error contract flip is intentionally deferred — it breaks hundreds of \`if not ret:\` callers and needs its own pass.)*

## Item 3 — quick wins
- Per-task \`try/except\` in \`tasks_runner_restart\`, \`tasks_runner_node_add\` (+ cap its unbounded backoff), \`device_monitor\`, \`mgmt_node_monitor\` so one task/node cannot kill the whole service.
- Wire \`is_migration_active_on_node\` into \`snapshot_controller.add\` to enforce the one-migration-per-source-node freeze invariant (previously dead code).
- \`lvol_monitor\` reconciles stale \`STATUS_IN_CREATION\` zombies (force-delete past \`LVOL_IN_CREATION_STALE_SEC\`) so crashed creates stop leaking pool capacity.

## Tests
- \`tests/test_task_lease.py\` (8) — lease/claim + staleness logic.
- \`tests/test_rpc_retry.py\` (3) — POST excluded from retry, connect retries preserved.
- Full unit + migration-unit suite green locally (117 passed / 44 FDB-e2e skipped).

## ⚠️ Before relying in production
The FDB-backed paths (\`atomic_update\`, the snapshot freeze-guard, the \`IN_CREATION\` reconciler) can only be exercised against a live FoundationDB — **needs a lab integration run**, not just unit CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)