### PR TITLE
Make API creation responses concistent

### DIFF
--- a/simplyblock_web/api/v2/cluster/__init__.py
+++ b/simplyblock_web/api/v2/cluster/__init__.py
@@ -1,6 +1,8 @@
 from threading import Thread
 from typing import Annotated, List, Literal, Optional
-from fastapi import APIRouter, HTTPException, Response
+from uuid import UUID
+
+from fastapi import APIRouter, HTTPException, Request, Response
 from pydantic import BaseModel, Field
 from pydantic.networks import AnyUrl, UrlConstraints
 
@@ -99,7 +101,7 @@ def list() -> List[ClusterDTO]:
 
 
 @api.post('/', name='clusters:create', status_code=201, responses={201: {"content": None}})
-def add(parameters: ClusterParams):
+def add(request: Request, parameters: ClusterParams, response_format: util.CreationResponseFormatParameter = "full"):
     try:
         params = parameters.model_dump(exclude_none=True)
         npcs = params.get('distr_npcs', 1)
@@ -113,7 +115,14 @@ def add(parameters: ClusterParams):
         raise ValueError('Failed to create cluster')
 
     cluster = db.get_cluster_by_id(cluster_id_or_false)
-    return ClusterDTO.from_model(cluster)
+
+    return util.creation_response(
+        request, response_format,
+        entity_id=UUID(cluster.get_id()),
+        route_name='clusters:detail',
+        route_kwargs={'cluster_id': UUID(cluster.get_id())},
+        get_full=lambda _: ClusterDTO.from_model(cluster),
+    )
 
 
 instance_api = APIRouter(prefix='/{cluster_id}')

--- a/simplyblock_web/api/v2/cluster/backup.py
+++ b/simplyblock_web/api/v2/cluster/backup.py
@@ -1,7 +1,7 @@
 from typing import List, Optional
 from uuid import UUID
 
-from fastapi import APIRouter, HTTPException, Query, Response
+from fastapi import APIRouter, HTTPException, Query, Request, Response
 from pydantic import BaseModel
 
 from simplyblock_core.db_controller import DBController
@@ -11,6 +11,7 @@ from simplyblock_core.models.lvol_model import LVol
 
 from .._dependencies import Cluster, Policy
 from .._dtos import BackupDTO, BackupPolicyDTO
+from ..util import CreationResponseFormatParameter, creation_response
 
 
 api = APIRouter()
@@ -29,12 +30,20 @@ class _BackupSnapshotParams(BaseModel):
 
 
 @api.post('/', name='clusters:backups:create', status_code=201, responses={201: {"content": None}})
-def create_backup(cluster: Cluster, parameters: _BackupSnapshotParams) -> Response:
+def create_backup(request: Request, cluster: Cluster, parameters: _BackupSnapshotParams, response_format: CreationResponseFormatParameter = "empty") -> Response:
     backup_id, error = backup_controller.backup_snapshot(
         parameters.snapshot_id, cluster_id=cluster.get_id())
     if error:
         raise HTTPException(400, error)
-    return Response(status_code=201, headers={'X-Backup-Id': backup_id})
+
+    return creation_response(
+        request, response_format,
+        entity_id=UUID(backup_id),
+        route_name='clusters:backups:detail',
+        route_kwargs={'cluster_id': UUID(cluster.get_id())},
+        get_full=lambda id: BackupDTO.from_model(db.get_backup_by_id(str(id))),
+        extra_headers={'X-Backup-Id': backup_id},  # For backwards compatibility
+    )
 
 
 class _RestoreParams(BaseModel):

--- a/simplyblock_web/api/v2/cluster/migration.py
+++ b/simplyblock_web/api/v2/cluster/migration.py
@@ -1,11 +1,12 @@
 from typing import List
+from uuid import UUID
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Request, Response
 from pydantic import BaseModel
 
 from .._dependencies import Cluster, Migration
 from .._dtos import MigrationDTO
-
+from ..util import CreationResponseFormatParameter, creation_response
 
 api = APIRouter()
 
@@ -25,9 +26,10 @@ class _MigrateParams(BaseModel):
     deadline_seconds: int = 14400
 
 
-@api.post('/', name='clusters:migrations:create', status_code=201)
-def start_migration(cluster: Cluster, parameters: _MigrateParams):
+@api.post('/', name='clusters:migrations:create', status_code=201, responses={201: {"content": None}})
+def start_migration(request: Request, cluster: Cluster, parameters: _MigrateParams, response_format: CreationResponseFormatParameter = "identifier") -> Response:
     from simplyblock_core.controllers import migration_controller
