### PR TITLE
Toggle cluster secret auth

### DIFF
--- a/simplyblock_web/api/__init__.py
+++ b/simplyblock_web/api/__init__.py
@@ -1,9 +1,4 @@
-from fastapi import APIRouter
-
 from . import v1
 from . import v2
 
-public = APIRouter()
-public.include_router(v2.api, prefix='/v2')
-
-__all__ = ['public', 'v1']
+__all__ = ['v1', 'v2']

--- a/simplyblock_web/api/v2/_auth.py
+++ b/simplyblock_web/api/v2/_auth.py
@@ -109,9 +109,14 @@ def authorized_cluster(
 ) -> UUID | None:
     """FastAPI dependency: identify which cluster a bearer token authenticates as.
 
-    Returns the UUID of the cluster whose secret matches the bearer token, or
-    `None` if no cluster matches (or the matched ID isn't a valid UUID).
+    Returns `None` immediately when cluster-secret authentication is disabled via
+    ``SB_ENABLE_CLUSTER_SECRET_AUTH=false``.  Otherwise returns the UUID of the
+    cluster whose secret matches the bearer token, or `None` if no cluster
+    matches (or the matched ID isn't a valid UUID).
     """
+    if not _web_settings.enable_cluster_secret_auth:
+        return None
+
     token = credentials.credentials
     matched_id = next((
         cluster.id

--- a/simplyblock_web/app.py
+++ b/simplyblock_web/app.py
@@ -14,7 +14,8 @@ from starlette.middleware.base import BaseHTTPMiddleware
 import uvicorn
 from uvicorn.config import Config
 
-from simplyblock_web.api import public, v1
+from simplyblock_web.api import v1, v2
+from simplyblock_web.settings import Settings as WebSettings
 from simplyblock_core import constants, utils as core_utils
 from simplyblock_core.settings import Settings
 from simplyblock_core.exceptions import PreconditionError
@@ -89,33 +90,29 @@ async def runtime_error_handler(request: Request, exc: RuntimeError):
     })
 
 
+_web_settings = WebSettings()
+
 app.add_middleware(AccessLogMiddleware)
-app.include_router(public, prefix='/api')
-app.mount('/api/v1', WSGIMiddleware(v1.api))  # For some reason this fails if done in `api/__init__.py`
 
+if 2 in _web_settings.api_versions:
+    app.include_router(v2.api, prefix='/api/v2')
 
-@app.api_route('/', methods=['GET'])
-@app.api_route('/cluster/{full_path:path}', methods=['GET', 'POST', 'PUT', 'DELETE'])
-@app.api_route('/mgmtnode/{full_path:path}', methods=['GET', 'POST', 'PUT', 'DELETE'])
-@app.api_route('/device/{full_path:path}', methods=['GET', 'POST', 'PUT', 'DELETE'])
-@app.api_route('/lvol/{full_path:path}', methods=['GET', 'POST', 'PUT', 'DELETE'])
-@app.api_route('/snapshot/{full_path:path}', methods=['GET', 'POST', 'PUT', 'DELETE'])
-@app.api_route('/storagenode/{full_path:path}', methods=['GET', 'POST', 'PUT', 'DELETE'])
-@app.api_route('/pool/{full_path:path}', methods=['GET', 'POST', 'PUT', 'DELETE'])
-def redirect_legacy(request: Request) -> RedirectResponse:
-    """
-    Redirect legacy API routes to their corresponding v1 endpoints.
-    
-    Args:
-        request: The incoming HTTP request
-        
-    Returns:
-        RedirectResponse: A 308 Permanent Redirect to the v1 API endpoint
-    """
-    redirect_url: str = f'/api/v1/{request.url.path}'
-    if (query_params := str(request.query_params)):
-        redirect_url += f'?{query_params}'
-    return RedirectResponse(url=redirect_url, status_code=308)
+if 1 in _web_settings.api_versions:
+    app.mount('/api/v1', WSGIMiddleware(v1.api))  # For some reason this fails if done in `api/__init__.py`
+
+    @app.api_route('/', methods=['GET'])
+    @app.api_route('/cluster/{full_path:path}', methods=['GET', 'POST', 'PUT', 'DELETE'])
+    @app.api_route('/mgmtnode/{full_path:path}', methods=['GET', 'POST', 'PUT', 'DELETE'])
+    @app.api_route('/device/{full_path:path}', methods=['GET', 'POST', 'PUT', 'DELETE'])
+    @app.api_route('/lvol/{full_path:path}', methods=['GET', 'POST', 'PUT', 'DELETE'])
+    @app.api_route('/snapshot/{full_path:path}', methods=['GET', 'POST', 'PUT', 'DELETE'])
+    @app.api_route('/storagenode/{full_path:path}', methods=['GET', 'POST', 'PUT', 'DELETE'])
+    @app.api_route('/pool/{full_path:path}', methods=['GET', 'POST', 'PUT', 'DELETE'])
+    def redirect_legacy(request: Request) -> RedirectResponse:
+        redirect_url: str = f'/api/v1/{request.url.path}'
+        if (query_params := str(request.query_params)):
+            redirect_url += f'?{query_params}'
+        return RedirectResponse(url=redirect_url, status_code=308)
 
 
 def main() -> None:

