### PR TITLE
Prevent secret leakage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,20 @@ Data flows: **CLI → Web API → Core controllers → FoundationDB**. Storage n
 - **Ruff** and **mypy** are enforced in CI. `simplyblock_cli/cli.py` is excluded from ruff (auto-generated). `simplyblock_web/test` is excluded from mypy.
 - `tests/perf/` is excluded from pytest discovery.
 
+### Secret Handling
+
+Secrets (passwords, tokens, keys, connection strings) are wrapped in Pydantic's `SecretStr` / `SecretBytes` throughout the codebase. The core principle is **wrap early, unwrap late**: secrets enter the system wrapped at the boundary (CLI parse, API ingress, DB read) and are only unwrapped to plaintext at the final wire-send moment. Every layer in between sees only masked values in `repr`/`str`/logging.
+
+Key rules:
+
+- **Model fields**: Declare secret fields as `SecretStr` with a `SecretStr("")` default. `BaseModel.from_dict()` auto-wraps inbound plaintext for backward compatibility with existing FDB records. `to_dict()` keeps wrappers by default (safe for logging); `to_dict(unwrap_secrets=True)` produces plaintext for persistence — only `write_to_db()` should call this.
+- **Clients (RPC, SNode, Firewall API)**: Accept `SecretStr` parameters. Log the payload dict *before* unwrapping (wrappers mask in log output), then call `unwrap_secrets_for_send(payload)` from `simplyblock_core/utils/secrets.py` right before `requests.post(json=...)`.
+- **v2 DTOs**: Use `@field_serializer('field', when_used='json')` to unwrap for JSON wire responses while keeping wrappers in Python-mode `model_dump()`.
+- **CLI arguments**: Declare the argument type as `secret` in `cli-reference.yaml`. The generator produces `SecretStr` as the argparse type converter, so the value is wrapped at parse time.
+- **Logging**: Never log unwrapped secret values. Response-body logging is gated by `Settings().log_response_bodies` (env `SB_LOG_RESPONSE_BODIES`, default `False`). External libraries that log HTTP bodies (`urllib3`, `kubernetes.client.rest`) are silenced to WARNING. The web access log records only `request.url.path`, never the query string.
+- **Comparison**: Use `hmac.compare_digest(secret.get_secret_value(), other)` for timing-safe comparison.
+- **Testing**: New secret-bearing code needs tests verifying (1) plaintext never appears in `repr`/`str`/log output, (2) plaintext is delivered on the wire, and (3) FDB round-trip preserves the value. See `tests/test_secret_redaction.py` and `tests/test_client_secret_logging.py` for patterns.
+
 ## Verification
 
 After any code change, run the `tox-verify` skill (`.agents/skills/tox-verify.md`). The short version:

--- a/simplyblock_cli/AGENTS.md
+++ b/simplyblock_cli/AGENTS.md
@@ -23,6 +23,7 @@ The generator (`scripts/cli-wrapper-gen.py`) reads the YAML and writes `cli.py`.
 - **Positional arguments** (no `--`/`-` prefix) are always required.
 - **Optional arguments** (`--`/`-` prefix) are optional unless marked `required: true`.
 - **Function naming**: The generator maps commands to handler functions in `clibase.py` as `<command>__<subcommand>`. Hyphens in command names become underscores (e.g., `storage-node list` → `storage_node__list`).
+- **Secret arguments**: Use `type: secret` in `cli-reference.yaml` for any argument that carries a password, token, or key. The generator maps this to `SecretStr` (from `pydantic`) as the argparse type converter, so the value is wrapped at parse time and masked in `repr(vars(args))`. Handler code in `clibase.py` receives a `SecretStr` and should pass it through to the API without unwrapping.
 
 ## Adding a CLI Command
 

--- a/simplyblock_cli/cli-reference-schema.yaml
+++ b/simplyblock_cli/cli-reference-schema.yaml
@@ -209,6 +209,7 @@ properties:
                             - bool
                             - size
                             - list
+                            - secret
                         - type: object
                           description: |
                             Valid arguments are integers within a specific range. Minimum is inclusive and maximum is exclusive.

--- a/simplyblock_cli/cli-reference.yaml
+++ b/simplyblock_cli/cli-reference.yaml
@@ -838,7 +838,7 @@ commands:
           - name: "--CLI_PASS"
             help: "The password for CLI SSH connection."
             dest: CLI_PASS
-            type: str
+            type: secret
             private: true
           - name: "--cap-warn"
             help: "The capacity warning level in percent. Default: `89`."
@@ -1344,7 +1344,7 @@ commands:
           - name: "secret"
             help: "The new 20 characters password."
             dest: secret
-            type: str
+            type: secret
       - name: update-fabric
         help: "Updates a cluster's fabric."
         arguments:
@@ -2004,7 +2004,7 @@ commands:
           - name: "cluster_secret"
             help: "The cluster secret."
             dest: cluster_secret
-            type: str
+            type: secret
           - name: "--ifname"
             help: "The management interface name."
             dest: ifname

--- a/simplyblock_cli/cli.py
+++ b/simplyblock_cli/cli.py
@@ -5,6 +5,8 @@ import logging
 import sys
 import traceback
 
+from pydantic import SecretStr
+
 from simplyblock_cli.clibase import CLIWrapperBase, range_type, size_type, list_type
 from simplyblock_core import utils, constants
 
@@ -388,7 +390,7 @@ class CLIWrapper(CLIWrapperBase):
         if self.developer_mode:
             subcommand.add_argument('--page_size', help='The size of a data page in bytes. Default: `2097152`.', type=int, default=2097152, dest='page_size')
         if self.developer_mode:
-            subcommand.add_argument('--CLI_PASS', help='The password for CLI SSH connection.', type=str, dest='CLI_PASS')
+            subcommand.add_argument('--CLI_PASS', help='The password for CLI SSH connection.', type=SecretStr, dest='CLI_PASS')
         subcommand.add_argument('--cap-warn', help='The capacity warning level in percent. Default: `89`.', type=int, default=89, dest='cap_warn')
         subcommand.add_argument('--cap-crit', help='The capacity critical level in percent. Default: `99`.', type=int, default=99, dest='cap_crit')
         subcommand.add_argument('--prov-cap-warn', help='The capacity warning level in percent. Default: `250`.', type=int, default=250, dest='prov_cap_warn')
@@ -518,7 +520,7 @@ class CLIWrapper(CLIWrapperBase):
     def init_cluster__update_secret(self, subparser):
         subcommand = self.add_sub_command(subparser, 'update-secret', 'Updates a cluster\'s secret.')
         subcommand.add_argument('cluster_id', help='The cluster id.', type=str).completer = self._completer_get_cluster_list
-        subcommand.add_argument('secret', help='The new 20 characters password.', type=str)
+        subcommand.add_argument('secret', help='The new 20 characters password.', type=SecretStr)
 
     def init_cluster__update_fabric(self, subparser):
         subcommand = self.add_sub_command(subparser, 'update-fabric', 'Updates a cluster\'s fabric.')
@@ -789,7 +791,7 @@ class CLIWrapper(CLIWrapperBase):
         subcommand = self.add_sub_command(subparser, 'add', 'Adds a control plane to the cluster (local run).')
         subcommand.add_argument('cluster_ip', help='The cluster IP address.', type=str)
         subcommand.add_argument('cluster_id', help='The cluster id.', type=str)
-        subcommand.add_argument('cluster_secret', help='The cluster secret.', type=str)
+        subcommand.add_argument('cluster_secret', help='The cluster secret.', type=SecretStr)
         subcommand.add_argument('--ifname', help='The management interface name.', type=str, dest='ifname')
         subcommand.add_argument('--mgmt-ip', help='Management IP address to use for the node (e.g., 192.168.1.10).', type=str, dest='mgmt_ip')
         subcommand.add_argument('--mode', help='The environment to deploy management services. Default: `docker`.', type=str, default='docker', dest='mode', choices=['docker','kubernetes',])

--- a/simplyblock_cli/clibase.py
+++ b/simplyblock_cli/clibase.py
@@ -7,7 +7,6 @@ import re
 import sys
 import time
 import argcomplete
-from pydantic import SecretStr
 
 from simplyblock_core import cluster_ops, utils, db_controller, constants
 from simplyblock_core.exceptions import MigrationConflictError, PreconditionError
@@ -771,7 +770,7 @@ class CLIWrapperBase:
     def control_plane__add(self, sub_command, args):
         cluster_id = args.cluster_id
         cluster_ip = args.cluster_ip
-        cluster_secret = SecretStr(args.cluster_secret)
+        cluster_secret = args.cluster_secret
         ifname = args.ifname
         mgmt_ip = args.mgmt_ip
         mode = args.mode

--- a/simplyblock_cli/clibase.py
+++ b/simplyblock_cli/clibase.py
@@ -7,6 +7,7 @@ import re
 import sys
 import time
 import argcomplete
+from pydantic import SecretStr
 
 from simplyblock_core import cluster_ops, utils, db_controller, constants
 from simplyblock_core.exceptions import MigrationConflictError, PreconditionError
@@ -770,7 +771,7 @@ class CLIWrapperBase:
     def control_plane__add(self, sub_command, args):
         cluster_id = args.cluster_id
         cluster_ip = args.cluster_ip
-        cluster_secret = args.cluster_secret
+        cluster_secret = SecretStr(args.cluster_secret)
         ifname = args.ifname
         mgmt_ip = args.mgmt_ip
         mode = args.mode

--- a/simplyblock_cli/scripts/cli-wrapper-gen.py
+++ b/simplyblock_cli/scripts/cli-wrapper-gen.py
@@ -49,6 +49,9 @@ def argument_type(spec):
     if spec == 'list':
         return "list_type()"
 
+    if spec == 'secret':
+        return "SecretStr"
+
     return spec
 
 

--- a/simplyblock_cli/scripts/cli-wrapper.jinja2
+++ b/simplyblock_cli/scripts/cli-wrapper.jinja2
@@ -5,6 +5,8 @@ import logging
 import sys
 import traceback
 
+from pydantic import SecretStr
+
 from simplyblock_cli.clibase import CLIWrapperBase, range_type, size_type, list_type
 from simplyblock_core import utils, constants
 

--- a/simplyblock_core/AGENTS.md
+++ b/simplyblock_core/AGENTS.md
@@ -19,6 +19,17 @@ All models extend `BaseModel` (`models/base_model.py`). Key conventions:
 - Identity: `uuid` field; `get_id()` returns it. `get_db_id()` returns the FDB key as `<object_type>/<class_name>/<uuid>`.
 - Persistence: `write_to_db(kv_store)` and `read_from_db(kv_store)` serialize to/from JSON in FDB.
 - `BaseNodeObject` extends `BaseModel` with standard node status constants (`STATUS_ONLINE`, `STATUS_OFFLINE`, etc.) and a status code map.