+    from simplyblock_core.db_controller import DBController
     migration_id, error = migration_controller.start_migration(
         parameters.volume_id,
         parameters.target_node_id,
@@ -36,7 +38,13 @@ def start_migration(cluster: Cluster, parameters: _MigrateParams):
     )
     if error:
         raise HTTPException(400, error)
-    return {"migration_id": migration_id}
+    return creation_response(
+        request, response_format,
+        entity_id=UUID(migration_id),
+        route_name='clusters:migrations:detail',
+        route_kwargs={'cluster_id': UUID(cluster.get_id()), 'migration_id': UUID(migration_id)},
+        get_full=lambda id: MigrationDTO.from_model(DBController().get_migration_by_id(str(id))),
+    )
 
 
 instance_api = APIRouter(prefix='/{migration_id}')

--- a/simplyblock_web/api/v2/cluster/storage_node/__init__.py
+++ b/simplyblock_web/api/v2/cluster/storage_node/__init__.py
@@ -1,7 +1,8 @@
 from threading import Thread
 from typing import List, Optional
+from uuid import UUID
 
-from fastapi import APIRouter, HTTPException, Response
+from fastapi import APIRouter, HTTPException, Request, Response
 from pydantic import BaseModel, Field
 
 from simplyblock_core.db_controller import DBController
@@ -11,7 +12,7 @@ from simplyblock_core import storage_node_ops
 from ... import util as util
 from ..._dependencies import Cluster, StorageNode
 from .device import api as device_api
-from ..._dtos import StorageNodeDTO
+from ..._dtos import StorageNodeDTO, TaskDTO
 
 
 api = APIRouter()
@@ -55,7 +56,7 @@ class StorageNodeParams(BaseModel):
 
 
 @api.post('/', name='clusters:storage-nodes:create', status_code=201, responses={201: {"content": None}})
