### PR TITLE
POST /snapshot: return error if value already exists

### DIFF
--- a/simplyblock_web/api/v2/_dtos.py
+++ b/simplyblock_web/api/v2/_dtos.py
@@ -1,4 +1,4 @@
-from datetime import timedelta
+from datetime import datetime, timedelta
 from ipaddress import IPv4Address
 from typing import List, Literal, Tuple, Optional, cast
 from uuid import UUID
@@ -249,7 +249,8 @@ class SnapshotDTO(BaseModel):
     used_size: util.Unsigned
     migrating: bool
     lvol: Optional[util.UrlPath]
-    created_at: int
+    created_at: datetime
+
 
     @staticmethod
     def from_model(

--- a/simplyblock_web/api/v2/_dtos.py
+++ b/simplyblock_web/api/v2/_dtos.py
@@ -249,6 +249,7 @@ class SnapshotDTO(BaseModel):
     used_size: util.Unsigned
     migrating: bool
     lvol: Optional[util.UrlPath]
+    created_at: int
 
     @staticmethod
     def from_model(
@@ -271,6 +272,7 @@ class SnapshotDTO(BaseModel):
             size=model.size,
             used_size=model.used_size,
             migrating=is_migrating,
+            created_at=model.created_at,
             lvol=str(
                 request.url_for(
                     "clusters:pools:volumes:detail",

--- a/simplyblock_web/api/v2/_dtos.py
+++ b/simplyblock_web/api/v2/_dtos.py
@@ -273,7 +273,7 @@ class SnapshotDTO(BaseModel):
             size=model.size,
             used_size=model.used_size,
             migrating=is_migrating,
-            created_at=model.created_at,
+            created_at=datetime.fromtimestamp(model.created_at),
             lvol=str(
                 request.url_for(
                     "clusters:pools:volumes:detail",

--- a/simplyblock_web/api/v2/cluster/storage_pool/volume.py
+++ b/simplyblock_web/api/v2/cluster/storage_pool/volume.py
@@ -288,6 +288,8 @@ def create_snapshot(
         volume.get_id(), parameters.name, backup=parameters.backup
     )
     if err_or_false:
+        if 'unique' in str(err_or_false).lower():
+            raise HTTPException(409, f'Snapshot {parameters.name} already exists')
         raise ValueError(err_or_false)
 
     entity_url = request.app.url_path_for(

--- a/simplyblock_web/api/v2/cluster/storage_pool/volume.py
+++ b/simplyblock_web/api/v2/cluster/storage_pool/volume.py
@@ -288,6 +288,8 @@ def create_snapshot(
         volume.get_id(), parameters.name, backup=parameters.backup
     )
     if err_or_false:
+        # FIXME: snapshot_controller.add() should raise a named exception directly
+        # instead of returning a string that we string-match here
         if 'unique' in str(err_or_false).lower():
             raise HTTPException(409, f'Snapshot {parameters.name} already exists')
         raise ValueError(err_or_false)


### PR DESCRIPTION
* SnapshotDTO doesn't have `created_at` field although the model returns it. 
* Return 409 during POST /snapshot if the snapshot with the name already exists. 


the upstream function returns the error. so we look for the error:
https://github.com/simplyblock/sbcli/blob/18d1efaf9364d1b91fd45f67d539e213b26dac7b/simplyblock_core/controllers/snapshot_controller.py#L104-L106



