### PR TITLE
Fix volume resize on equal size

### DIFF
--- a/simplyblock_cli/clibase.py
+++ b/simplyblock_cli/clibase.py
@@ -613,8 +613,8 @@ class CLIWrapperBase:
     def volume__resize(self, sub_command, args):
         volume_id = args.volume_id
         size = args.size
-        ret, err = lvol_controller.resize_lvol(volume_id, size)
-        return ret
+        lvol_controller.resize_lvol(volume_id, size)
+        return True
 
     def volume__create_snapshot(self, sub_command, args):
         volume_id = args.volume_id

--- a/simplyblock_core/controllers/lvol_controller.py
+++ b/simplyblock_core/controllers/lvol_controller.py
@@ -2010,7 +2010,9 @@ def resize_lvol(id, new_size):
         logger.error(msg)
         return False, msg
 
-    if lvol.size >= new_size:
+    if lvol.size == new_size:
+        return True, None  # Nothing to do
+    elif lvol.size > new_size:
         msg = f"New size {utils.humanbytes(new_size)} must be higher than the original size {utils.humanbytes(lvol.size)}"
         logger.error(msg)
         return False, msg

--- a/simplyblock_core/controllers/lvol_controller.py
+++ b/simplyblock_core/controllers/lvol_controller.py
@@ -12,6 +12,7 @@ from simplyblock_core import utils, constants
 from simplyblock_core.controllers import snapshot_controller, pool_controller, lvol_events, tasks_controller, \
     snapshot_events
 from simplyblock_core.db_controller import DBController
+from simplyblock_core.exceptions import PreconditionError
 from simplyblock_core.kms import KMSException, create_kms_connection
 from simplyblock_core.models.cluster import Cluster
 from simplyblock_core.models.job_schedule import JobSchedule
