### PR TITLE
Introduce status checks to API v2

### DIFF
--- a/simplyblock_web/api/v2/__init__.py
+++ b/simplyblock_web/api/v2/__init__.py
@@ -10,6 +10,7 @@ from . import snapshot
 from . import storage_node
 from . import task
 from . import migration
+from . import meta
 from ._auth import verify_api_token
 
 # Assemble routes here to avoid circular imports
@@ -44,8 +45,7 @@ cluster.instance_api.include_router(migration.api)
 cluster.api.include_router(cluster.instance_api)
 management_node.api.include_router(management_node.instance_api)
 
-api = APIRouter(
-    dependencies=[Depends(verify_api_token)],
-)
-api.include_router(cluster.api)
-api.include_router(management_node.api)
+api = APIRouter()
+api.include_router(cluster.api, dependencies=[Depends(verify_api_token)])
+api.include_router(management_node.api, dependencies=[Depends(verify_api_token)])
+api.include_router(meta.api, prefix="/_meta")

--- a/simplyblock_web/api/v2/meta.py
+++ b/simplyblock_web/api/v2/meta.py
@@ -1,0 +1,32 @@
+from fastapi import APIRouter
+from fastapi.responses import PlainTextResponse, Response
+import fdb
+
+from simplyblock_core.db_controller import DBController
+
+
+api = APIRouter()
+
+
+@api.get('/health', status_code=204, response_class=Response)
+def health() -> Response:
+    """Liveness probe: succeeds whenever the process can serve requests."""
+    return Response(status_code=204)
+
+
+@api.get('/ready', status_code=204, response_class=Response)
+def ready() -> Response:
+    """Readiness probe: succeeds when the FoundationDB backend is reachable."""
+    db = DBController()
+    if db.kv_store is None:
+        return Response("FDB not ready", status_code=503)
+
+    try:
+        tr = db.kv_store.create_transaction()
+        tr.options.set_timeout(1000)
+        tr.get(b'\x00')
+        tr.commit().wait()
+    except fdb.FDBError:  # type: ignore[attr-defined]
+        return PlainTextResponse("FDB not ready", status_code=503)
+
+    return Response(status_code=204)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,7 +24,9 @@ def _stub(name, **attrs):
 
 
 if 'fdb' not in sys.modules:
-    _fdb = _stub('fdb', open=lambda *a, **kw: None)
+    class _FDBError(Exception):
+        pass
+    _stub('fdb', open=lambda *a, **kw: None, FDBError=_FDBError)
     _stub('fdb.tuple')
 
 


### PR DESCRIPTION
This adds the last missing feature to the API v2, a system health and readiness check. In introduces two new endpoints:
- `/_meta/health`: always returns a positive response to indicate service responsiveness
- `/_meta/ready`: indicates operational readiness, i.e., whether a database connection can be established. A custom timeout of 1s is used.