-def add(cluster: Cluster, parameters: StorageNodeParams):
+def add(request: Request, cluster: Cluster, parameters: StorageNodeParams, response_format: util.CreationResponseFormatParameter = "identifier"):
     task_id_or_false = tasks_controller.add_node_add_task(
         cluster.get_id(),
         {
@@ -85,7 +86,14 @@ def add(cluster: Cluster, parameters: StorageNodeParams):
     )
     if not task_id_or_false:
         raise ValueError('Failed to create add-node task')
-    return task_id_or_false
+
+    return util.creation_response(
+        request, response_format,
+        entity_id=UUID(task_id_or_false),
+        route_name='clusters:tasks:detail',
+        route_kwargs={'cluster_id': UUID(cluster.get_id()), 'volume_id': UUID(task_id_or_false)},
+        get_full=lambda id: TaskDTO.from_model(db.get_task_by_id(str(id))),
+    )
 
 
 instance_api = APIRouter(prefix='/{storage_node_id}')

--- a/simplyblock_web/api/v2/cluster/storage_pool/__init__.py
+++ b/simplyblock_web/api/v2/cluster/storage_pool/__init__.py
@@ -1,6 +1,7 @@
 from typing import List, Optional
+from uuid import UUID
 
-from fastapi import APIRouter, HTTPException, Response
+from fastapi import APIRouter, HTTPException, Request, Response
 from pydantic import BaseModel
 
 from simplyblock_core.db_controller import DBController
@@ -44,7 +45,7 @@ class StoragePoolParams(BaseModel):
 
 
 @api.post('/', name='clusters:storage-pools:create', status_code=201, responses={201: {"content": None}})
-def add(cluster: Cluster, parameters: StoragePoolParams) -> Response:
+def add(request: Request, cluster: Cluster, parameters: StoragePoolParams, response_format: util.CreationResponseFormatParameter = "full") -> Response:
     for pool in db.get_pools(cluster.get_id()):
         if pool.pool_name == parameters.name:
             raise HTTPException(409, f'Pool {parameters.name} already exists')
@@ -59,8 +60,14 @@ def add(cluster: Cluster, parameters: StoragePoolParams) -> Response:
     if not id_or_false:
         raise ValueError('Failed to create pool')
 
-    pool = db.get_pool_by_id(id_or_false)
-    return pool.to_dict()
+    return util.creation_response(
+        request, response_format,
+        entity_id=UUID(id_or_false),
+        route_name='clusters:storage-pools:volumes:detail',
+        route_kwargs={'cluster_id': UUID(cluster.get_id()), 'pool_id': UUID(id_or_false)},
+        get_full=lambda id: StoragePoolDTO.from_model(db.get_pool_by_id(str(id))),
+    )
+
 
 
 instance_api = APIRouter(prefix='/{pool_id}')

--- a/simplyblock_web/api/v2/cluster/storage_pool/volume.py
+++ b/simplyblock_web/api/v2/cluster/storage_pool/volume.py
@@ -1,4 +1,5 @@
 from typing import Annotated, List, Literal, Optional, Union
+from uuid import UUID
 
 from fastapi import APIRouter, HTTPException, Request, Response
 from pydantic import BaseModel, Field, RootModel
@@ -60,7 +61,8 @@ class _CloneParams(BaseModel):
 @api.post('/', name='clusters:storage-pools:volumes:create', status_code=201, responses={201: {"content": None}})
 def add(
         request: Request, cluster: Cluster, pool: StoragePool,
-        parameters: RootModel[Union[_CreateParams, _CloneParams]]
+        parameters: RootModel[Union[_CreateParams, _CloneParams]],
+        response_format: util.CreationResponseFormatParameter = "empty",
 ) -> Response:
     data = parameters.root
     try:
@@ -110,13 +112,17 @@ def add(
     if volume_id_or_false == False:  # noqa
         raise ValueError(error)
 
-    entity_url = request.app.url_path_for(
-            'clusters:storage-pools:volumes:detail',
-            cluster_id=cluster.get_id(),
-            pool_id=pool.get_id(),
-            volume_id=volume_id_or_false,
+    return util.creation_response(
+        request, response_format,
+        entity_id=UUID(volume_id_or_false),
+        route_name='clusters:storage-pools:volumes:detail',
+        route_kwargs={
+            'cluster_id': UUID(cluster.get_id()),
+            'pool_id': UUID(pool.get_id()),
+            'volume_id': UUID(volume_id_or_false),
+        },
+        get_full=lambda id: VolumeDTO.from_model(db.get_lvol_by_id(str(id)), request, cluster.get_id()),
     )
-    return Response(status_code=201, headers={'Location': entity_url})
 
 
 class ReplicateLVolParams(BaseModel):

--- a/simplyblock_web/api/v2/util.py
+++ b/simplyblock_web/api/v2/util.py
@@ -1,9 +1,12 @@
-from typing import Annotated, Any
+from typing import Annotated, Any, Callable, Literal
 from urllib.parse import urlparse
+from uuid import UUID
+
+from fastapi import Query, Request, Response
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, BeforeValidator, Field
 
 from simplyblock_core import utils as core_utils
-
-from pydantic import BeforeValidator, Field
 
 
 Unsigned = Annotated[int, Field(ge=0)]
@@ -24,3 +27,28 @@ def _validate_url_path(value: Any) -> str:
     return value
 
 UrlPath = Annotated[str, _validate_url_path]
+
+CreationResponseFormat = Literal["empty", "full", "identifier"]
+CreationResponseFormatParameter = Annotated[CreationResponseFormat, Query(alias="response-format")]
+
+
+def creation_response(
+    request: Request,
+    response_format: CreationResponseFormat,
+    entity_id: UUID,
+    route_name: str,
+    route_kwargs: dict[str, UUID],
+    get_full: Callable[[UUID], BaseModel],
+    extra_headers: dict[str, str] | None = None,
+) -> Response:
+    headers = {"Location": str(request.app.url_path_for(route_name, **route_kwargs))}
+    if extra_headers:
+        headers.update(extra_headers)
+
+    match response_format:
+        case "empty":
+            return Response(status_code=201, headers=headers)
+        case "identifier":
+            return JSONResponse(content=str(entity_id), status_code=201, headers=headers)
+        case "full":
+            return JSONResponse(content=get_full(entity_id), status_code=201, headers=headers)


### PR DESCRIPTION
Currently, different endpoints for entity creation behave inconsistently:
- Backups: Indicate ID as `X-Backup-Id` header
- Cluster: Return full DTO
- Migration: Return `{migration_id: $id}` object
- Pool: Return database representation
- Storage Node: Return task ID
- Volume: Return empty response with Location header indicating the volume URL

This PR introduces a common helper that supports three approaches, all of which use the `Location` header to indicate the entity location:
- empty response
- ID
- DTO

They can be requested by setting the `response-format` field to `empty`, `identifier`, or `full` respectively. The default for each endpoint ensures this change is backwards compatible with existing clients. In two places, backwards compatibility is not fully given:
- Migration: the object with the `migration_id` is not supported and is replaced by the identifier only response.
- Pools: This returned the database representation which should not be accessible to the user.

The operator is updated to be resilient to the change in return value in https://github.com/simplyblock/simplyblock-operator/pull/241.

Asking for a review from @noctarius as well to gauge the severity of the API stability violation.