@@ -1979,61 +1980,42 @@ def connect_lvol(uuid, ctrl_loss_tmo=constants.LVOL_NVME_CONNECT_CTRL_LOSS_TMO, 
     return out, None
 
 
-def resize_lvol(id, new_size):
+def resize_lvol(id, new_size) -> None:
     db_controller = DBController()
-    try:
-        lvol = db_controller.get_lvol_by_id(id)
-    except KeyError as e:
-        logger.error(e)
-        return False, str(e)
+    lvol = db_controller.get_lvol_by_id(id)
 
     # Block during restart Phase 5
     try:
         snode = db_controller.get_storage_node_by_id(lvol.node_id)
         if snode.lvstore_status == "in_creation":
-            msg = f"Cannot resize lvol {lvol.uuid}: node LVStore restart in progress"
-            logger.error(msg)
-            return False, msg
+            raise PreconditionError(f"Cannot resize lvol {lvol.uuid}: node LVStore restart in progress")
     except KeyError:
         pass
 
     from simplyblock_core.controllers import migration_controller
     active_mig = migration_controller.get_active_migration_for_lvol(lvol.uuid)
     if active_mig:
-        msg = f"Cannot resize lvol {lvol.uuid}: active migration {active_mig.uuid}"
-        logger.error(msg)
-        return False, msg
+        raise PreconditionError(f"Cannot resize lvol {lvol.uuid}: active migration {active_mig.uuid}")
 
     pool = db_controller.get_pool_by_id(lvol.pool_uuid)
     if pool.status == Pool.STATUS_INACTIVE:
-        msg = f"Pool is disabled {pool.get_id()}"
-        logger.error(msg)
-        return False, msg
+        raise PreconditionError(f"Pool is disabled {pool.get_id()}")
 
     if lvol.size == new_size:
-        return True, None  # Nothing to do
+        return  # Nothing to do
     elif lvol.size > new_size:
-        msg = f"New size {utils.humanbytes(new_size)} must be higher than the original size {utils.humanbytes(lvol.size)}"
-        logger.error(msg)
-        return False, msg
+        raise PreconditionError(f"New size {utils.humanbytes(new_size)} must be higher than the original size {utils.humanbytes(lvol.size)}")
 
-    if lvol.max_size < new_size:
-        msg = f"New size {new_size} must be smaller than the max size {lvol.max_size}"
-        logger.error(msg)
-        return False, msg
+    if new_size > lvol.max_size:
+        raise PreconditionError(f"New size {utils.humanbytes(new_size)} must not be larger than the max size {utils.humanbytes(lvol.max_size)}")
 
     if 0 < pool.lvol_max_size < new_size:
-        msg = f"Pool Max LVol size is: {utils.humanbytes(pool.lvol_max_size)}, "\
-              f"LVol size: {utils.humanbytes(new_size)} must be below this limit"
-        logger.error(msg)
-        return False, msg
+        raise PreconditionError(f"New size {utils.humanbytes(new_size)} must not be larger than the pool max size {utils.humanbytes(pool.lvol_max_size)}")
 
     if pool.pool_max_size > 0:
         total = pool_controller.get_pool_total_capacity(pool.get_id())
         if total + new_size > pool.pool_max_size:
-            msg =f"Invalid LVol size: {utils.humanbytes(new_size)}, Pool max size has reached {utils.humanbytes(total+new_size)} of {utils.humanbytes(pool.pool_max_size)}"
-            logger.error(msg)
-            return False, msg
+            raise PreconditionError(f"Invalid LVol size: {utils.humanbytes(new_size)}, Pool max size has reached {utils.humanbytes(total+new_size)} of {utils.humanbytes(pool.pool_max_size)}")
 
     snode = db_controller.get_storage_node_by_id(lvol.node_id)
 
@@ -2048,12 +2030,9 @@ def resize_lvol(id, new_size):
     rpc_client = snode.rpc_client()
 
     if lvol.ha_type == "single":
-
         ret = rpc_client.bdev_lvol_resize(f"{lvol.lvs_name}/{lvol.lvol_bdev}", size_in_mib)
         if not ret:
-            msg = f"Error resizing lvol on node: {snode.get_id()}"
-            logger.error(msg)
-            return False, msg
+            raise RuntimeError(f"Error resizing lvol on node: {snode.get_id()}")
 
     else:
         primary_node = None
@@ -2089,9 +2068,7 @@ def resize_lvol(id, new_size):
             action = check_non_leader_for_operation(
                 candidate.get_id(), lvol.lvs_name, operation_type="create")
             if action == "reject":
-                msg = f"Cannot resize: non-leader {candidate.get_id()[:8]} unreachable but fabric healthy"
-                logger.error(msg)
-                return False, msg
+                raise RuntimeError(f"Cannot resize: non-leader {candidate.get_id()[:8]} unreachable but fabric healthy")
             elif action == "proceed":
                 secondary_nodes.append(candidate)
             elif action == "queue":
@@ -2107,25 +2084,19 @@ def resize_lvol(id, new_size):
             rpc_client = primary_node.rpc_client()
             ret = rpc_client.bdev_lvol_resize(f"{lvol.lvs_name}/{lvol.lvol_bdev}", size_in_mib)
             if not ret:
-                msg = f"Error resizing lvol on node: {primary_node.get_id()}"
-                logger.error(msg)
-                return False, msg
+                raise RuntimeError(f"Error resizing lvol on node: {primary_node.get_id()}")
 
         for sec in secondary_nodes:
             logger.info(f"Resizing LVol: {lvol.get_id()} on node: {sec.get_id()}")
             sec_rpc_client = sec.rpc_client()
             ret = sec_rpc_client.bdev_lvol_resize(f"{lvol.lvs_name}/{lvol.lvol_bdev}", size_in_mib)
             if not ret:
-                msg = f"Error resizing lvol on node: {sec.get_id()}"
-                logger.error(msg)
-                return False, msg
+                raise RuntimeError(f"Error resizing lvol on node: {sec.get_id()}")
 
     lvol = db_controller.get_lvol_by_id(id)
     lvol.size = new_size
     lvol.write_to_db(db_controller.kv_store)
     logger.info("Done")
-
-    return True, None
 
 
 def create_snapshot(lvol_id, snapshot_name, backup=False):

--- a/simplyblock_core/controllers/lvol_controller.py
+++ b/simplyblock_core/controllers/lvol_controller.py
@@ -2004,18 +2004,18 @@ def resize_lvol(id, new_size) -> None:
     if lvol.size == new_size:
         return  # Nothing to do
     elif lvol.size > new_size:
-        raise PreconditionError(f"New size {utils.humanbytes(new_size)} must be higher than the original size {utils.humanbytes(lvol.size)}")
+        raise PreconditionError(f"New size {new_size} must be larger than the original size {lvol.size}")
 
     if new_size > lvol.max_size:
-        raise PreconditionError(f"New size {utils.humanbytes(new_size)} must not be larger than the max size {utils.humanbytes(lvol.max_size)}")
+        raise PreconditionError(f"New size {new_size} must not be larger than the max size {lvol.max_size}")
 
     if 0 < pool.lvol_max_size < new_size:
-        raise PreconditionError(f"New size {utils.humanbytes(new_size)} must not be larger than the pool max size {utils.humanbytes(pool.lvol_max_size)}")
+        raise PreconditionError(f"New size {new_size} must not be larger than the pool max size {pool.lvol_max_size}")
 
     if pool.pool_max_size > 0:
         total = pool_controller.get_pool_total_capacity(pool.get_id())
         if total + new_size > pool.pool_max_size:
-            raise PreconditionError(f"Invalid LVol size: {utils.humanbytes(new_size)}, Pool max size has reached {utils.humanbytes(total+new_size)} of {utils.humanbytes(pool.pool_max_size)}")
+            raise PreconditionError(f"Invalid LVol size: {new_size}, Pool max size has reached {total + new_size} of {pool.pool_max_size}")
 
     snode = db_controller.get_storage_node_by_id(lvol.node_id)
 

--- a/simplyblock_core/controllers/snapshot_controller.py
+++ b/simplyblock_core/controllers/snapshot_controller.py
@@ -917,7 +917,12 @@ def clone(snapshot_id, clone_name, new_size=0, pvc_name=None, pvc_namespace=None
     logger.info("Done")
     snapshot_events.snapshot_clone(snap, lvol)
     if new_size and conv_new_size > snap.lvol.size:
-        lvol_controller.resize_lvol(lvol.get_id(), new_size)
+        try:
+            lvol_controller.resize_lvol(lvol.get_id(), new_size)
+        except Exception:
+            msg = "Resize failed"
+            logger.exception(msg)
+            return False, msg
     return lvol.uuid, False
 
 

--- a/simplyblock_core/exceptions.py
+++ b/simplyblock_core/exceptions.py
@@ -1,0 +1,2 @@
+class PreconditionError(Exception):
+    """Raised when an operation's preconditions are not met."""

--- a/simplyblock_web/api/v1/lvol.py
+++ b/simplyblock_web/api/v1/lvol.py
@@ -8,6 +8,7 @@ from flask import Blueprint
 from flask import request
 
 from simplyblock_core.controllers import lvol_controller, snapshot_controller
+from simplyblock_core.exceptions import PreconditionError
 
 from simplyblock_web import utils
 
@@ -256,8 +257,13 @@ def resize_lvol(uuid):
 
     new_size = core_utils.parse_size(cl_data['size'])
 
-    ret, error = lvol_controller.resize_lvol(uuid, new_size)
-    return utils.get_response(ret, error)
+    try:
+        lvol_controller.resize_lvol(uuid, new_size)
+        return utils.get_response(True)
+    except PreconditionError as e:
+        return utils.get_response_error(str(e), 400)
+    except RuntimeError as e:
+        return utils.get_response_error(str(e), 500)
 
 
 @bp.route('/lvol/connect/<string:uuid>', methods=['GET'])

--- a/simplyblock_web/api/v2/volume.py
+++ b/simplyblock_web/api/v2/volume.py
@@ -166,9 +166,7 @@ def update(cluster: Cluster, pool: StoragePool, volume: Volume, body: UpdatableL
         raise ValueError('Failed to update volume')
 
     if 'size' in body.model_fields_set:
-        success, msg = lvol_controller.resize_lvol(volume.get_id(), body.size)
-        if not success:
-            raise HTTPException(400, msg)
+        lvol_controller.resize_lvol(volume.get_id(), body.size)
 
     return Response(status_code=204)
 

--- a/simplyblock_web/app.py
+++ b/simplyblock_web/app.py
@@ -9,7 +9,7 @@ import time
 
 from fastapi import FastAPI, Request
 from fastapi.middleware.wsgi import WSGIMiddleware
-from fastapi.responses import RedirectResponse
+from fastapi.responses import JSONResponse, RedirectResponse
 from starlette.middleware.base import BaseHTTPMiddleware
 import uvicorn
 from uvicorn.config import Config
@@ -17,6 +17,7 @@ from uvicorn.config import Config
 from simplyblock_web.api import public, v1
 from simplyblock_core import constants, utils as core_utils
 from simplyblock_core.settings import Settings
+from simplyblock_core.exceptions import PreconditionError
 
 logger = core_utils.get_logger(__name__)
 logger.setLevel(constants.LOG_WEB_LEVEL)
@@ -68,6 +69,26 @@ class AccessLogMiddleware(BaseHTTPMiddleware):
 
 
 app: FastAPI = FastAPI()
+
+
+@app.exception_handler(PreconditionError)
+async def precondition_handler(request: Request, exc: PreconditionError):
+    logger.exception("Preciondition checks failed", exc_info=exc)
+    return JSONResponse(status_code=400, content={
+        "error": "Preconditions are not met",
+        "detail": str(exc),
+    })
+
+
+@app.exception_handler(RuntimeError)
+async def runtime_error_handler(request: Request, exc: RuntimeError):
+    logger.exception("Unexcpected error while processing request", exc_info=exc)
+    return JSONResponse(status_code=500, content={
+        "status": "An error occured while processing the request",
+        "detail": str(exc),
+    })
+
+
 app.add_middleware(AccessLogMiddleware)
 app.include_router(public, prefix='/api')
 app.mount('/api/v1', WSGIMiddleware(v1.api))  # For some reason this fails if done in `api/__init__.py`

--- a/tests/ftt2/operation_runner.py
+++ b/tests/ftt2/operation_runner.py
@@ -228,8 +228,11 @@ class OperationRunner:
         """Resize a volume via lvol_controller.resize_lvol()."""
         def _do():
             from simplyblock_core.controllers import lvol_controller
-            result = lvol_controller.resize_lvol(lvol_id, new_size)
-            self._result.success = bool(result)
+            try:
+                lvol_controller.resize_lvol(lvol_id, new_size)
+                self._result.success = True
+            except Exception:
+                self._result.success = False
 
         self.start(_do)
         return self

--- a/tests/ftt2/test_restart_concurrent_ops.py
+++ b/tests/ftt2/test_restart_concurrent_ops.py
@@ -161,8 +161,8 @@ class StressRunner:
                     from simplyblock_core.controllers import lvol_controller
                     lvol = random.choice(created_lvols)
                     new_size = lvol.size + 1_073_741_824
-                    result = lvol_controller.resize_lvol(lvol.uuid, new_size)
-                    self._record("resize", bool(result), t0, time.time(), lvol.uuid)
+                    lvol_controller.resize_lvol(lvol.uuid, new_size)
+                    self._record("resize", True, t0, time.time(), lvol.uuid)
 
             except Exception as e:
                 self._record(op, False, t0, time.time(), str(e))

--- a/tests/migration/test_complex_tree.py
+++ b/tests/migration/test_complex_tree.py
@@ -502,10 +502,11 @@ class TestMigrationProtection:
 
         # Try to resize l3 — must be blocked
         new_size = 4 * 1024 * 1024 * 1024  # 4G
-        result, msg = lvol_controller.resize_lvol(ctx.lvol_uuid("l3"), new_size)
-        assert result is False, \
-            "Resizing a volume with an active migration should be blocked"
-        assert "migration" in msg.lower()
+        try:
+            lvol_controller.resize_lvol(ctx.lvol_uuid("l3"), new_size)
+            assert False, "Resizing a volume with an active migration should be blocked"
+        except Exception as e:
+            assert "migration" in str(e).lower()
 
         run_migration_task(mig_id, max_steps=2000, step_sleep=0.02)
 


### PR DESCRIPTION
Currently, resizing a volume to its current size fails with an error. While this is technically correct --- the best kind of correct --- it's unexpected for users. This PR introduces an early abort in this case, while reporting success. I used the opportunity to rework the `lvol_controller.resize_lvol` function to exception-based error handling.