### PR TITLE
fix snapshot API response

### DIFF
--- a/simplyblock_web/api/v2/_dtos.py
+++ b/simplyblock_web/api/v2/_dtos.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from ipaddress import IPv4Address
 from typing import List, Literal, Tuple, Optional, cast
 from uuid import UUID
@@ -273,7 +273,7 @@ class SnapshotDTO(BaseModel):
             size=model.size,
             used_size=model.used_size,
             migrating=is_migrating,
-            created_at=datetime.fromtimestamp(model.created_at),
+            created_at=datetime.fromtimestamp(model.created_at, tz=timezone.utc),
             lvol=str(
                 request.url_for(
                     "clusters:pools:volumes:detail",
@@ -282,7 +282,7 @@ class SnapshotDTO(BaseModel):
                     volume_id=model.lvol.get_id(),
                 )
             )
-            if model.lvol is not None and (volume_id == model.lvol.get_id())
+            if model.lvol is not None and (volume_id is None or volume_id == model.lvol.get_id())
             else None,
         )
 

--- a/simplyblock_web/api/v2/_dtos.py
+++ b/simplyblock_web/api/v2/_dtos.py
@@ -254,7 +254,7 @@ class SnapshotDTO(BaseModel):
 
     @staticmethod
     def from_model(
-        model: SnapShot, request: Request, cluster_id, pool_id, volume_id=None
+        model: SnapShot, request: Request, cluster_id, pool_id
     ):
         from simplyblock_core.controllers import migration_controller
 
@@ -282,7 +282,7 @@ class SnapshotDTO(BaseModel):
                     volume_id=model.lvol.get_id(),
                 )
             )
-            if model.lvol is not None and (volume_id is None or volume_id == model.lvol.get_id())
+            if model.lvol is not None
             else None,
         )
 

--- a/simplyblock_web/api/v2/cluster/storage_pool/volume.py
+++ b/simplyblock_web/api/v2/cluster/storage_pool/volume.py
@@ -272,7 +272,7 @@ def iostats(cluster: Cluster, pool: StoragePool, volume: Volume, history: Option
 @instance_api.get('/snapshots', name='clusters:storage-pools:volumes:snapshots:list')
 def snapshot(request: Request, cluster: Cluster, pool: StoragePool, volume: Volume) -> List[SnapshotDTO]:
     return [
-        SnapshotDTO.from_model(snapshot, request, cluster_id=cluster.get_id(), pool_id=pool.get_id(), volume_id=volume.get_id())
+        SnapshotDTO.from_model(snapshot, request, cluster_id=cluster.get_id(), pool_id=pool.get_id())
         for snapshot
         in db.get_snapshots()
         if snapshot.lvol is not None and snapshot.lvol.get_id() == volume.get_id()


### PR DESCRIPTION
Fixes responses for snapshot API

* return `created_at` in RFC 3339 format
* In the pool-level listing `volume_id` is `None`, so `None == model.lvol.get_id()` is always `False`. meaning `lvol` would be `None` in every pool-level response even when the snapshot has a source volume. 