+- **Secret fields** use `SecretStr` (from `pydantic`) as the type annotation with `SecretStr("")` default. `from_dict()` auto-wraps plain strings from FDB into `SecretStr`. `to_dict()` keeps wrappers (safe for logging); only `write_to_db()` calls `to_dict(unwrap_secrets=True)` to persist plaintext. When adding a new secret field, follow existing examples in `cluster.py`, `storage_node.py`, or `pool.py`.
+
+## Client Pattern (RPC, SNode, Firewall API)
+
+Clients in `rpc_client.py`, `snode_client.py`, and `fw_api_client.py` accept `SecretStr` parameters and follow the **log-then-unwrap** pattern:
+
+1. Log the payload dict containing `SecretStr` wrappers (masked by Pydantic's `__repr__`).
+2. Call `unwrap_secrets_for_send(payload)` from `utils/secrets.py` to produce a plaintext dict.
+3. Send the plaintext dict as JSON on the wire.
+
+Response-body logging is gated by `Settings().log_response_bodies` (default `False`). When off, only status code and content-length are logged.
 
 ## Tests
 

--- a/simplyblock_core/cluster_ops.py
+++ b/simplyblock_core/cluster_ops.py
@@ -465,7 +465,7 @@ def _cleanup_nvme(mount_point, nqn_value) -> None:
 def add_cluster(blk_size, page_size_in_blocks, cap_warn, cap_crit, prov_cap_warn, prov_cap_crit,
                 distr_ndcs, distr_npcs, distr_bs, distr_chunk_bs, ha_type, enable_node_affinity, qpair_count,
                 max_queue_size, inflight_io_threshold, strict_node_anti_affinity, is_single_node, name, cr_name=None,
-                cr_namespace=None, cr_plural=None, fabric="tcp", cluster_ip=None, grafana_secret=None,
+                cr_namespace=None, cr_plural=None, fabric="tcp", cluster_ip=None, grafana_secret: t.Optional[SecretStr] = None,
                 client_data_nic="", max_fault_tolerance=1, backup_config=None,
                 nvmf_base_port=4420, rpc_base_port=8080, snode_api_port=50001,
                 hashicorp_vault_settings : t.Optional[HashicorpVaultSettings] = None,
@@ -519,7 +519,7 @@ def add_cluster(blk_size, page_size_in_blocks, cap_warn, cap_crit, prov_cap_warn
     if default_cluster:
         cluster.mode = default_cluster.mode
         cluster.db_connection = default_cluster.db_connection
-        cluster.grafana_secret = SecretStr(grafana_secret) if grafana_secret else default_cluster.grafana_secret
+        cluster.grafana_secret = grafana_secret if grafana_secret else default_cluster.grafana_secret
         cluster.grafana_endpoint = default_cluster.grafana_endpoint
     else:
         # creating first cluster on k8s

--- a/simplyblock_core/cluster_ops.py
+++ b/simplyblock_core/cluster_ops.py
@@ -260,7 +260,7 @@ def create_cluster(blk_size, page_size_in_blocks, cli_pass,
     scripts.install_deps(mode)
     logger.info("Installing dependencies > Done")
 
-    db_connection = None
+    db_connection: SecretStr | None = None
     if mode == "docker":
         if not ifname:
             ifname = "eth0"
@@ -269,8 +269,8 @@ def create_cluster(blk_size, page_size_in_blocks, cli_pass,
         if not dev_ip:
             raise ValueError(f"Error getting interface ip: {ifname}")
 
-        db_connection = f"{utils.generate_string(8)}:{utils.generate_string(32)}@{dev_ip}:4500"
-        scripts.set_db_config(db_connection)
+        db_connection = SecretStr(f"{utils.generate_string(8)}:{utils.generate_string(32)}@{dev_ip}:4500")
+        scripts.set_db_config(db_connection.get_secret_value())
         logger.info(f"Node IP: {dev_ip}")
         scripts.configure_docker(dev_ip)
         logger.info("Configuring docker swarm...")

--- a/simplyblock_core/cluster_ops.py
+++ b/simplyblock_core/cluster_ops.py
@@ -13,6 +13,8 @@ from kubernetes import client as k8s_client
 import requests
 
 from docker.errors import DockerException
+from pydantic import SecretStr
+
 from simplyblock_core import utils, scripts, constants, mgmt_node_ops, storage_node_ops
 from simplyblock_core import port_block
 from simplyblock_core.controllers import backup_controller, cluster_events, device_controller, qos_controller, tasks_controller, tcp_ports_events
@@ -322,9 +324,9 @@ def create_cluster(blk_size, page_size_in_blocks, cli_pass,
     cluster.blk_size = blk_size
     cluster.page_size_in_blocks = page_size_in_blocks
     cluster.nqn = f"{constants.CLUSTER_NQN}:{cluster.uuid}"
-    cluster.cli_pass = cli_pass
-    cluster.secret = utils.generate_string(20)
-    cluster.grafana_secret = monitoring_secret if mode == "kubernetes" else cluster.secret
+    cluster.cli_pass = SecretStr(cli_pass)
+    cluster.secret = SecretStr(utils.generate_string(20))
+    cluster.grafana_secret = SecretStr(monitoring_secret) if mode == "kubernetes" else cluster.secret
     if cap_warn and cap_warn > 0:
         cluster.cap_warn = cap_warn
     if cap_crit and cap_crit > 0:
@@ -380,18 +382,18 @@ def create_cluster(blk_size, page_size_in_blocks, cli_pass,
 
     if mode == "docker":
         if not disable_monitoring:
-            utils.render_and_deploy_alerting_configs(contact_point, cluster.grafana_endpoint, cluster.uuid, cluster.secret)
+            utils.render_and_deploy_alerting_configs(contact_point, cluster.grafana_endpoint, cluster.uuid, cluster.secret.get_secret_value())
 
         logger.info("Deploying swarm stack ...")
         log_level = "DEBUG" if constants.LOG_WEB_DEBUG else "INFO"
-        scripts.deploy_stack(cli_pass, dev_ip, constants.SIMPLY_BLOCK_DOCKER_IMAGE, cluster.secret, cluster.uuid,
+        scripts.deploy_stack(cli_pass, dev_ip, constants.SIMPLY_BLOCK_DOCKER_IMAGE, cluster.secret.get_secret_value(), cluster.uuid,
                                 log_del_interval, metrics_retention_period, log_level, cluster.grafana_endpoint, str(disable_monitoring))
         logger.info("Deploying swarm stack > Done")
 
         logger.info("Configuring DB...")
         scripts.set_db_config_single()
         logger.info("Configuring DB > Done")
-        monitoring_secret = cluster.secret
+        monitoring_secret = cluster.secret.get_secret_value()
 
     elif mode == "kubernetes":
         logger.info("Retrieving foundationdb connection string...")
@@ -399,7 +401,7 @@ def create_cluster(blk_size, page_size_in_blocks, cli_pass,
         db_connection = fdb_cluster_string
 
         logger.info("Patching prometheus configmap...")
-        utils.patch_prometheus_configmap(cluster.uuid, cluster.secret)
+        utils.patch_prometheus_configmap(cluster.uuid, cluster.secret.get_secret_value())
 
         if ingress_host_source == "hostip":
             dns_name = dev_ip
@@ -419,7 +421,7 @@ def create_cluster(blk_size, page_size_in_blocks, cli_pass,
     if not disable_monitoring:
         _set_max_result_window(os_endpoint)
         _add_graylog_input(graylog_endpoint, monitoring_secret)
-        _create_update_user(cluster.uuid, cluster.grafana_endpoint, monitoring_secret, cluster.secret)
+        _create_update_user(cluster.uuid, cluster.grafana_endpoint, monitoring_secret, cluster.secret.get_secret_value())
 
     cluster.db_connection = db_connection  # type: ignore[assignment]
     cluster.status = Cluster.STATUS_UNREADY
@@ -513,12 +515,12 @@ def add_cluster(blk_size, page_size_in_blocks, cap_warn, cap_crit, prov_cap_warn
     cluster.blk_size = blk_size
     cluster.page_size_in_blocks = page_size_in_blocks
     cluster.nqn = f"{constants.CLUSTER_NQN}:{cluster.uuid}"
-    cluster.secret = utils.generate_string(20)
+    cluster.secret = SecretStr(utils.generate_string(20))
     cluster.strict_node_anti_affinity = strict_node_anti_affinity
     if default_cluster:
         cluster.mode = default_cluster.mode
         cluster.db_connection = default_cluster.db_connection
-        cluster.grafana_secret = grafana_secret if grafana_secret else default_cluster.grafana_secret
+        cluster.grafana_secret = SecretStr(grafana_secret) if grafana_secret else default_cluster.grafana_secret
         cluster.grafana_endpoint = default_cluster.grafana_endpoint
     else:
         # creating first cluster on k8s
@@ -527,9 +529,9 @@ def add_cluster(blk_size, page_size_in_blocks, cap_warn, cap_crit, prov_cap_warn
         fdb_cluster_string = utils.get_fdb_cluster_string(constants.FDB_CONFIG_NAME, constants.K8S_NAMESPACE)
         cluster.db_connection = fdb_cluster_string
         if monitoring_secret:
-            cluster.grafana_secret = monitoring_secret
+            cluster.grafana_secret = SecretStr(monitoring_secret)
         elif enable_monitoring != "true":
-            cluster.grafana_secret = ""
+            cluster.grafana_secret = SecretStr("")
         else:
             raise Exception("monitoring_secret is required")
         cluster.grafana_endpoint = constants.GRAFANA_K8S_ENDPOINT
@@ -541,14 +543,14 @@ def add_cluster(blk_size, page_size_in_blocks, cap_warn, cap_crit, prov_cap_warn
         if enable_monitoring == "true":
             graylog_endpoint = constants.GRAYLOG_K8S_ENDPOINT
             os_endpoint = constants.OS_K8S_ENDPOINT
-            _create_update_user(cluster.uuid, cluster.grafana_endpoint, cluster.grafana_secret, cluster.secret)
+            _create_update_user(cluster.uuid, cluster.grafana_endpoint, cluster.grafana_secret.get_secret_value(), cluster.secret.get_secret_value())
 
             _set_max_result_window(os_endpoint)
 
             _add_graylog_input(graylog_endpoint, monitoring_secret)
 
     if cluster.mode == "kubernetes":
-        utils.patch_prometheus_configmap(cluster.uuid, cluster.secret)
+        utils.patch_prometheus_configmap(cluster.uuid, cluster.secret.get_secret_value())
 
     cluster.distr_ndcs = distr_ndcs
     cluster.distr_npcs = distr_npcs
@@ -1570,11 +1572,11 @@ def get_iostats_history(cluster_id, history_string, records_count=20, with_sizes
 
 
 def get_ssh_pass(cluster_id) -> str:
-    return db_controller.get_cluster_by_id(cluster_id).cli_pass
+    return db_controller.get_cluster_by_id(cluster_id).cli_pass.get_secret_value()
 
 
 def get_secret(cluster_id) -> str:
-    return db_controller.get_cluster_by_id(cluster_id).secret
+    return db_controller.get_cluster_by_id(cluster_id).secret.get_secret_value()
 
 
 def set_secret(cluster_id, secret) -> None:
@@ -1583,9 +1585,9 @@ def set_secret(cluster_id, secret) -> None:
     if len(secret) < 20:
         raise ValueError("Secret must be at least 20 char")
 
-    _create_update_user(cluster_id, cluster.grafana_endpoint, cluster.grafana_secret, secret, update_secret=True)
+    _create_update_user(cluster_id, cluster.grafana_endpoint, cluster.grafana_secret.get_secret_value(), secret, update_secret=True)
 
-    cluster.secret = secret
+    cluster.secret = SecretStr(secret)
     cluster.write_to_db(db_controller.kv_store)
 
 

--- a/simplyblock_core/cluster_ops.py
+++ b/simplyblock_core/cluster_ops.py
@@ -307,7 +307,7 @@ def create_cluster(blk_size, page_size_in_blocks, cli_pass,
 
 
     if not cli_pass:
-        cli_pass = utils.generate_string(10)
+        cli_pass = SecretStr(utils.generate_string(10))
 
     logger.info("Adding new cluster object")
     cluster = Cluster()
@@ -324,7 +324,7 @@ def create_cluster(blk_size, page_size_in_blocks, cli_pass,
     cluster.blk_size = blk_size
     cluster.page_size_in_blocks = page_size_in_blocks
     cluster.nqn = f"{constants.CLUSTER_NQN}:{cluster.uuid}"
-    cluster.cli_pass = SecretStr(cli_pass)
+    cluster.cli_pass = cli_pass
     cluster.secret = SecretStr(utils.generate_string(20))
     cluster.grafana_secret = monitoring_secret if mode == "kubernetes" else cluster.secret
     if cap_warn and cap_warn > 0:
@@ -386,7 +386,7 @@ def create_cluster(blk_size, page_size_in_blocks, cli_pass,
 
         logger.info("Deploying swarm stack ...")
         log_level = "DEBUG" if constants.LOG_WEB_DEBUG else "INFO"
-        scripts.deploy_stack(cli_pass, dev_ip, constants.SIMPLY_BLOCK_DOCKER_IMAGE, cluster.secret.get_secret_value(), cluster.uuid,
+        scripts.deploy_stack(cli_pass.get_secret_value(), dev_ip, constants.SIMPLY_BLOCK_DOCKER_IMAGE, cluster.secret.get_secret_value(), cluster.uuid,
                                 log_del_interval, metrics_retention_period, log_level, cluster.grafana_endpoint, str(disable_monitoring))
         logger.info("Deploying swarm stack > Done")
 
@@ -1578,15 +1578,16 @@ def get_secret(cluster_id) -> str:
     return db_controller.get_cluster_by_id(cluster_id).secret.get_secret_value()
 
 
-def set_secret(cluster_id, secret) -> None:
+def set_secret(cluster_id, secret: SecretStr) -> None:
     cluster = db_controller.get_cluster_by_id(cluster_id)
-    secret = secret.strip()
-    if len(secret) < 20:
+    plain = secret.get_secret_value().strip()
+    if len(plain) < 20:
         raise ValueError("Secret must be at least 20 char")
+    secret = SecretStr(plain)
 
-    _create_update_user(cluster_id, cluster.grafana_endpoint, cluster.grafana_secret, SecretStr(secret), update_secret=True)
+    _create_update_user(cluster_id, cluster.grafana_endpoint, cluster.grafana_secret, secret, update_secret=True)
 
-    cluster.secret = SecretStr(secret)
+    cluster.secret = secret
     cluster.write_to_db(db_controller.kv_store)
 
 

--- a/simplyblock_core/cluster_ops.py
+++ b/simplyblock_core/cluster_ops.py
@@ -35,9 +35,9 @@ logger = utils.get_logger(__name__)
 
 db_controller = DBController()
 
-def _create_update_user(cluster_id, grafana_url, grafana_secret, user_secret, update_secret=False):
+def _create_update_user(cluster_id, grafana_url, grafana_secret: SecretStr, user_secret: SecretStr, update_secret=False):
     session = requests.session()
-    session.auth = ("admin", grafana_secret)
+    session.auth = ("admin", grafana_secret.get_secret_value())
     headers = {
         'X-Requested-By': '',
         'Content-Type': 'application/json',
@@ -49,7 +49,7 @@ def _create_update_user(cluster_id, grafana_url, grafana_secret, user_secret, up
         userid = response.json().get("id")
 
         payload = json.dumps({
-            "password": user_secret
+            "password": user_secret.get_secret_value()
         })
 
         url = f"{grafana_url}/api/admin/users/{userid}/password"
@@ -68,7 +68,7 @@ def _create_update_user(cluster_id, grafana_url, grafana_secret, user_secret, up
         payload = json.dumps({
             "name": cluster_id,
             "login": cluster_id,
-            "password": user_secret
+            "password": user_secret.get_secret_value()
         })
         url = f"{grafana_url}/api/admin/users"
         while retries > 0:
@@ -82,14 +82,14 @@ def _create_update_user(cluster_id, grafana_url, grafana_secret, user_secret, up
             time.sleep(3)
 
 
-def _add_graylog_input(cluster_ip, password):
+def _add_graylog_input(cluster_ip, password: SecretStr):
     base_url = f"{cluster_ip}/api"
     input_url = f"{base_url}/system/inputs"
 
     retries = 30
     reachable = False
     session = requests.session()
-    session.auth = ("admin", password)
+    session.auth = ("admin", password.get_secret_value())
     headers = {
         'X-Requested-By': 'setup-script',
         'Content-Type': 'application/json',
@@ -117,17 +117,17 @@ def _add_graylog_input(cluster_ip, password):
             reachable = True
             break
 
-        logger.debug(response.text)
+        logger.debug("Graylog input POST returned status %s", response.status_code)
         retries -= 1
         time.sleep(5)
 
     if not reachable:
-        logger.error(f"Failed to create graylog input: {response.text}")
+        logger.error("Failed to create graylog input (status %s)", response.status_code)
         return False
 
     inputs_response = session.get(input_url, headers=headers)
     if inputs_response.status_code != 200:
-        logger.error(f"Failed to retrieve inputs: {inputs_response.text}")
+        logger.error("Failed to retrieve inputs (status %s)", inputs_response.status_code)
         return False
 
     input_id = None
@@ -156,7 +156,7 @@ def _add_graylog_input(cluster_ip, password):
 
     extractor_response = session.post(extractor_url, headers=headers, data=json.dumps(extractor_payload))
     if extractor_response.status_code != 201:
-        logger.error(f"Failed to add JSON extractor: {extractor_response.text}")
+        logger.error("Failed to add JSON extractor (status %s)", extractor_response.status_code)
         return False
 
     logger.info("JSON extractor added successfully.")
@@ -254,7 +254,7 @@ def create_cluster(blk_size, page_size_in_blocks, cli_pass,
             if existing.cluster_name and existing.cluster_name == name:
                 raise ValueError(f"A cluster with the name '{name}' already exists")
 
-    monitoring_secret = os.environ.get("MONITORING_SECRET", "")
+    monitoring_secret = SecretStr(os.environ.get("MONITORING_SECRET", ""))
 
     logger.info("Installing dependencies...")
     scripts.install_deps(mode)
@@ -326,7 +326,7 @@ def create_cluster(blk_size, page_size_in_blocks, cli_pass,
     cluster.nqn = f"{constants.CLUSTER_NQN}:{cluster.uuid}"
     cluster.cli_pass = SecretStr(cli_pass)
     cluster.secret = SecretStr(utils.generate_string(20))
-    cluster.grafana_secret = SecretStr(monitoring_secret) if mode == "kubernetes" else cluster.secret
+    cluster.grafana_secret = monitoring_secret if mode == "kubernetes" else cluster.secret
     if cap_warn and cap_warn > 0:
         cluster.cap_warn = cap_warn
     if cap_crit and cap_crit > 0:
@@ -393,7 +393,7 @@ def create_cluster(blk_size, page_size_in_blocks, cli_pass,
         logger.info("Configuring DB...")
         scripts.set_db_config_single()
         logger.info("Configuring DB > Done")
-        monitoring_secret = cluster.secret.get_secret_value()
+        monitoring_secret = cluster.secret
 
     elif mode == "kubernetes":
         logger.info("Retrieving foundationdb connection string...")
@@ -421,7 +421,7 @@ def create_cluster(blk_size, page_size_in_blocks, cli_pass,
     if not disable_monitoring:
         _set_max_result_window(os_endpoint)
         _add_graylog_input(graylog_endpoint, monitoring_secret)
-        _create_update_user(cluster.uuid, cluster.grafana_endpoint, monitoring_secret, cluster.secret.get_secret_value())
+        _create_update_user(cluster.uuid, cluster.grafana_endpoint, monitoring_secret, cluster.secret)
 
     cluster.db_connection = db_connection  # type: ignore[assignment]
     cluster.status = Cluster.STATUS_UNREADY
@@ -473,7 +473,6 @@ def add_cluster(blk_size, page_size_in_blocks, cap_warn, cap_crit, prov_cap_warn
 
 
     default_cluster = None
-    monitoring_secret = os.environ.get("MONITORING_SECRET", "")
     enable_monitoring = os.environ.get("ENABLE_MONITORING", "")
     clusters = db_controller.get_clusters()
     if clusters:
@@ -498,7 +497,7 @@ def add_cluster(blk_size, page_size_in_blocks, cap_warn, cap_crit, prov_cap_warn
     if (hashicorp_vault_settings is not None) and (Settings().tls_connect != "authenticated"):
         raise ValueError("External KMS requires mTLS authentication to be used")
 
-    monitoring_secret = os.environ.get("MONITORING_SECRET", "")
+    monitoring_secret = SecretStr(os.environ.get("MONITORING_SECRET", ""))
 
     logger.info("Adding new cluster")
     cluster = Cluster()
@@ -529,7 +528,7 @@ def add_cluster(blk_size, page_size_in_blocks, cap_warn, cap_crit, prov_cap_warn
         fdb_cluster_string = utils.get_fdb_cluster_string(constants.FDB_CONFIG_NAME, constants.K8S_NAMESPACE)
         cluster.db_connection = fdb_cluster_string
         if monitoring_secret:
-            cluster.grafana_secret = SecretStr(monitoring_secret)
+            cluster.grafana_secret = monitoring_secret
         elif enable_monitoring != "true":
             cluster.grafana_secret = SecretStr("")
         else:
@@ -543,7 +542,7 @@ def add_cluster(blk_size, page_size_in_blocks, cap_warn, cap_crit, prov_cap_warn
         if enable_monitoring == "true":
             graylog_endpoint = constants.GRAYLOG_K8S_ENDPOINT
             os_endpoint = constants.OS_K8S_ENDPOINT
-            _create_update_user(cluster.uuid, cluster.grafana_endpoint, cluster.grafana_secret.get_secret_value(), cluster.secret.get_secret_value())
+            _create_update_user(cluster.uuid, cluster.grafana_endpoint, cluster.grafana_secret, cluster.secret)
 
             _set_max_result_window(os_endpoint)
 
@@ -1585,7 +1584,7 @@ def set_secret(cluster_id, secret) -> None:
     if len(secret) < 20:
         raise ValueError("Secret must be at least 20 char")
 
-    _create_update_user(cluster_id, cluster.grafana_endpoint, cluster.grafana_secret.get_secret_value(), secret, update_secret=True)
+    _create_update_user(cluster_id, cluster.grafana_endpoint, cluster.grafana_secret, SecretStr(secret), update_secret=True)
 
     cluster.secret = SecretStr(secret)
     cluster.write_to_db(db_controller.kv_store)

--- a/simplyblock_core/controllers/backup_controller.py
+++ b/simplyblock_core/controllers/backup_controller.py
@@ -11,6 +11,7 @@ from simplyblock_core.controllers import backup_events, tasks_controller
 from simplyblock_core.db_controller import DBController
 from simplyblock_core.models.backup import Backup, BackupPolicy, BackupPolicyAttachment
 from simplyblock_core.models.storage_node import StorageNode
+from simplyblock_core.utils.secrets import unwrap_secret as _unwrap_secret
 
 logger = logging.getLogger()
 
@@ -176,9 +177,9 @@ def create_s3_bdev(node, backup_config):
     # Step 2: Ensure the S3 bucket exists, then register it with the S3 bdev
     bucket_name = backup_config.get("bucket_name", f"simplyblock-backup-{node.cluster_id}")
     try:
-        s3_kwargs = {
-            "aws_access_key_id": backup_config.get("access_key_id", ""),
-            "aws_secret_access_key": backup_config.get("secret_access_key", ""),
+        s3_kwargs: dict = {
+            "aws_access_key_id": _unwrap_secret(backup_config.get("access_key_id")) or "",
+            "aws_secret_access_key": _unwrap_secret(backup_config.get("secret_access_key")) or "",
         }
         endpoint_url = backup_config.get("local_endpoint", "")
         if endpoint_url:
@@ -725,9 +726,9 @@ def switch_backup_source(cluster_id, source_cluster_id):
 
     # Verify the bucket exists
     try:
-        s3_kwargs = {
-            "aws_access_key_id": backup_config.get("access_key_id", ""),
-            "aws_secret_access_key": backup_config.get("secret_access_key", ""),
+        s3_kwargs: dict = {
+            "aws_access_key_id": _unwrap_secret(backup_config.get("access_key_id")) or "",
+            "aws_secret_access_key": _unwrap_secret(backup_config.get("secret_access_key")) or "",
         }
         endpoint_url = backup_config.get("local_endpoint", "")
         if endpoint_url:

--- a/simplyblock_core/controllers/host_auth.py
+++ b/simplyblock_core/controllers/host_auth.py
@@ -36,8 +36,8 @@ def _register_pool_dhchap_keys_on_node(pool, snode, rpc_client):
     key_names = {}
 
     for key_type, key_value in (
-        ("dhchap_key", pool.dhchap_key),
-        ("dhchap_ctrlr_key", pool.dhchap_ctrlr_key),
+        ("dhchap_key", pool.dhchap_key.get_secret_value()),
+        ("dhchap_ctrlr_key", pool.dhchap_ctrlr_key.get_secret_value()),
     ):
         if not key_value:
             continue

--- a/simplyblock_core/controllers/lvol_controller.py
+++ b/simplyblock_core/controllers/lvol_controller.py
@@ -1771,8 +1771,8 @@ def connect_lvol(uuid, ctrl_loss_tmo=constants.LVOL_NVME_CONNECT_CTRL_LOSS_TMO, 
             if h["nqn"] == host_nqn:
                 host_entry = h
                 pool = db_controller.get_pool_by_id(lvol.pool_uuid)
-                host_entry["dhchap_key"] = pool.dhchap_key
-                host_entry["dhchap_ctrlr_key"] = pool.dhchap_ctrlr_key
+                host_entry["dhchap_key"] = pool.dhchap_key.get_secret_value()
+                host_entry["dhchap_ctrlr_key"] = pool.dhchap_ctrlr_key.get_secret_value()
                 break
         if not host_entry:
             return False, f"Host NQN {host_nqn} not found in allowed hosts for volume {uuid}"

--- a/simplyblock_core/controllers/pool_controller.py
+++ b/simplyblock_core/controllers/pool_controller.py
@@ -8,6 +8,8 @@ import string
 import time
 import uuid
 
+from pydantic import SecretStr
+
 from simplyblock_core import utils
 from simplyblock_core.controllers import pool_events, lvol_controller
 from simplyblock_core.db_controller import DBController
@@ -98,8 +100,8 @@ def add_pool(name, pool_max, lvol_max, max_rw_iops, max_rw_mbytes, max_r_mbytes,
 
     pool.dhchap = bool(dhchap)
     if pool.dhchap:
-        pool.dhchap_key = utils.generate_dhchap_key(length=32)
-        pool.dhchap_ctrlr_key = utils.generate_dhchap_key(length=32)
+        pool.dhchap_key = SecretStr(utils.generate_dhchap_key(length=32))
+        pool.dhchap_ctrlr_key = SecretStr(utils.generate_dhchap_key(length=32))
 
 
     try:

--- a/simplyblock_core/db_controller.py
+++ b/simplyblock_core/db_controller.py
@@ -51,8 +51,8 @@ class DBController(metaclass=Singleton):
             fdb.api_version(constants.KVD_DB_VERSION)
             self.kv_store = fdb.open(constants.KVD_DB_FILE_PATH)  # type: ignore[func-returns-value]
             self.kv_store.options.set_transaction_timeout(constants.KVD_DB_TIMEOUT_MS)
-        except Exception as e:
-            print(e)
+        except Exception:
+            logger.exception("FDB initialization failed")
 
     def get_storage_nodes(self) -> List[StorageNode]:
         ret = StorageNode().read_from_db(self.kv_store)
@@ -424,7 +424,7 @@ class DBController(metaclass=Singleton):
             lock.requested_snapshot_id = requested_snapshot_id
             lock.lvol_id = lvol_id
             lock.created_at = now
-            tr[key] = json.dumps(lock.to_dict()).encode()
+            tr[key] = json.dumps(lock.to_dict(unwrap_secrets=True)).encode()
 
         return True, None
 
@@ -578,7 +578,7 @@ class DBController(metaclass=Singleton):
         obj = model_cls().from_dict(json.loads(raw))
         if mutate_fn(obj) is False:
             return obj
-        tr[key] = json.dumps(obj.to_dict()).encode()
+        tr[key] = json.dumps(obj.to_dict(unwrap_secrets=True)).encode()
         return obj
 
     def atomic_update(self, obj, mutate_fn):
@@ -640,7 +640,7 @@ class DBController(metaclass=Singleton):
         if target:
             target.status = StorageNode.STATUS_RESTARTING
             prefix = target.get_db_id()
-            data = json.dumps(target.get_clean_dict())
+            data = json.dumps(target.get_clean_dict(unwrap_secrets=True))
             tr[prefix.encode()] = data.encode()
 
         return True, None

--- a/simplyblock_core/fw_api_client.py
+++ b/simplyblock_core/fw_api_client.py
@@ -6,6 +6,9 @@ import logging
 from requests.adapters import HTTPAdapter
 from urllib3 import Retry
 
+from simplyblock_core.settings import Settings
+from simplyblock_core.utils.secrets import unwrap_secrets_for_send
+
 
 logger = logging.getLogger()
 
@@ -31,21 +34,26 @@ class FirewallClient:
     def _request(self, method, path, payload=None):
         try:
             logger.debug("Requesting path: %s, params: %s", path, payload)
+            wire_payload = unwrap_secrets_for_send(payload) if payload else None
             data = None
             params = None
-            if payload:
-                if method == "GET" :
-                    params = payload
+            if wire_payload:
+                if method == "GET":
+                    params = wire_payload
                 else:
-                    data = json.dumps(payload)
+                    data = json.dumps(wire_payload)
 
             response = self.session.request(method, self.url+path, data=data,
                                             timeout=self.timeout, params=params)
         except Exception as e:
             raise FirewallClientException(str(e))
 
-        logger.debug("Response: status_code: %s, content: %s",
-                     response.status_code, response.content)
+        if Settings().log_response_bodies:
+            logger.debug("Response: status_code: %s, content: %s",
+                         response.status_code, response.content)
+        else:
+            logger.debug("Response: status_code: %s, content-length: %s",
+                         response.status_code, len(response.content))
         ret_code = response.status_code
 
         result = None
@@ -67,7 +75,7 @@ class FirewallClient:
             raise FirewallClientException("Invalid http status: %s" % ret_code)
 
         if ret_code == 422:
-            raise FirewallClientException(f"Request validation failed: '{response.text}'")
+            raise FirewallClientException("Request validation failed (status 422)")
 
         logger.error("Unknown http status: %s", ret_code)
         return None, None

--- a/simplyblock_core/mgmt_node_ops.py
+++ b/simplyblock_core/mgmt_node_ops.py
@@ -9,6 +9,7 @@ import requests
 
 import docker
 from kubernetes import client as k8s_client
+from pydantic import SecretStr
 
 
 from simplyblock_core import utils, scripts, constants
@@ -20,10 +21,10 @@ logger = logging.getLogger()
 
 
 
-def deploy_mgmt_node(cluster_ip, cluster_id, ifname, mgmt_ip, cluster_secret, mode):
+def deploy_mgmt_node(cluster_ip, cluster_id, ifname, mgmt_ip, cluster_secret: SecretStr, mode):
 
     try:
-        headers = {'Authorization': f'{cluster_id} {cluster_secret}'}
+        headers = {'Authorization': f'{cluster_id} {cluster_secret.get_secret_value()}'}
         resp = requests.get(f"http://{cluster_ip}/api/v1/cluster/{cluster_id}", headers=headers)
         resp_json = resp.json()
         cluster_data = resp_json['results'][0]

--- a/simplyblock_core/models/base_model.py
+++ b/simplyblock_core/models/base_model.py
@@ -7,6 +7,8 @@ import sys
 from typing import Mapping, Type, Union
 from collections import ChainMap
 
+from pydantic import SecretBytes, SecretStr
+
 
 class BaseModel(object):
 
@@ -75,6 +77,16 @@ class BaseModel(object):
                         if type(value) is list and dtype is int:
                             value = len(value)
 
+                elif dtype is SecretStr:
+                    value = value if isinstance(value, SecretStr) else SecretStr(value or "")
+                elif dtype is SecretBytes:
+                    if isinstance(value, SecretBytes):
+                        pass
+                    elif isinstance(value, (bytes, bytearray)):
+                        value = SecretBytes(bytes(value))
+                    else:
+                        value = SecretBytes((value or "").encode())
+
                 elif hasattr(dtype, '__origin__'):
                     if dtype.__origin__ is list:
                         if hasattr(dtype, "__args__") and hasattr(dtype.__args__[0], "from_dict"):
@@ -94,6 +106,16 @@ class BaseModel(object):
                             inner = inner_types[0] if inner_types else None
                             if inner is not None and hasattr(inner, "from_dict"):
                                 value = inner().from_dict(data[attr])
+                            elif inner is SecretStr:
+                                value = data[attr] if isinstance(data[attr], SecretStr) else SecretStr(data[attr] or "")
+                            elif inner is SecretBytes:
+                                raw = data[attr]
+                                if isinstance(raw, SecretBytes):
+                                    value = raw
+                                elif isinstance(raw, (bytes, bytearray)):
+                                    value = SecretBytes(bytes(raw))
+                                else:
+                                    value = SecretBytes((raw or "").encode())
                             elif inner is not None:
                                 value = inner(data[attr])
                 else:
@@ -102,27 +124,48 @@ class BaseModel(object):
         self.id = self.uuid
         return self
 
-    def to_dict(self):
+    def to_dict(self, unwrap_secrets: bool = False):
+        """Serialize to a plain dict.
+
+        With ``unwrap_secrets=False`` (default), ``SecretStr``/``SecretBytes``
+        instances stay wrapped — safe for logging, ``repr``, and ``pprint``. With
+        ``unwrap_secrets=True``, wrappers are replaced by their plaintext value,
+        producing a JSON-serializable structure for FoundationDB persistence.
+
+        ``unwrap_secrets`` propagates into nested ``BaseModel`` children so a
+        single ``write_to_db`` call unwraps end-to-end.
+        """
+        def _maybe_to_dict(value):
+            if isinstance(value, BaseModel):
+                return value.to_dict(unwrap_secrets=unwrap_secrets)
+            if isinstance(value, (SecretStr, SecretBytes)):
+                return value.get_secret_value() if unwrap_secrets else value
+            if isinstance(value, dict):
+                return {k: _maybe_to_dict(v) for k, v in value.items()}
+            if hasattr(value, "to_dict"):
+                return value.to_dict()
+            return value
+
         result: dict = {}
         for attr in self.get_attrs_map():
             value = getattr(self, attr)
             if isinstance(value, list):
-                result[attr] = list(map(lambda x: x.to_dict() if hasattr(x, "to_dict") else x, value))
+                result[attr] = [_maybe_to_dict(x) for x in value]
+            elif isinstance(value, BaseModel):
+                result[attr] = value.to_dict(unwrap_secrets=unwrap_secrets)
             elif hasattr(value, "to_dict"):
                 result[attr] = value.to_dict()
             elif isinstance(value, dict):
-                result[attr] = dict(map(
-                    lambda item: (item[0], item[1].to_dict())
-                    if hasattr(item[1], "to_dict") else item,
-                    value.items()
-                ))
+                result[attr] = {k: _maybe_to_dict(v) for k, v in value.items()}
+            elif isinstance(value, (SecretStr, SecretBytes)):
+                result[attr] = value.get_secret_value() if unwrap_secrets else value
             else:
                 result[attr] = value
 
         return result
 
-    def get_clean_dict(self):
-        data = self.to_dict()
+    def get_clean_dict(self, unwrap_secrets: bool = False):
+        data = self.to_dict(unwrap_secrets=unwrap_secrets)
         for key in ['name', 'object_type']:
             del data[key]
         data['status_code'] = self.get_status_code()
@@ -160,11 +203,12 @@ class BaseModel(object):
             kv_store = DBController().kv_store
         try:
             prefix = self.get_db_id()
-            st = json.dumps(self.to_dict())
+            st = json.dumps(self.to_dict(unwrap_secrets=True))
             kv_store.set(prefix.encode(), st.encode())
             return True
-        except Exception as e:
-            print(f"Error Writing to FDB! {e}")
+        except Exception:
+            from simplyblock_core import utils
+            utils.get_logger(__name__).exception("Error writing to FDB")
             exit(1)
 
     def remove(self, kv_store):

--- a/simplyblock_core/models/cluster.py
+++ b/simplyblock_core/models/cluster.py
@@ -46,7 +46,7 @@ class Cluster(BaseModel):
     cluster_max_devices: int = 0
     cluster_max_nodes: int = 0
     cluster_max_size: int = 0
-    db_connection: str = ""
+    db_connection: SecretStr = SecretStr("")
     dhchap: str = ""
     distr_bs: int = 0
     distr_chunk_bs: int = 0

--- a/simplyblock_core/models/cluster.py
+++ b/simplyblock_core/models/cluster.py
@@ -2,6 +2,8 @@
 
 from typing import List, Optional
 
+from pydantic import SecretStr
+
 from simplyblock_core.models.base_model import BaseModel
 
 
@@ -40,7 +42,7 @@ class Cluster(BaseModel):
     blk_size: int = 0
     cap_crit: int = 90
     cap_warn: int = 80
-    cli_pass: str = ""
+    cli_pass: SecretStr = SecretStr("")
     cluster_max_devices: int = 0
     cluster_max_nodes: int = 0
     cluster_max_size: int = 0
@@ -53,7 +55,7 @@ class Cluster(BaseModel):
     enable_node_affinity: bool = False
     grafana_endpoint: str = ""
     mode: str = "docker"
-    grafana_secret: str = ""
+    grafana_secret: SecretStr = SecretStr("")
     contact_point: str = ""
     ha_type: str = "single"
     inflight_io_threshold: int = 4
@@ -69,7 +71,7 @@ class Cluster(BaseModel):
     fabric_tcp: bool = True
     fabric_rdma: bool = False
     client_qpair_count: int = 3
-    secret: str = ""
+    secret: SecretStr = SecretStr("")
     cr_name: str = ""
     cr_namespace: str = ""
     cr_plural: str = ""
@@ -123,11 +125,6 @@ class Cluster(BaseModel):
             return self.STATUS_CODE_MAP[self.status]
         else:
             return -1
-
-    def get_clean_dict(self):
-        data = super(Cluster, self).get_clean_dict()
-        data['status_code'] = self.get_status_code()
-        return data
 
     def is_qos_set(self) -> bool:
         # Import is here is to avoid circular import dependency

--- a/simplyblock_core/models/pool.py
+++ b/simplyblock_core/models/pool.py
@@ -2,6 +2,8 @@
 
 from typing import List
 
+from pydantic import SecretStr
+
 from simplyblock_core.models.base_model import BaseModel
 
 
@@ -26,7 +28,7 @@ class Pool(BaseModel):
     pool_max_size: int = 0
     pool_name: str = ""
     numeric_id: int = 0
-    secret: str = ""  # unused
+    secret: SecretStr = SecretStr("")  # unused
     users: List[str] = []
     qos_host: str = ""
     cr_name: str = ""
@@ -37,8 +39,8 @@ class Pool(BaseModel):
     lvols_cr_plural: str = ""
     sec_options: dict = {}
     dhchap: bool = False
-    dhchap_key: str = ""
-    dhchap_ctrlr_key: str = ""
+    dhchap_key: SecretStr = SecretStr("")
+    dhchap_ctrlr_key: SecretStr = SecretStr("")
     allowed_hosts: List[str] = []
 
 

--- a/simplyblock_core/models/storage_node.py
+++ b/simplyblock_core/models/storage_node.py
@@ -186,7 +186,7 @@ class StorageNode(BaseNodeObject):
             host = f"{self._k8s_node_label()}.simplyblock-spdk-proxy.{self.cr_namespace}.svc.cluster.local"
         return RPCClient(
             host, self.rpc_port,
-            self.rpc_username, self.rpc_password.get_secret_value(), **kwargs)
+            self.rpc_username, self.rpc_password, **kwargs)
 
     def _k8s_node_label(self) -> str:
         return self.hostname.removesuffix(f"_{self.rpc_port}")

--- a/simplyblock_core/models/storage_node.py
+++ b/simplyblock_core/models/storage_node.py
@@ -4,6 +4,8 @@ from datetime import datetime, timedelta, timezone
 from typing import List, Optional
 from uuid import uuid4
 
+from pydantic import SecretStr
+
 from simplyblock_core import utils, constants
 from simplyblock_core.models.base_model import BaseNodeObject, BaseModel
 from simplyblock_core.models.hublvol import HubLVol
@@ -46,7 +48,7 @@ class StorageNode(BaseNodeObject):
     cluster_id: str = ""
     cpu: int = 0
     cpu_hz: int = 0
-    ctrl_secret: str = ""
+    ctrl_secret: SecretStr = SecretStr("")
     data_nics: List[IFace] = []
     distrib_cpu_cores: List[int] = []
     distrib_cpu_index: int = 0
@@ -58,7 +60,7 @@ class StorageNode(BaseNodeObject):
     # health is only measured/shown for ONLINE or DOWN nodes.
     health_check: Optional[bool] = True
     host_nqn: str = ""
-    host_secret: str = ""
+    host_secret: SecretStr = SecretStr("")
     hostname: str = ""
     hugepages: int = 0
     ib_devices: List[IFace] = []
@@ -112,7 +114,7 @@ class StorageNode(BaseNodeObject):
     raid: str = ""
     remote_devices: List[RemoteDevice] = []
     remote_jm_devices: List[RemoteJMDevice] = []
-    rpc_password: str = ""
+    rpc_password: SecretStr = SecretStr("")
     rpc_port: int = -1
     rpc_username: str = ""
     secondary_node_id: str = ""
@@ -184,7 +186,7 @@ class StorageNode(BaseNodeObject):
             host = f"{self._k8s_node_label()}.simplyblock-spdk-proxy.{self.cr_namespace}.svc.cluster.local"
         return RPCClient(
             host, self.rpc_port,
-            self.rpc_username, self.rpc_password, **kwargs)
+            self.rpc_username, self.rpc_password.get_secret_value(), **kwargs)
 
     def _k8s_node_label(self) -> str:
         return self.hostname.removesuffix(f"_{self.rpc_port}")

--- a/simplyblock_core/rpc_client.py
+++ b/simplyblock_core/rpc_client.py
@@ -5,12 +5,14 @@ from json import JSONDecodeError
 from typing import Any, Optional
 
 import requests
+from pydantic import SecretStr
 from requests.exceptions import ConnectionError, HTTPError, Timeout, TooManyRedirects
 import jsonschema
 from jsonschema.exceptions import ValidationError
 
 from simplyblock_core import utils, constants
 from simplyblock_core.settings import Settings
+from simplyblock_core.utils.secrets import unwrap_secrets_for_send
 from requests.adapters import HTTPAdapter
 from urllib3 import Retry
 
@@ -105,7 +107,7 @@ class RPCClient:
     DEFAULT_ALLOWED_METHODS = ["HEAD", "GET", "PUT", "DELETE", "OPTIONS", "TRACE"]
     RPC_NO_PRINT_OUTPUT = ["bdev_get_bdevs", "nvmf_get_subsystems", "bdev_get_iostat"]
 
-    def __init__(self, host, port, username, password, timeout=180, retry=3):
+    def __init__(self, host, port, username, password: SecretStr, timeout=180, retry=3):
         self.host = host
         self.port = port
         settings = Settings()
@@ -117,7 +119,7 @@ class RPCClient:
         self.session = requests.session()
         if settings.tls_connect != "disabled":
             self.session.verify = str(settings.tls_certificate_authority)
-        self.session.auth = (self.username, self.password)
+        self.session.auth = (self.username, self.password.get_secret_value())
         retries = Retry(total=retry, backoff_factor=1, connect=retry, read=retry,
                         allowed_methods=self.DEFAULT_ALLOWED_METHODS)
         self.session.mount("http://", HTTPAdapter(max_retries=retries))
@@ -146,7 +148,7 @@ class RPCClient:
         return ret
 
     def _request2(self, method, params=None, request_timeout=None):
-        payload = {'id': 1, 'method': method}
+        payload: dict = {'id': 1, 'method': method}
         if params:
             payload['params'] = params
         # Per-call override of the client-level HTTP timeout. Used by callers
@@ -156,7 +158,8 @@ class RPCClient:
         effective_timeout = request_timeout if request_timeout is not None else self.timeout
         try:
             logger.debug("From: %s, Requesting method: %s, params: %s", self.host, method, params)
-            response = self.session.post(self.url, data=json.dumps(payload), timeout=effective_timeout)
+            wire_payload = unwrap_secrets_for_send(payload)
+            response = self.session.post(self.url, data=json.dumps(wire_payload), timeout=effective_timeout)
         except Exception:
             raise RPCException("connection error")
 
@@ -169,10 +172,11 @@ class RPCClient:
         if ret_code == 200:
             try:
                 data = response.json()
-                if method not in self.RPC_NO_PRINT_OUTPUT:
+                if method not in self.RPC_NO_PRINT_OUTPUT and Settings().log_response_bodies:
                     logger.debug("Response json: %s", json.dumps(data))
             except Exception:
-                logger.debug("Response ret_content: %s", ret_content)
+                if Settings().log_response_bodies:
+                    logger.debug("Response ret_content: %s", ret_content)
                 return ret_content, None
 
             if 'result' in data:
@@ -192,11 +196,12 @@ class RPCClient:
     def _request3(self, method: str, **kwargs):
         logger.debug("Requesting method: %s, params: %s", method, kwargs)
         try:
-            response = self.session.post(self.url, data=json.dumps({
+            wire_payload = unwrap_secrets_for_send({
                 'id': 1,
                 'method': method,
                 'params': kwargs,
-            }), timeout=self.timeout)
+            })
+            response = self.session.post(self.url, data=json.dumps(wire_payload), timeout=self.timeout)
             response.raise_for_status()
             data = response.json()
             _response_validator.validate(data)

--- a/simplyblock_core/settings.py
+++ b/simplyblock_core/settings.py
@@ -53,6 +53,17 @@ class Settings(BaseSettings):
     tls_key: Path = Path("/etc/simplyblock/tls/tls.key")
     tls_certificate_authority: Path = Path("/etc/simplyblock/tls/ca.crt")
 
+    log_response_bodies: Annotated[
+        bool,
+        Field(
+            description=(
+                "Log full HTTP response bodies at DEBUG. Default off — response "
+                "bodies can carry plaintext secrets (e.g. cluster.secret in a GET) "
+                "and the response stream has no type information to mask by."
+            )
+        ),
+    ] = False
+
     @model_validator(mode="after")
     def validate_tls_files(self):
         if not self.tls_serve and self.tls_connect == "disabled":

--- a/simplyblock_core/snode_client.py
+++ b/simplyblock_core/snode_client.py
@@ -3,10 +3,12 @@ import json
 import requests
 import logging
 
+from pydantic import SecretStr
 from requests.adapters import HTTPAdapter
 from urllib3 import Retry
 
 from simplyblock_core.settings import Settings
+from simplyblock_core.utils.secrets import unwrap_secrets_for_send
 
 logger = logging.getLogger()
 
@@ -42,21 +44,27 @@ class SNodeClient:
     def _request(self, method, path, payload=None):
         try:
             logger.debug("Requesting path: %s, params: %s", path, payload)
+            wire_payload = unwrap_secrets_for_send(payload) if payload else None
             data = None
             params = None
-            if payload:
-                if method == "GET" :
-                    params = payload
+            if wire_payload:
+                if method == "GET":
+                    params = wire_payload
                 else:
-                    data = json.dumps(payload)
+                    data = json.dumps(wire_payload)
 
             response = self.session.request(method, self.url+path, data=data,
                                             timeout=self.timeout, params=params)
         except Exception as e:
             raise SNodeClientException(str(e))
 
-        logger.debug("Response: status_code: %s, content: %s",
-                     response.status_code, response.content)
+        log_body = Settings().log_response_bodies
+        if log_body:
+            logger.debug("Response: status_code: %s, content: %s",
+                         response.status_code, response.content)
+        else:
+            logger.debug("Response: status_code: %s, content-length: %s",
+                         response.status_code, len(response.content))
         ret_code = response.status_code
 
         result = None
@@ -79,7 +87,7 @@ class SNodeClient:
             raise SNodeClientException("Invalid http status: %s" % ret_code)
 
         if ret_code == 422:
-            raise SNodeClientException(f"Request validation failed: '{response.text}'")
+            raise SNodeClientException("Request validation failed (status 422)")
 
         raise SNodeClientException(f"Unknown http status: {ret_code}")
 
@@ -109,7 +117,7 @@ class SNodeClient:
 
     def spdk_process_start(self, l_cores, spdk_mem, spdk_image=None, spdk_debug=None, cluster_ip=None,
                            fdb_connection=None, namespace=None, server_ip=None, rpc_port=None,
-                           rpc_username=None, rpc_password=None, multi_threading_enabled=False, timeout=0, ssd_pcie=None,
+                           rpc_username=None, rpc_password: SecretStr | None = None, multi_threading_enabled=False, timeout=0, ssd_pcie=None,
                            total_mem=None, system_mem=None, cluster_mode=None, socket=0, firewall_port=0, cluster_id=None,
                            spdk_proxy_image=None):
         params = {

--- a/simplyblock_core/snode_client.py
+++ b/simplyblock_core/snode_client.py
@@ -116,7 +116,7 @@ class SNodeClient:
         return self._request("POST", "recalculate_cores_distribution", params)
 
     def spdk_process_start(self, l_cores, spdk_mem, spdk_image=None, spdk_debug=None, cluster_ip=None,
-                           fdb_connection=None, namespace=None, server_ip=None, rpc_port=None,
+                           fdb_connection: SecretStr | None = None, namespace=None, server_ip=None, rpc_port=None,
                            rpc_username=None, rpc_password: SecretStr | None = None, multi_threading_enabled=False, timeout=0, ssd_pcie=None,
                            total_mem=None, system_mem=None, cluster_mode=None, socket=0, firewall_port=0, cluster_id=None,
                            spdk_proxy_image=None):

--- a/simplyblock_core/storage_node_ops.py
+++ b/simplyblock_core/storage_node_ops.py
@@ -16,6 +16,7 @@ import uuid
 
 import docker
 from docker.types import LogConfig
+from pydantic import SecretStr
 
 from simplyblock_core import constants, scripts, distr_controller, cluster_ops
 from simplyblock_core import port_block, utils
@@ -1912,11 +1913,11 @@ def add_node(cluster_id, node_addr, iface_name, data_nics_list,
         snode.primary_ip = mgmt_ip
         snode.rpc_port = rpc_port
         snode.rpc_username = rpc_user
-        snode.rpc_password = rpc_pass
+        snode.rpc_password = SecretStr(rpc_pass)
         snode.cluster_id = cluster_id
         snode.api_endpoint = node_addr
-        snode.host_secret = utils.generate_string(20)
-        snode.ctrl_secret = utils.generate_string(20)
+        snode.host_secret = SecretStr(utils.generate_string(20))
+        snode.ctrl_secret = SecretStr(utils.generate_string(20))
         snode.number_of_distribs = number_of_distribs
         snode.number_of_alceml_devices = number_of_alceml_devices
         snode.enable_ha_jm = enable_ha_jm
@@ -2764,7 +2765,7 @@ def _restart_storage_node_impl(
         snode_api.set_hugepages()
         results, err = snode_api.spdk_process_start(
             snode.l_cores, snode.spdk_mem, snode.spdk_image, spdk_debug, cluster_ip, fdb_connection,
-            snode.namespace, snode.mgmt_ip, snode.rpc_port, snode.rpc_username, snode.rpc_password,
+            snode.namespace, snode.mgmt_ip, snode.rpc_port, snode.rpc_username, snode.rpc_password.get_secret_value(),
             multi_threading_enabled=constants.SPDK_PROXY_MULTI_THREADING_ENABLED, timeout=constants.SPDK_PROXY_TIMEOUT,
             ssd_pcie=snode.ssd_pcie, total_mem=total_mem, system_mem=minimum_sys_memory, cluster_mode=cluster.mode,
             socket=snode.socket, cluster_id=snode.cluster_id,
@@ -4258,7 +4259,7 @@ def get_host_secret(node_id):
         logger.error("node not found")
         return False
 
-    return node.host_secret
+    return node.host_secret.get_secret_value()
 
 
 def get_ctrl_secret(node_id):
@@ -4269,7 +4270,7 @@ def get_ctrl_secret(node_id):
         logger.error("node not found")
         return False
 
-    return node.ctrl_secret
+    return node.ctrl_secret.get_secret_value()
 
 
 def health_check(node_id):

--- a/simplyblock_core/storage_node_ops.py
+++ b/simplyblock_core/storage_node_ops.py
@@ -2765,7 +2765,7 @@ def _restart_storage_node_impl(
         snode_api.set_hugepages()
         results, err = snode_api.spdk_process_start(
             snode.l_cores, snode.spdk_mem, snode.spdk_image, spdk_debug, cluster_ip, fdb_connection,
-            snode.namespace, snode.mgmt_ip, snode.rpc_port, snode.rpc_username, snode.rpc_password.get_secret_value(),
+            snode.namespace, snode.mgmt_ip, snode.rpc_port, snode.rpc_username, snode.rpc_password,
             multi_threading_enabled=constants.SPDK_PROXY_MULTI_THREADING_ENABLED, timeout=constants.SPDK_PROXY_TIMEOUT,
             ssd_pcie=snode.ssd_pcie, total_mem=total_mem, system_mem=minimum_sys_memory, cluster_mode=cluster.mode,
             socket=snode.socket, cluster_id=snode.cluster_id,

--- a/simplyblock_core/storage_node_ops.py
+++ b/simplyblock_core/storage_node_ops.py
@@ -1913,7 +1913,7 @@ def add_node(cluster_id, node_addr, iface_name, data_nics_list,
         snode.primary_ip = mgmt_ip
         snode.rpc_port = rpc_port
         snode.rpc_username = rpc_user
-        snode.rpc_password = SecretStr(rpc_pass)
+        snode.rpc_password = rpc_pass
         snode.cluster_id = cluster_id
         snode.api_endpoint = node_addr
         snode.host_secret = SecretStr(utils.generate_string(20))

--- a/simplyblock_core/utils/__init__.py
+++ b/simplyblock_core/utils/__init__.py
@@ -14,6 +14,8 @@ import uuid
 import time
 from datetime import datetime, timezone
 from typing import Union, Any, Optional, Tuple, List, Dict, Iterable
+
+from pydantic import SecretStr
 from docker import DockerClient
 from kubernetes import client, config
 from kubernetes.client import ApiException, V1Deployment, V1DeploymentSpec, V1ObjectMeta, \
@@ -287,12 +289,12 @@ def print_table_dict(node_stats):
     print(print_table(d))
 
 
-def generate_rpc_user_and_pass():
+def generate_rpc_user_and_pass() -> Tuple[str, SecretStr]:
     def _generate_string(length):
         return ''.join(random.SystemRandom().choice(
             string.ascii_letters + string.digits) for _ in range(length))
 
-    return _generate_string(8), _generate_string(16)
+    return _generate_string(8), SecretStr(_generate_string(16))
 
 
 def parse_history_param(history_string):
@@ -2741,7 +2743,7 @@ def get_mgmt_ip(node_info: Any, iface_names: Union[str, list[str]]) -> Optional[
     return None
 
 
-def get_fdb_cluster_string(configmap_name: str, namespace: str) -> str:
+def get_fdb_cluster_string(configmap_name: str, namespace: str) -> SecretStr:
     load_kube_config_with_fallback()
     v1 = client.CoreV1Api()
 
@@ -2749,8 +2751,8 @@ def get_fdb_cluster_string(configmap_name: str, namespace: str) -> str:
         cm = v1.read_namespaced_config_map(configmap_name, namespace)
         cluster_file = cm.data.get("cluster-file") if cm.data else None
         if cluster_file:
-            logger.info(f"fdb cluster connection string: {cluster_file}")
-            return cluster_file
+            logger.info("fdb cluster connection string retrieved")
+            return SecretStr(cluster_file)
         else:
             raise ValueError("cluster-file not found in ConfigMap")
     except client.exceptions.ApiException as e:

--- a/simplyblock_core/utils/__init__.py
+++ b/simplyblock_core/utils/__init__.py
@@ -680,7 +680,11 @@ def decimal_to_hex_power_of_2(decimal_number):
 
 def get_logger(name=""):
     # first configure a root logger
-    logging.getLogger("urllib3.connectionpool").setLevel(logging.WARNING)
+    # Silence external libraries that log secrets (tokens, full HTTP response
+    # bodies) at DEBUG level.  Keep them at WARNING so our own DEBUG logging
+    # is unaffected.
+    for _ext in ("urllib3", "kubernetes.client.rest"):
+        logging.getLogger(_ext).setLevel(logging.WARNING)
     logg = logging.getLogger()
 
     log_level = os.getenv("SIMPLYBLOCK_LOG_LEVEL")

--- a/simplyblock_core/utils/secrets.py
+++ b/simplyblock_core/utils/secrets.py
@@ -1,0 +1,39 @@
+from typing import Any, Optional, Union
+
+from pydantic import SecretBytes, SecretStr
+
+
+def unwrap_secrets_for_send(obj: Any) -> Any:
+    """Return a copy of ``obj`` with every ``SecretStr``/``SecretBytes`` replaced
+    by its plaintext value.
+
+    Used at the wire-send site of clients (just before ``requests.post(json=...)``)
+    so the dict carrying the wrapper can be logged safely one line earlier — the
+    wrapper's repr masks the value, while this function produces a plain
+    JSON-serializable structure for the HTTP body.
+    """
+    match obj:
+        case SecretStr() | SecretBytes():
+            return obj.get_secret_value()
+        case dict():
+            return {k: unwrap_secrets_for_send(v) for k, v in obj.items()}
+        case list():
+            return [unwrap_secrets_for_send(v) for v in obj]
+        case tuple():
+            return tuple(unwrap_secrets_for_send(v) for v in obj)
+        case _:
+            return obj
+
+
+def unwrap_secret(value: Union[SecretStr, str, None]) -> Optional[str]:
+    """Tolerant scalar unwrap for transitional call sites that still expect ``str``.
+
+    Removed once the surrounding code is type-correct on ``SecretStr``.
+    """
+    match value:
+        case None:
+            return None
+        case SecretStr():
+            return value.get_secret_value()
+        case _:
+            return value

--- a/simplyblock_web/AGENTS.md
+++ b/simplyblock_web/AGENTS.md
@@ -14,11 +14,13 @@ REST API server for the Simplyblock control plane. Runs as a single uvicorn proc
 
 Use these patterns when adding new v2 endpoints:
 
-**DTOs** (`_dtos.py`): Pydantic `BaseModel` subclasses. Each DTO has a `from_model(model, ...)` static method that converts a core model into the DTO. Never expose core models directly in API responses.
+**DTOs** (`_dtos.py`): Pydantic `BaseModel` subclasses. Each DTO has a `from_model(model, ...)` static method that converts a core model into the DTO. Never expose core models directly in API responses. DTO fields that carry secrets use `SecretStr` with a `@field_serializer('field', when_used='json')` that calls `value.get_secret_value()` — this keeps wrappers in Python-mode `model_dump()` (safe for logging) while unwrapping to plaintext in `model_dump_json()` (for wire responses).
 
 **Dependencies** (`_dependencies.py`): FastAPI `Depends()`-based resource lookup. Typed aliases like `Cluster`, `StorageNode`, `Volume`, `Snapshot` resolve path parameters to core model objects (raising 404 on miss). Dependencies chain — e.g., `Volume` depends on `StoragePool` which depends on `Cluster` — enforcing hierarchical ownership.
 
-**Auth** (`_auth.py`): `verify_api_token` dependency on all routers. Supports k8s service account tokens (via TokenReview) and cluster-secret bearer tokens. Admin service accounts bypass per-cluster checks.
+**Auth** (`_auth.py`): `verify_api_token` dependency on all routers. Supports k8s service account tokens (via TokenReview) and cluster-secret bearer tokens. Admin service accounts bypass per-cluster checks. Secret comparison uses `hmac.compare_digest(secret.get_secret_value(), token)` for timing safety.
+
+**Access logging** (`app.py`): The `AccessLogMiddleware` logs only `request.url.path`, never the query string — query parameters can carry credentials (`?secret=…`, `?token=…`) and have no type info to mask by.
 
 **Route naming**: Routes use `name="resource:action"` format (e.g., `"clusters:pools:volumes:detail"`) for `request.url_for()` cross-references in DTOs.
 

--- a/simplyblock_web/api/v1/lvol.py
+++ b/simplyblock_web/api/v1/lvol.py
@@ -109,7 +109,6 @@ def add_lvol():
     """""
 
     cl_data = request.get_json()
-    logger.debug(cl_data)
     if 'size' not in cl_data:
         return utils.get_response(None, "missing required param: size", 400)
     if 'name' not in cl_data:

--- a/simplyblock_web/api/v2/_auth.py
+++ b/simplyblock_web/api/v2/_auth.py
@@ -121,7 +121,7 @@ def authorized_cluster(
     matched_id = next((
         cluster.id
         for cluster in _db.get_clusters()
-        if hmac.compare_digest(cluster.secret, token)
+        if hmac.compare_digest(cluster.secret.get_secret_value(), token)
     ), None)
 
     if matched_id is None:

--- a/simplyblock_web/api/v2/_dtos.py
+++ b/simplyblock_web/api/v2/_dtos.py
@@ -134,7 +134,7 @@ class ClusterDTO(BaseModel):
             provisioned_capacity_critical=model.prov_cap_crit,
             node_affinity=model.enable_node_affinity,
             anti_affinity=model.strict_node_anti_affinity,
-            secret=model.secret,
+            secret=model.secret.get_secret_value(),
             tls_enabled=model.tls,
             max_fault_tolerance=model.max_fault_tolerance,
             backup_enabled=bool(model.backup_config),

--- a/simplyblock_web/api/v2/_dtos.py
+++ b/simplyblock_web/api/v2/_dtos.py
@@ -4,7 +4,7 @@ from typing import List, Literal, Tuple, Optional, cast
 from uuid import UUID
 
 from fastapi import Request
-from pydantic import BaseModel
+from pydantic import BaseModel, SecretStr, field_serializer
 
 from simplyblock_core.controllers import migration_controller
 from simplyblock_core.db_controller import DBController
@@ -110,11 +110,15 @@ class ClusterDTO(BaseModel):
     provisioned_capacity_warning: util.Unsigned
     node_affinity: bool
     anti_affinity: bool
-    secret: str
+    secret: SecretStr
     tls_enabled: bool
     max_fault_tolerance: int
     backup_enabled: bool
     capacity: CapacityStatDTO
+
+    @field_serializer('secret', when_used='json')
+    def _unwrap_secret_for_json(self, value: SecretStr) -> str:
+        return value.get_secret_value()
 
     @staticmethod
     def from_model(model: Cluster, stat_obj: Optional[StatsObject] = None):
@@ -134,7 +138,7 @@ class ClusterDTO(BaseModel):
             provisioned_capacity_critical=model.prov_cap_crit,
             node_affinity=model.enable_node_affinity,
             anti_affinity=model.strict_node_anti_affinity,
-            secret=model.secret.get_secret_value(),
+            secret=model.secret,
             tls_enabled=model.tls,
             max_fault_tolerance=model.max_fault_tolerance,
             backup_enabled=bool(model.backup_config),

--- a/simplyblock_web/api/v2/cluster/__init__.py
+++ b/simplyblock_web/api/v2/cluster/__init__.py
@@ -3,7 +3,7 @@ from typing import Annotated, List, Literal, Optional
 from uuid import UUID
 
 from fastapi import APIRouter, HTTPException, Request, Response
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, SecretStr
 from pydantic.networks import AnyUrl, UrlConstraints
 
 from simplyblock_core.db_controller import DBController
@@ -35,8 +35,8 @@ class _UpdateParams(BaseModel):
 
 
 class BackupConfigParams(BaseModel):
-    access_key_id: Optional[str] = None
-    secret_access_key: Optional[str] = None
+    access_key_id: Optional[SecretStr] = None
+    secret_access_key: Optional[SecretStr] = None
     local_endpoint: Optional[str] = None
     bucket_name: Optional[str] = None
     snapshot_backups: Optional[bool] = None
@@ -77,7 +77,7 @@ class ClusterParams(BaseModel):
     cr_namespace: str = ""
     cr_plural: str = ""
     cluster_ip: str = ""
-    grafana_secret: str = ""
+    grafana_secret: SecretStr = SecretStr("")
     client_data_nic: str = ""
     max_fault_tolerance: int = 1
     nvmf_base_port: int = 4420

--- a/simplyblock_web/api/v2/cluster/storage_pool/volume/__init__.py
+++ b/simplyblock_web/api/v2/cluster/storage_pool/volume/__init__.py
@@ -195,6 +195,9 @@ def add_host(cluster: Cluster, pool: StoragePool, volume: Volume, body: _AddHost
 
 @instance_api.get('/hosts/{host_nqn}/secret', name='clusters:storage-pools:volumes:get-host-secret')
 def get_host_secret(cluster: Cluster, pool: StoragePool, volume: Volume, host_nqn: str):
+    # Sanctioned secret-egress endpoint: returns the DH-HMAC-CHAP key for the
+    # host so the client can configure NVMe-oF auth. The returned dict carries
+    # already-unwrapped plain-text key material — that is the contract.
     result, error = lvol_controller.get_host_secret(volume.get_id(), host_nqn)
     if error:
         raise HTTPException(404, error)

--- a/simplyblock_web/app.py
+++ b/simplyblock_web/app.py
@@ -24,6 +24,14 @@ logger = core_utils.get_logger(__name__)
 logger.setLevel(constants.LOG_WEB_LEVEL)
 logging.getLogger().setLevel(constants.LOG_WEB_LEVEL)
 
+# Prevent external libraries from logging secrets (tokens, response bodies)
+# at DEBUG level while keeping our own loggers at DEBUG.
+for _ext_logger_name in (
+    "kubernetes.client.rest",
+    "urllib3",
+):
+    logging.getLogger(_ext_logger_name).setLevel(logging.WARNING)
+
 access_logger = logging.getLogger('simplyblock_web.access')
 _access_handler = logging.StreamHandler(stream=sys.stdout)
 _access_handler.setFormatter(logging.Formatter(

--- a/simplyblock_web/app.py
+++ b/simplyblock_web/app.py
@@ -42,9 +42,9 @@ class AccessLogMiddleware(BaseHTTPMiddleware):
         client_ip = request.client.host if request.client else '-'
         request_size = request.headers.get('content-length', '-')
 
+        # Query strings can carry credentials (?secret=…, ?token=…) and have
+        # no type info to mask by, so log the path only.
         path = request.url.path
-        if request.url.query:
-            path = f'{path}?{request.url.query}'
 
         start = time.monotonic()
         response = await call_next(request)

--- a/simplyblock_web/auth_middleware.py
+++ b/simplyblock_web/auth_middleware.py
@@ -56,9 +56,10 @@ def token_required(f: F) -> Callable[..., ResponseType]:
                         decoded_auth = base64.b64decode(cluster_secret).decode('utf-8')
                         if ":" in decoded_auth:
                             cluster_id, cluster_secret = decoded_auth.split(":", 1)
-                    except Exception as e:
-                        # Log the error but continue with empty credentials
-                        logging.warning(f"Failed to decode Basic Auth: {e}")
+                    except Exception:
+                        # The exception message itself can carry the b64
+                        # payload — log only the traceback.
+                        logging.exception("Failed to decode Basic Auth")
 
         # Authentication headers
         headers: Dict[str, str] = {"WWW-Authenticate": 'Basic realm="Login Required"'}
@@ -108,13 +109,15 @@ def token_required(f: F) -> Callable[..., ResponseType]:
             # Authentication successful, proceed with the request
             return cast(ResponseType, f(*args, **kwargs))
             
-        except Exception as e:
-            logging.error(f"Authentication error: {e}", exc_info=True)
+        except Exception:
+            # The exception message can carry decoded credentials — keep the
+            # traceback for ops, drop the message from the client response.
+            logging.exception("Authentication error")
             return (
                 {
                     "message": "Something went wrong",
                     "data": None,
-                    "error": str(e)
+                    "error": "Internal error"
                 },
                 500,
                 {}

--- a/simplyblock_web/auth_middleware.py
+++ b/simplyblock_web/auth_middleware.py
@@ -83,7 +83,7 @@ def token_required(f: F) -> Callable[..., ResponseType]:
                 cluster = db_controller.get_cluster_by_id(cluster_id)
                 
                 # Validate cluster secret
-                if not hmac.compare_digest(cluster.secret, cluster_secret):
+                if not hmac.compare_digest(cluster.secret.get_secret_value(), cluster_secret):
                     return (
                         {
                             "message": "Invalid Cluster secret",

--- a/simplyblock_web/utils.py
+++ b/simplyblock_web/utils.py
@@ -1,4 +1,5 @@
 import base64
+import logging
 import random
 import re
 import string
@@ -120,8 +121,9 @@ def get_cluster_id(request):
                     if tkn:
                         cluster_id = tkn.split(":")[0]
                         cluster_secret = tkn.split(":")[1]
-                except Exception as e:
-                    print(e)
+                except Exception:
+                    # Exception message can carry the decoded b64 payload.
+                    logging.exception("Failed to decode Basic Auth header")
                     return
 
             return cluster_id

--- a/tests/ftt2/conftest.py
+++ b/tests/ftt2/conftest.py
@@ -30,6 +30,7 @@ from typing import List
 from unittest.mock import patch
 
 import pytest
+from pydantic import SecretStr
 
 from simplyblock_core.models.cluster import Cluster
 from simplyblock_core.models.iface import IFace
@@ -180,7 +181,7 @@ def ftt2_env(ensure_db, mock_rpc_servers):
         n.api_endpoint = f"127.0.0.1:{5000 + i}"
         n.rpc_port = port
         n.rpc_username = "spdkuser"
-        n.rpc_password = "spdkpass"
+        n.rpc_password = SecretStr("spdkpass")
         n.is_secondary_node = False
         n.number_of_distribs = 1
         n.active_tcp = True

--- a/tests/ftt2/test_hublvol_mock_rpc.py
+++ b/tests/ftt2/test_hublvol_mock_rpc.py
@@ -21,6 +21,7 @@ import uuid as _uuid_mod
 from unittest.mock import patch
 
 import pytest
+from pydantic import SecretStr
 
 from simplyblock_core.models.hublvol import HubLVol
 from simplyblock_core.models.iface import IFace
@@ -59,7 +60,7 @@ def _make_node(ip: str, lvstore: str, port: int, jm_vuid: int) -> StorageNode:
     n.mgmt_ip = "127.0.0.1"
     n.rpc_port = port
     n.rpc_username = "spdkuser"
-    n.rpc_password = "spdkpass"
+    n.rpc_password = SecretStr("spdkpass")
     n.active_tcp = True
     n.active_rdma = False
     n.data_nics = [_make_nic(ip)]

--- a/tests/test_api_dto_secrets.py
+++ b/tests/test_api_dto_secrets.py
@@ -1,0 +1,82 @@
+"""PR 4 — request DTOs use SecretStr; response DTOs mask in python mode but unwrap on the JSON wire."""
+import json
+
+from pydantic import SecretStr
+
+from simplyblock_web.api.v2.cluster import BackupConfigParams, ClusterParams
+from simplyblock_web.api.v2._dtos import ClusterDTO, CapacityStatDTO
+from uuid import uuid4
+
+
+def _build_capacity():
+    from simplyblock_core.models.stats import StatsObject
+    return CapacityStatDTO.from_model(StatsObject())
+
+
+def test_backup_config_params_carry_secretstr():
+    params = BackupConfigParams.model_validate({
+        "access_key_id": "AKID",
+        "secret_access_key": "SK",
+    })
+    assert isinstance(params.access_key_id, SecretStr)
+    assert isinstance(params.secret_access_key, SecretStr)
+    assert params.access_key_id.get_secret_value() == "AKID"
+    assert params.secret_access_key.get_secret_value() == "SK"
+
+
+def test_backup_config_repr_masks_secret_values():
+    params = BackupConfigParams.model_validate({
+        "access_key_id": "AKID",
+        "secret_access_key": "SK",
+    })
+    text = repr(params)
+    assert "AKID" not in text
+    assert "SK" not in text
+
+
+def test_cluster_params_grafana_secret_is_secretstr():
+    params = ClusterParams.model_validate({"grafana_secret": "graf-secret"})
+    assert isinstance(params.grafana_secret, SecretStr)
+    assert params.grafana_secret.get_secret_value() == "graf-secret"
+
+
+def _build_cluster_dto():
+    return ClusterDTO(
+        id=uuid4(),
+        name="t",
+        nqn="nqn.example",
+        status="active",
+        is_re_balancing=False,
+        block_size=512,
+        distr_ndcs=1,
+        distr_npcs=1,
+        ha=True,
+        utilization_warning=5,
+        utilization_critical=10,
+        provisioned_capacity_critical=100,
+        provisioned_capacity_warning=50,
+        node_affinity=False,
+        anti_affinity=False,
+        secret=SecretStr("CLUSTER-SECRET"),
+        tls_enabled=False,
+        max_fault_tolerance=1,
+        backup_enabled=False,
+        capacity=_build_capacity(),
+    )
+
+
+def test_cluster_dto_python_dump_keeps_wrapper():
+    d = _build_cluster_dto().model_dump()
+    assert isinstance(d["secret"], SecretStr)
+    assert "CLUSTER-SECRET" not in repr(d)
+
+
+def test_cluster_dto_repr_masks_secret():
+    text = repr(_build_cluster_dto())
+    assert "CLUSTER-SECRET" not in text
+    assert "**********" in text
+
+
+def test_cluster_dto_json_unwraps_secret():
+    payload = json.loads(_build_cluster_dto().model_dump_json())
+    assert payload["secret"] == "CLUSTER-SECRET"

--- a/tests/test_basemodel_secrets.py
+++ b/tests/test_basemodel_secrets.py
@@ -1,0 +1,82 @@
+import json
+
+import pytest
+from pydantic import SecretStr
+
+from simplyblock_core.models.cluster import Cluster
+
+
+def test_secret_field_round_trip_through_dict():
+    cluster = Cluster()
+    cluster.cli_pass = SecretStr("xyz")
+
+    persisted = cluster.to_dict(unwrap_secrets=True)
+    assert persisted["cli_pass"] == "xyz"
+
+    revived = Cluster().from_dict(persisted)
+    assert isinstance(revived.cli_pass, SecretStr)
+    assert revived.cli_pass.get_secret_value() == "xyz"
+
+
+def test_repr_masks_secret_value():
+    cluster = Cluster()
+    cluster.secret = SecretStr("super-secret")
+    text = repr(cluster)
+    assert "super-secret" not in text
+    assert "**********" in text
+
+
+def test_to_dict_default_keeps_wrapper():
+    cluster = Cluster()
+    cluster.secret = SecretStr("xyz")
+    d = cluster.to_dict()
+    assert isinstance(d["secret"], SecretStr)
+    assert "xyz" not in repr(d)
+
+
+def test_write_path_serializable_only_with_unwrap_flag():
+    cluster = Cluster()
+    cluster.secret = SecretStr("xyz")
+
+    assert json.dumps(cluster.to_dict(unwrap_secrets=True))
+
+    with pytest.raises(TypeError):
+        json.dumps(cluster.to_dict())
+
+
+def test_from_dict_lifts_plain_string_into_secretstr():
+    """Backward-compat: existing FoundationDB records store plaintext."""
+    revived = Cluster().from_dict({"secret": "legacy-plain"})
+    assert isinstance(revived.secret, SecretStr)
+    assert revived.secret.get_secret_value() == "legacy-plain"
+
+
+def test_secretstr_inside_dict_field_unwrapped():
+    """SecretStr values inside a dict field must be unwrapped for JSON."""
+    cluster = Cluster()
+    cluster.tls_config = {"token": SecretStr("s3cret"), "plain": "ok"}
+
+    d = cluster.to_dict(unwrap_secrets=True)
+    assert d["tls_config"]["token"] == "s3cret"
+    assert d["tls_config"]["plain"] == "ok"
+    # Must be JSON-serializable
+    json.dumps(d)
+
+
+def test_secretstr_inside_dict_field_stays_wrapped():
+    """Without unwrap, SecretStr in dict fields stays wrapped."""
+    cluster = Cluster()
+    cluster.tls_config = {"token": SecretStr("s3cret")}
+
+    d = cluster.to_dict(unwrap_secrets=False)
+    assert isinstance(d["tls_config"]["token"], SecretStr)
+
+
+def test_secretstr_inside_nested_dict_unwrapped():
+    """SecretStr deeply nested in a dict field must be unwrapped."""
+    cluster = Cluster()
+    cluster.tls_config = {"outer": {"inner": SecretStr("deep")}}
+
+    d = cluster.to_dict(unwrap_secrets=True)
+    assert d["tls_config"]["outer"]["inner"] == "deep"
+    json.dumps(d)

--- a/tests/test_cli_secret_args.py
+++ b/tests/test_cli_secret_args.py
@@ -1,0 +1,38 @@
+"""PR 3 — argparse layer constructs SecretStr at parse time for secret args."""
+import argparse
+
+from pydantic import SecretStr
+
+from simplyblock_cli import cli as cli_module
+
+
+def _build_parser():
+    """Build a CLI wrapper without instantiating its run loop."""
+    cli_module.CLIWrapper.__init__(wrapper := cli_module.CLIWrapper.__new__(cli_module.CLIWrapper))
+    return wrapper.parser
+
+
+def test_update_secret_arg_is_secretstr_after_parse():
+    parser = _build_parser()
+    args = parser.parse_args(["cluster", "update-secret", "abc-cluster-id", "supersecret-value"])
+    assert isinstance(args.secret, SecretStr)
+    assert args.secret.get_secret_value() == "supersecret-value"
+
+
+def test_control_plane_add_cluster_secret_is_secretstr():
+    parser = _build_parser()
+    args = parser.parse_args([
+        "control-plane", "add",
+        "1.2.3.4", "abc-cluster-id", "the-cluster-secret",
+    ])
+    assert isinstance(args.cluster_secret, SecretStr)
+    assert args.cluster_secret.get_secret_value() == "the-cluster-secret"
+
+
+def test_namespace_repr_masks_secret_value():
+    args = argparse.Namespace(
+        cluster_id="x",
+        secret=SecretStr("supersecret-value"),
+    )
+    assert "supersecret-value" not in repr(vars(args))
+    assert "**********" in repr(vars(args))

--- a/tests/test_client_secret_logging.py
+++ b/tests/test_client_secret_logging.py
@@ -1,0 +1,113 @@
+"""Verifies that secrets never reach log records but do reach the wire body."""
+import json
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pydantic import SecretStr
+
+from simplyblock_core.rpc_client import RPCClient
+from simplyblock_core.snode_client import SNodeClient
+
+
+def _make_json_response(payload):
+    response = MagicMock()
+    response.status_code = 200
+    response.json.return_value = payload
+    response.content = json.dumps(payload).encode()
+    response.text = json.dumps(payload)
+    return response
+
+
+def _captured_logs_text(caplog) -> str:
+    return "\n".join(record.getMessage() for record in caplog.records)
+
+
+@pytest.fixture
+def rpc_client():
+    with patch("simplyblock_core.rpc_client.requests.session") as session_factory:
+        session = MagicMock()
+        session_factory.return_value = session
+        client = RPCClient("host", 9999, "user", SecretStr("ctor-secret"))
+        client._fake_session = session  # expose for assertions
+        yield client
+
+
+def test_rpc_client_session_auth_carries_unwrapped_password(rpc_client):
+    user, password = rpc_client._fake_session.auth
+    assert user == "user"
+    assert password == "ctor-secret"
+
+
+def test_rpc_client_request_body_carries_unwrapped_param(rpc_client, caplog):
+    rpc_client._fake_session.post.return_value = _make_json_response({
+        "jsonrpc": "2.0", "id": 1, "result": {"ok": True},
+    })
+
+    with caplog.at_level(logging.DEBUG):
+        rpc_client._request2("nvmf_subsystem_add_host", {
+            "nqn": "nqn.example",
+            "dhchap_key": SecretStr("DHCHAPVALUE"),
+        })
+
+    posted_body = rpc_client._fake_session.post.call_args.kwargs["data"]
+    parsed = json.loads(posted_body)
+    assert parsed["params"]["dhchap_key"] == "DHCHAPVALUE"
+
+    assert "DHCHAPVALUE" not in _captured_logs_text(caplog)
+    assert "ctor-secret" not in _captured_logs_text(caplog)
+
+
+def test_rpc_client_response_body_hidden_by_default(rpc_client, caplog):
+    rpc_client._fake_session.post.return_value = _make_json_response({
+        "jsonrpc": "2.0", "id": 1, "result": {"sensitive": "RESPVALUE"},
+    })
+    with caplog.at_level(logging.DEBUG):
+        rpc_client._request2("some_method", {})
+
+    assert "RESPVALUE" not in _captured_logs_text(caplog)
+
+
+def test_rpc_client_response_body_logged_when_flag_on(rpc_client, caplog, monkeypatch):
+    monkeypatch.setenv("SB_LOG_RESPONSE_BODIES", "true")
+    rpc_client._fake_session.post.return_value = _make_json_response({
+        "jsonrpc": "2.0", "id": 1, "result": {"sensitive": "RESPVALUE"},
+    })
+    with caplog.at_level(logging.DEBUG):
+        rpc_client._request2("some_method", {})
+
+    assert "RESPVALUE" in _captured_logs_text(caplog)
+
+
+@pytest.fixture
+def snode_client():
+    with patch("simplyblock_core.snode_client.requests.session") as session_factory:
+        session = MagicMock()
+        session_factory.return_value = session
+        session.headers = {}
+        client = SNodeClient("snode.host")
+        client._fake_session = session
+        yield client
+
+
+def test_snode_request_wire_unwraps_secrets(snode_client, caplog):
+    snode_client._fake_session.request.return_value = _make_json_response({"results": "ok"})
+
+    with caplog.at_level(logging.DEBUG):
+        snode_client._request("POST", "spdk_process_start", {
+            "rpc_username": "u",
+            "rpc_password": SecretStr("PWVALUE"),
+        })
+
+    posted_body = snode_client._fake_session.request.call_args.kwargs["data"]
+    parsed = json.loads(posted_body)
+    assert parsed["rpc_password"] == "PWVALUE"
+
+    assert "PWVALUE" not in _captured_logs_text(caplog)
+
+
+def test_snode_response_body_hidden_by_default(snode_client, caplog):
+    snode_client._fake_session.request.return_value = _make_json_response({"results": {"x": "RESPVAL"}})
+    with caplog.at_level(logging.DEBUG):
+        snode_client._request("GET", "info")
+    assert "RESPVAL" not in _captured_logs_text(caplog)

--- a/tests/test_dhchap_e2e.py
+++ b/tests/test_dhchap_e2e.py
@@ -25,6 +25,7 @@ from http.server import HTTPServer, BaseHTTPRequestHandler
 from threading import Thread
 
 import requests
+from pydantic import SecretStr
 
 # ---------------------------------------------------------------------------
 # Mock SPDK JSON-RPC server
@@ -310,7 +311,7 @@ class TestDHCHAPE2E(unittest.TestCase):
         from simplyblock_core.rpc_client import RPCClient
 
         snode_client = SNodeClient(f"127.0.0.1:{SNODE_API_PORT}")
-        rpc_client = RPCClient("127.0.0.1", MOCK_SPDK_PORT, "", "")
+        rpc_client = RPCClient("127.0.0.1", MOCK_SPDK_PORT, "", SecretStr(""))
 
         # Write key file
         key_content = "DHHC-1:01:dGVzdGtleQ==:"
@@ -331,7 +332,7 @@ class TestDHCHAPE2E(unittest.TestCase):
         from simplyblock_core.utils import generate_dhchap_key
 
         snode_client = SNodeClient(f"127.0.0.1:{SNODE_API_PORT}")
-        rpc_client = RPCClient("127.0.0.1", MOCK_SPDK_PORT, "", "")
+        rpc_client = RPCClient("127.0.0.1", MOCK_SPDK_PORT, "", SecretStr(""))
 
         host_nqn = "nqn.2014-08.org.nvmexpress:uuid:test-host-1"
         subsys_nqn = "nqn.2023-02.io.simplyblock:test:subsys1"
@@ -378,7 +379,7 @@ class TestDHCHAPE2E(unittest.TestCase):
     def test_subsystem_add_host_fails_without_keyring_registration(self):
         """SPDK rejects add_host when dhchap_key name is not in the keyring."""
         from simplyblock_core.rpc_client import RPCClient
-        rpc_client = RPCClient("127.0.0.1", MOCK_SPDK_PORT, "", "")
+        rpc_client = RPCClient("127.0.0.1", MOCK_SPDK_PORT, "", SecretStr(""))
 
         subsys_nqn = "nqn:test:subsys2"
         rpc_client._request("nvmf_create_subsystem", {"nqn": subsys_nqn})
@@ -404,9 +405,9 @@ class TestDHCHAPE2E(unittest.TestCase):
         snode.mgmt_ip = "127.0.0.1"
         snode.rpc_port = MOCK_SPDK_PORT
         snode.rpc_username = ""
-        snode.rpc_password = ""
+        snode.rpc_password = SecretStr("")
 
-        rpc_client = RPCClient("127.0.0.1", MOCK_SPDK_PORT, "", "")
+        rpc_client = RPCClient("127.0.0.1", MOCK_SPDK_PORT, "", SecretStr(""))
 
         host_nqn = "nqn.2014-08.org.nvmexpress:uuid:e2e-host"
         host_entry = {
@@ -465,8 +466,8 @@ class TestDHCHAPE2E(unittest.TestCase):
         from simplyblock_core.models.pool import Pool
         pool = Pool()
         pool.uuid = "pool-1"
-        pool.dhchap_key = dhchap_key
-        pool.dhchap_ctrlr_key = dhchap_ctrlr_key
+        pool.dhchap_key = SecretStr(dhchap_key)
+        pool.dhchap_ctrlr_key = SecretStr(dhchap_ctrlr_key)
 
         lvol = LVol()
         lvol.uuid = "lvol-1"

--- a/tests/test_dhchap_pool_level.py
+++ b/tests/test_dhchap_pool_level.py
@@ -20,6 +20,8 @@ import inspect
 import unittest
 from unittest.mock import MagicMock, patch
 
+from pydantic import SecretStr
+
 from tests._mocks import make_mock_cluster
 
 
@@ -254,10 +256,10 @@ class TestPoolModelDhchapFields(unittest.TestCase):
         return Pool()
 
     def test_dhchap_key_default_empty(self):
-        self.assertEqual(self._pool().dhchap_key, "")
+        self.assertEqual(self._pool().dhchap_key.get_secret_value(), "")
 
     def test_dhchap_ctrlr_key_default_empty(self):
-        self.assertEqual(self._pool().dhchap_ctrlr_key, "")
+        self.assertEqual(self._pool().dhchap_ctrlr_key.get_secret_value(), "")
 
     def test_allowed_hosts_default_empty_list(self):
         self.assertEqual(self._pool().allowed_hosts, [])
@@ -304,8 +306,9 @@ class TestAddPoolKeyGeneration(unittest.TestCase):
 
     def test_key_is_dhhc1_format(self):
         pool_obj = self._run_add(dhchap=True)
-        self.assertTrue(str(pool_obj.dhchap_key).startswith("DHHC-1:"),
-                        f"Expected DHHC-1 prefix, got: {pool_obj.dhchap_key}")
+        key_value = pool_obj.dhchap_key.get_secret_value()
+        self.assertTrue(key_value.startswith("DHHC-1:"),
+                        f"Expected DHHC-1 prefix, got: {key_value}")
 
     def test_two_distinct_keys_generated(self):
         pool_obj = self._run_add(dhchap=True)
@@ -330,8 +333,8 @@ def _make_dhchap_pool(pool_id="pool-1", hosts=None):
     p = Pool()
     p.uuid = pool_id
     p.dhchap = True
-    p.dhchap_key = "DHHC-1:01:aGVsbG8=:"
-    p.dhchap_ctrlr_key = "DHHC-1:01:d29ybGQ=:"
+    p.dhchap_key = SecretStr("DHHC-1:01:aGVsbG8=:")
+    p.dhchap_ctrlr_key = SecretStr("DHHC-1:01:d29ybGQ=:")
     p.allowed_hosts = list(hosts or [])
     return p
 
@@ -687,8 +690,8 @@ def _make_connect_ctx(lvol_allowed_hosts, pool_dhchap_key="", pool_dhchap_ctrlr_
 
     pool = Pool()
     pool.uuid = "pool-1"
-    pool.dhchap_key = pool_dhchap_key
-    pool.dhchap_ctrlr_key = pool_dhchap_ctrlr_key
+    pool.dhchap_key = SecretStr(pool_dhchap_key)
+    pool.dhchap_ctrlr_key = SecretStr(pool_dhchap_ctrlr_key)
 
     db_patch = patch(
         "simplyblock_core.controllers.lvol_controller.DBController")

--- a/tests/test_rpc_client_cache.py
+++ b/tests/test_rpc_client_cache.py
@@ -9,13 +9,15 @@ import threading
 import unittest
 from unittest.mock import patch
 
+from pydantic import SecretStr
+
 from simplyblock_core.rpc_client import RPCClient, _rpc_cache, _rpc_cache_lock
 
 
 def _make_client(**kwargs):
     """Create an RPCClient without hitting the network."""
     with patch("requests.session"):
-        return RPCClient("127.0.0.1", 8081, "user", "pass", timeout=1, retry=0, **kwargs)
+        return RPCClient("127.0.0.1", 8081, "user", SecretStr("pass"), timeout=1, retry=0, **kwargs)
 
 
 class TestRequestCached(unittest.TestCase):
@@ -80,8 +82,8 @@ class TestRequestCached(unittest.TestCase):
         mock_req.return_value = ["data"]
 
         with patch("requests.session"):
-            client_a = RPCClient("10.0.0.1", 8081, "u", "p", timeout=1, retry=0)
-            client_b = RPCClient("10.0.0.2", 8081, "u", "p", timeout=1, retry=0)
+            client_a = RPCClient("10.0.0.1", 8081, "u", SecretStr("p"), timeout=1, retry=0)
+            client_b = RPCClient("10.0.0.2", 8081, "u", SecretStr("p"), timeout=1, retry=0)
 
         client_a._request_cached("bdev_get_bdevs")
         client_b._request_cached("bdev_get_bdevs")

--- a/tests/test_rpc_retry.py
+++ b/tests/test_rpc_retry.py
@@ -8,12 +8,14 @@ governed separately (the `connect` count) and are safe, so they must remain.
 """
 from unittest.mock import patch
 
+from pydantic import SecretStr
+
 from simplyblock_core.rpc_client import RPCClient
 
 
 def _make_client(retry=3, **kwargs):
     with patch("requests.session"):
-        return RPCClient("127.0.0.1", 8081, "user", "pass", timeout=1, retry=retry, **kwargs)
+        return RPCClient("127.0.0.1", 8081, "user", SecretStr("pass"), timeout=1, retry=retry, **kwargs)
 
 
 def _mounted_retries(client):

--- a/tests/test_secret_redaction.py
+++ b/tests/test_secret_redaction.py
@@ -1,0 +1,120 @@
+# coding=utf-8
+"""Tests for SecretStr-based redaction for BaseModel.
+
+Goal: confirm that secrets are masked anywhere a model or its dict
+representation is rendered for humans (repr/str/pprint/log formatters), while
+plaintext is still available where business logic requires it (FDB
+persistence, explicit consumer reads).
+"""
+import json
+import logging
+import pprint
+import unittest
+
+from pydantic import SecretStr
+
+from simplyblock_core.models.cluster import Cluster
+from simplyblock_core.models.pool import Pool
+from simplyblock_core.models.storage_node import StorageNode
+
+
+SECRET_VALUE = "super-secret-token-12345"
+MASK = "**********"
+
+
+def _everywhere(rendering: str, value: str) -> bool:
+    return value in rendering
+
+
+class TestBaseModelSecretMasking(unittest.TestCase):
+    def setUp(self):
+        self.cluster = Cluster()
+        self.cluster.uuid = "c-1"
+        self.cluster.secret = SecretStr(SECRET_VALUE)
+        self.cluster.cli_pass = SecretStr("cli-" + SECRET_VALUE)
+        self.cluster.grafana_secret = SecretStr("grafana-" + SECRET_VALUE)
+        self.cluster.db_connection = SecretStr("user:pw@host:4500")
+
+    def test_repr_masks_secrets(self):
+        rendered = repr(self.cluster)
+        self.assertNotIn(SECRET_VALUE, rendered)
+        self.assertNotIn("cli-" + SECRET_VALUE, rendered)
+        self.assertIn(MASK, rendered)
+
+    def test_str_masks_secrets(self):
+        rendered = str(self.cluster)
+        self.assertNotIn(SECRET_VALUE, rendered)
+        self.assertIn(MASK, rendered)
+
+    def test_to_str_masks_secrets(self):
+        self.assertNotIn(SECRET_VALUE, self.cluster.to_str())
+
+    def test_pprint_to_dict_masks_secrets(self):
+        rendered = pprint.pformat(self.cluster.to_dict())
+        self.assertNotIn(SECRET_VALUE, rendered)
+        self.assertIn(MASK, rendered)
+
+    def test_to_dict_default_masks(self):
+        d = self.cluster.to_dict()
+        self.assertEqual(str(d["secret"]), MASK)
+        self.assertEqual(str(d["cli_pass"]), MASK)
+        self.assertEqual(str(d["db_connection"]), MASK)
+
+    def test_to_dict_unwrap_returns_plaintext(self):
+        d = self.cluster.to_dict(unwrap_secrets=True)
+        self.assertEqual(d["secret"], SECRET_VALUE)
+        self.assertEqual(d["db_connection"], "user:pw@host:4500")
+
+    def test_log_formatter_masks_secrets(self):
+        logger = logging.getLogger("test_secret_redaction")
+        with self.assertLogs(logger, level="DEBUG") as captured:
+            logger.debug("cluster: %s", self.cluster)
+        self.assertFalse(any(SECRET_VALUE in msg for msg in captured.output))
+
+
+class TestBaseModelFDBRoundtrip(unittest.TestCase):
+    """FoundationDB persistence must store the real value, and reading back
+    must rehydrate the SecretStr wrapper around the original plaintext."""
+
+    def test_roundtrip_preserves_secret(self):
+        original = Cluster()
+        original.uuid = "c-roundtrip"
+        original.secret = SecretStr(SECRET_VALUE)
+
+        # write_to_db serializes to_dict(unwrap_secrets=True) — verify the
+        # JSON blob carries the plaintext, then rehydrate via from_dict.
+        wire = json.dumps(original.to_dict(unwrap_secrets=True))
+        self.assertIn(SECRET_VALUE, wire)
+
+        restored = Cluster()
+        restored.from_dict(json.loads(wire))
+        self.assertIsInstance(restored.secret, SecretStr)
+        self.assertEqual(restored.secret.get_secret_value(), SECRET_VALUE)
+
+
+class TestStorageNodeAndPoolMasking(unittest.TestCase):
+    def test_storage_node_to_dict_masks(self):
+        node = StorageNode()
+        node.uuid = "n-1"
+        node.ctrl_secret = SecretStr("ctrl-secret-xyz")
+        node.host_secret = SecretStr("host-secret-xyz")
+        node.rpc_password = SecretStr("rpc-pw")
+
+        d = node.to_dict()
+        self.assertEqual(str(d["ctrl_secret"]), MASK)
+        self.assertEqual(str(d["host_secret"]), MASK)
+        self.assertEqual(str(d["rpc_password"]), MASK)
+
+    def test_pool_to_dict_masks(self):
+        pool = Pool()
+        pool.uuid = "p-1"
+        pool.dhchap_key = SecretStr("DHHC-1:01:abc=:")
+        pool.dhchap_ctrlr_key = SecretStr("DHHC-1:01:def=:")
+
+        d = pool.to_dict()
+        self.assertEqual(str(d["dhchap_key"]), MASK)
+        self.assertEqual(str(d["dhchap_ctrlr_key"]), MASK)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -1,0 +1,49 @@
+import logging
+
+from pydantic import SecretBytes, SecretStr
+
+from simplyblock_core.utils.secrets import unwrap_secret, unwrap_secrets_for_send
+
+
+def test_unwrap_scalar_secretstr():
+    assert unwrap_secrets_for_send(SecretStr("v")) == "v"
+
+
+def test_unwrap_scalar_secretbytes():
+    assert unwrap_secrets_for_send(SecretBytes(b"v")) == b"v"
+
+
+def test_unwrap_nested_dict():
+    obj = {"k": SecretStr("v"), "nested": {"k2": SecretStr("v2"), "ok": 1}}
+    out = unwrap_secrets_for_send(obj)
+    assert out == {"k": "v", "nested": {"k2": "v2", "ok": 1}}
+
+
+def test_unwrap_list_and_tuple_preserve_type():
+    obj = [SecretStr("a"), (SecretStr("b"), 2)]
+    out = unwrap_secrets_for_send(obj)
+    assert out == ["a", ("b", 2)]
+    assert isinstance(out[1], tuple)
+
+
+def test_unwrap_leaves_non_secret_values_unchanged():
+    obj = {"x": 1, "y": True, "z": None, "s": "plain"}
+    assert unwrap_secrets_for_send(obj) == obj
+
+
+def test_repr_of_dict_with_secretstr_masks_value():
+    assert "v" not in repr({"k": SecretStr("v")})
+
+
+def test_logging_pipeline_masks_secretstr():
+    record = logging.LogRecord(
+        name="t", level=logging.INFO, pathname="", lineno=0,
+        msg="payload: %s", args=({"k": SecretStr("hunter2")},), exc_info=None,
+    )
+    assert "hunter2" not in record.getMessage()
+
+
+def test_unwrap_secret_scalar_helper():
+    assert unwrap_secret(None) is None
+    assert unwrap_secret("plain") == "plain"
+    assert unwrap_secret(SecretStr("v")) == "v"

--- a/tests/test_shared_placement.py
+++ b/tests/test_shared_placement.py
@@ -19,6 +19,8 @@ These tests pin those invariants without touching FDB.
 import unittest
 from unittest.mock import MagicMock, patch
 
+from pydantic import SecretStr
+
 from simplyblock_core.models.cluster import Cluster
 from simplyblock_core.models.storage_node import StorageNode
 
@@ -345,7 +347,7 @@ class TestRpcMethodShape(unittest.TestCase):
         from simplyblock_core.rpc_client import RPCClient
 
         with patch("requests.session"):
-            c = RPCClient("127.0.0.1", 8081, "u", "p", timeout=1, retry=0)
+            c = RPCClient("127.0.0.1", 8081, "u", SecretStr("p"), timeout=1, retry=0)
         with patch.object(c, "get_bdevs", return_value=None), \
              patch.object(c, "_request", return_value=True) as mock_req:
             c.bdev_distrib_create(
@@ -362,7 +364,7 @@ class TestRpcMethodShape(unittest.TestCase):
         from simplyblock_core.rpc_client import RPCClient
 
         with patch("requests.session"):
-            c = RPCClient("127.0.0.1", 8081, "u", "p", timeout=1, retry=0)
+            c = RPCClient("127.0.0.1", 8081, "u", SecretStr("p"), timeout=1, retry=0)
         with patch.object(c, "get_bdevs", return_value=None), \
              patch.object(c, "_request", return_value=True) as mock_req:
             c.bdev_distrib_create(
@@ -378,7 +380,7 @@ class TestRpcMethodShape(unittest.TestCase):
         from simplyblock_core.rpc_client import RPCClient
 
         with patch("requests.session"):
-            c = RPCClient("127.0.0.1", 8081, "u", "p", timeout=1, retry=0)
+            c = RPCClient("127.0.0.1", 8081, "u", SecretStr("p"), timeout=1, retry=0)
         with patch.object(c, "_request", return_value=True) as mock_req:
             c.distr_shared_placement(name="distrib_1", enable=True)
 
@@ -390,7 +392,7 @@ class TestRpcMethodShape(unittest.TestCase):
         from simplyblock_core.rpc_client import RPCClient
 
         with patch("requests.session"):
-            c = RPCClient("127.0.0.1", 8081, "u", "p", timeout=1, retry=0)
+            c = RPCClient("127.0.0.1", 8081, "u", SecretStr("p"), timeout=1, retry=0)
         with patch.object(c, "_request", return_value=True) as mock_req:
             c.distr_shared_placement(enable=True)
 
@@ -404,7 +406,7 @@ class TestRpcMethodShape(unittest.TestCase):
         from simplyblock_core.rpc_client import RPCClient
 
         with patch("requests.session"):
-            c = RPCClient("127.0.0.1", 8081, "u", "p", timeout=1, retry=0)
+            c = RPCClient("127.0.0.1", 8081, "u", SecretStr("p"), timeout=1, retry=0)
         with patch.object(c, "_request", return_value=True) as mock_req:
             c.bdev_jm_create(name="jm_1", name_storage1="alceml_1",
                              shared_placement=True)
@@ -417,7 +419,7 @@ class TestRpcMethodShape(unittest.TestCase):
         from simplyblock_core.rpc_client import RPCClient
 
         with patch("requests.session"):
-            c = RPCClient("127.0.0.1", 8081, "u", "p", timeout=1, retry=0)
+            c = RPCClient("127.0.0.1", 8081, "u", SecretStr("p"), timeout=1, retry=0)
         with patch.object(c, "_request", return_value=True) as mock_req:
             c.bdev_jm_create(name="jm_1", name_storage1="alceml_1")
 
@@ -430,7 +432,7 @@ class TestRpcMethodShape(unittest.TestCase):
         from simplyblock_core.rpc_client import RPCClient
 
         with patch("requests.session"):
-            c = RPCClient("127.0.0.1", 8081, "u", "p", timeout=1, retry=0)
+            c = RPCClient("127.0.0.1", 8081, "u", SecretStr("p"), timeout=1, retry=0)
         with patch.object(c, "_request", return_value=True) as mock_req:
             c.jm_set_shared_placement(name="jm_1", enable=True)
 
@@ -445,7 +447,7 @@ class TestRpcMethodShape(unittest.TestCase):
         from simplyblock_core.rpc_client import RPCClient
 
         with patch("requests.session"):
-            c = RPCClient("127.0.0.1", 8081, "u", "p", timeout=1, retry=0)
+            c = RPCClient("127.0.0.1", 8081, "u", SecretStr("p"), timeout=1, retry=0)
         with self.assertRaises(TypeError):
             c.jm_set_shared_placement(enable=True)
 
@@ -453,7 +455,7 @@ class TestRpcMethodShape(unittest.TestCase):
         from simplyblock_core.rpc_client import RPCClient
 
         with patch("requests.session"):
-            c = RPCClient("127.0.0.1", 8081, "u", "p", timeout=1, retry=0)
+            c = RPCClient("127.0.0.1", 8081, "u", SecretStr("p"), timeout=1, retry=0)
         with patch.object(c, "_request", return_value=True) as mock_req:
             c.jm_set_shared_placement(name="jm_1", enable=False)
 

--- a/tests/test_subsystem_add_ns_idempotent.py
+++ b/tests/test_subsystem_add_ns_idempotent.py
@@ -14,12 +14,14 @@ duplicate JSON-RPC that SPDK would reject with -EEXIST.
 import unittest
 from unittest.mock import patch
 
+from pydantic import SecretStr
+
 from simplyblock_core.rpc_client import RPCClient
 
 
 def _client():
     with patch("requests.session"):
-        return RPCClient("127.0.0.1", 8081, "user", "pass", timeout=1, retry=0)
+        return RPCClient("127.0.0.1", 8081, "user", SecretStr("pass"), timeout=1, retry=0)
 
 
 class TestAddNsIdempotent(unittest.TestCase):

--- a/tests/test_teardown_non_leader_lvstore.py
+++ b/tests/test_teardown_non_leader_lvstore.py
@@ -10,6 +10,8 @@ actually a sec/tert for the given primary.
 import unittest
 from unittest.mock import MagicMock, patch
 
+from pydantic import SecretStr
+
 from simplyblock_core.models.storage_node import StorageNode
 from simplyblock_core.models.iface import IFace
 from simplyblock_core.models.hublvol import HubLVol
@@ -34,7 +36,7 @@ def _node(uuid, lvstore="", secondary_node_id="", tertiary_node_id="",
     n.mgmt_ip = mgmt_ip or f"10.0.0.{abs(hash(uuid)) % 254 + 1}"
     n.rpc_port = 8080
     n.rpc_username = "user"
-    n.rpc_password = "pass"
+    n.rpc_password = SecretStr("pass")
     n.hublvol = HubLVol({"nvmf_port": 5000, "uuid": f"hub-{uuid}",
                           "nqn": f"nqn.hub.{uuid}",
                           "bdev_name": f"lvs/{uuid}/hublvol",

--- a/tests/web/api/v2/test_auth.py
+++ b/tests/web/api/v2/test_auth.py
@@ -11,6 +11,7 @@ from uuid import UUID, uuid4
 import pytest
 from fastapi import HTTPException
 from fastapi.security import HTTPAuthorizationCredentials
+from pydantic import SecretStr
 
 
 def _make_credentials(token: str) -> HTTPAuthorizationCredentials:
@@ -96,7 +97,7 @@ class TestAuthorizedCluster:
     def _cluster(self, id: str, secret: str) -> MagicMock:
         c = MagicMock()
         c.id = id
-        c.secret = secret
+        c.secret = SecretStr(secret)
         return c
 
     def test_returns_uuid_for_matching_secret(self):


### PR DESCRIPTION
The extensive logging done throughout the application may inadvertently leak confidential data. This PR aims to mitigate this, preventing secrets to be present in the logs. 

The core tool in this PR is the use of pydantic's `SecretStr`/`SecretBytes`. They are a simple wrapper around `str`/`bytes`, that, when converted to string yield a redacted string (`**********`). The actual value needs to be explicitly unwrapped via `get_secret_value()`.

This changeset introduces:
- support for using fields of the secret type in models
- unwrapping of secret values in the clients, s.t. the secret values are correctly unwrapped before transmitting them
- Entrypoints in CLI/API wrap confidential values as soon as possible

What htis PR notably does _not_ do, is prevent explicit leakage through endpoints that currently allow access to the confidential values. Handling that in a better way is left as a follow-up.