--- a/simplyblock_web/settings.py
+++ b/simplyblock_web/settings.py
@@ -58,6 +58,7 @@ class Settings(BaseSettings):
         BeforeValidator(_parse_int_list),
         AfterValidator(_check_api_versions),
     ] = {1, 2}
+    enable_cluster_secret_auth: bool = True
     k8s_admin_service_accounts: Annotated[
         list[str],
         Field(

--- a/simplyblock_web/settings.py
+++ b/simplyblock_web/settings.py
@@ -1,12 +1,34 @@
 from typing import Annotated, Any
 
-from pydantic import BeforeValidator, Field
+from pydantic import AfterValidator, BeforeValidator, Field, model_validator
 from pydantic_settings import BaseSettings, EnvSettingsSource, SettingsConfigDict
 
 
 def _parse_str_list(v: Any) -> list[str]:
     if isinstance(v, str):
         return [item.strip() for item in v.split(',') if item.strip()]
+    return v
+
+
+def _check_api_versions(v: set[int]) -> set[int]:
+    if unknown := v - {1, 2}:
+        raise ValueError(
+            f"SB_API_VERSIONS contains unknown versions: {sorted(unknown)}. Valid versions are: 1, 2."
+        )
+    return v
+
+
+def _parse_int_list(v: Any) -> list[int]:
+    """Parse a comma-separated string or a bare integer into a list of ints.
+
+    Handles the case where ``_CommaSupportedEnvSource`` already applied
+    ``json.loads`` and returned a Python int (e.g. ``SB_API_VERSIONS=2``
+    becomes the integer ``2`` after JSON parsing).
+    """
+    if isinstance(v, str):
+        return [int(item.strip()) for item in v.split(',') if item.strip()]
+    if isinstance(v, int):
+        return [v]
     return v
 
 
@@ -24,6 +46,18 @@ class _CommaSupportedEnvSource(EnvSettingsSource):
 class Settings(BaseSettings):
     model_config = SettingsConfigDict(env_prefix="sb_", case_sensitive=False)
 
+    api_versions: Annotated[
+        set[int],
+        Field(
+            description=(
+                "API versions to enable. "
+                "Comma-separated list of version numbers (e.g. '1,2'). "
+                "Valid versions are 1 and 2. Defaults to all versions."
+            )
+        ),
+        BeforeValidator(_parse_int_list),
+        AfterValidator(_check_api_versions),
+    ] = {1, 2}
     k8s_admin_service_accounts: Annotated[
         list[str],
         Field(
@@ -35,6 +69,14 @@ class Settings(BaseSettings):
         ),
         BeforeValidator(_parse_str_list),
     ] = []
+
+    @model_validator(mode="after")
+    def validate_cluster_secret_auth(self) -> "Settings":
+        if not self.enable_cluster_secret_auth and 1 in self.api_versions:
+            raise ValueError(
+                "SB_ENABLE_CLUSTER_SECRET_AUTH=false requires API v1 to be disabled."
+            )
+        return self
 
     @classmethod
     def settings_customise_sources(

--- a/tests/web/api/test_settings.py
+++ b/tests/web/api/test_settings.py
@@ -3,6 +3,9 @@
 test_web_settings.py – unit tests for simplyblock_web.settings.
 """
 
+import pytest
+from pydantic import ValidationError
+
 from simplyblock_web.settings import Settings, _parse_str_list, _parse_int_list
 
 
@@ -108,3 +111,35 @@ class TestApiVersionsSetting:
         monkeypatch.setenv("SB_API_VERSIONS", "1,3")
         with pytest.raises(ValidationError, match="SB_API_VERSIONS"):
             Settings()
+
+
+class TestClusterSecretAuthSetting:
+    def test_enabled_by_default(self, monkeypatch):
+        monkeypatch.delenv("SB_ENABLE_CLUSTER_SECRET_AUTH", raising=False)
+        s = Settings()
+        assert s.enable_cluster_secret_auth is True
+
+    def test_can_disable_when_v1_not_in_api_versions(self, monkeypatch):
+        monkeypatch.setenv("SB_API_VERSIONS", "2")
+        monkeypatch.setenv("SB_ENABLE_CLUSTER_SECRET_AUTH", "false")
+        s = Settings()
+        assert s.enable_cluster_secret_auth is False
+
+    def test_disable_with_v1_in_api_versions_fails(self, monkeypatch):
+        monkeypatch.setenv("SB_API_VERSIONS", "1,2")
+        monkeypatch.setenv("SB_ENABLE_CLUSTER_SECRET_AUTH", "false")
+        with pytest.raises(ValidationError, match="SB_ENABLE_CLUSTER_SECRET_AUTH"):
+            Settings()
+
+    def test_disable_with_default_api_versions_fails(self, monkeypatch):
+        monkeypatch.delenv("SB_API_VERSIONS", raising=False)
+        monkeypatch.setenv("SB_ENABLE_CLUSTER_SECRET_AUTH", "false")
+        with pytest.raises(ValidationError, match="SB_ENABLE_CLUSTER_SECRET_AUTH"):
+            Settings()
+
+    def test_both_enabled_is_valid(self, monkeypatch):
+        monkeypatch.setenv("SB_API_VERSIONS", "1,2")
+        monkeypatch.setenv("SB_ENABLE_CLUSTER_SECRET_AUTH", "true")
+        s = Settings()
+        assert s.enable_cluster_secret_auth is True
+        assert 1 in s.api_versions

--- a/tests/web/api/test_settings.py
+++ b/tests/web/api/test_settings.py
@@ -3,7 +3,7 @@
 test_web_settings.py – unit tests for simplyblock_web.settings.
 """
 
-from simplyblock_web.settings import Settings, _parse_str_list
+from simplyblock_web.settings import Settings, _parse_str_list, _parse_int_list
 
 
 class TestParseStrList:
@@ -32,6 +32,26 @@ class TestParseStrList:
         assert _parse_str_list("") == []
 
 
+class TestParseIntList:
+    def test_comma_separated_string(self):
+        assert _parse_int_list("1,2") == [1, 2]
+
+    def test_single_string(self):
+        assert _parse_int_list("1") == [1]
+
+    def test_bare_int(self):
+        # _CommaSupportedEnvSource applies json.loads first, so a bare digit
+        # env var arrives as a Python int rather than a string.
+        assert _parse_int_list(2) == [2]
+
+    def test_passthrough_list(self):
+        lst = [1, 2]
+        assert _parse_int_list(lst) is lst
+
+    def test_empty_string_yields_empty_list(self):
+        assert _parse_int_list("") == []
+
+
 class TestSettings:
     def test_default_is_empty_list(self, monkeypatch):
         monkeypatch.delenv("SB_K8S_ADMIN_SERVICE_ACCOUNTS", raising=False)
@@ -56,3 +76,35 @@ class TestSettings:
         )
         s = Settings()
         assert s.k8s_admin_service_accounts == ["system:serviceaccount:default:my-operator"]
+
+
+class TestApiVersionsSetting:
+    def test_default_is_all_versions(self, monkeypatch):
+        monkeypatch.delenv("SB_API_VERSIONS", raising=False)
+        s = Settings()
+        assert s.api_versions == {1, 2}
+
+    def test_comma_separated_env_var(self, monkeypatch):
+        monkeypatch.setenv("SB_API_VERSIONS", "1,2")
+        s = Settings()
+        assert s.api_versions == {1, 2}
+
+    def test_single_version_v1_only(self, monkeypatch):
+        monkeypatch.setenv("SB_API_VERSIONS", "1")
+        s = Settings()
+        assert s.api_versions == {1}
+
+    def test_single_version_v2_only(self, monkeypatch):
+        monkeypatch.setenv("SB_API_VERSIONS", "2")
+        s = Settings()
+        assert s.api_versions == {2}
+
+    def test_empty_disables_all(self, monkeypatch):
+        monkeypatch.setenv("SB_API_VERSIONS", "")
+        s = Settings()
+        assert s.api_versions == set()
+
+    def test_unknown_version_fails(self, monkeypatch):
+        monkeypatch.setenv("SB_API_VERSIONS", "1,3")
+        with pytest.raises(ValidationError, match="SB_API_VERSIONS"):
+            Settings()

--- a/tests/web/api/v2/test_auth.py
+++ b/tests/web/api/v2/test_auth.py
@@ -135,6 +135,20 @@ class TestAuthorizedCluster:
         with patch.object(auth, "_db", mock_db):
             assert auth.authorized_cluster(_make_credentials("s3cr3t")) is None
 
+    def test_returns_none_without_db_lookup_when_cluster_secret_auth_disabled(self):
+        import simplyblock_web.api.v2._auth as auth
+
+        mock_db = MagicMock()
+        mock_db.get_clusters.return_value = [self._cluster(self._CLUSTER_UUID, "s3cr3t")]
+        mock_settings = MagicMock()
+        mock_settings.enable_cluster_secret_auth = False
+
+        with patch.object(auth, "_db", mock_db), patch.object(auth, "_web_settings", mock_settings):
+            result = auth.authorized_cluster(_make_credentials("s3cr3t"))
+
+        assert result is None
+        mock_db.get_clusters.assert_not_called()
+
 
 # ---------------------------------------------------------------------------
 # verify_api_token (orchestration)


### PR DESCRIPTION
This introduces an option to toggle cluster-secret-based authentication in the API. Since the tokens are long-lived and there is no rotation mechanism for them, depending on security requirements it makes sense for some deployments to completely rely on the service account based authentication introduced recently.

Since the cluster-secret is the only authentication mechanism for API v1, it requires it to be disabled for this purpose. This option is also introduced in this PR, by configuring a list of enabled API versions, which yields a generic option for managing which API versions are available.