### PR TITLE
Convert lvol deletion error handling to exceptions

### DIFF
--- a/simplyblock_cli/cli-reference.yaml
+++ b/simplyblock_cli/cli-reference.yaml
@@ -1724,10 +1724,9 @@ commands:
           is released.
         arguments:
           - name: "volume_id"
-            help: "The logical volumes id or ids."
+            help: "The logical volumes id."
             dest: volume_id
             type: str
-            nargs: "+"
           - name: "--force"
             help: "Force delete logical volume from the cluster."
             dest: force

--- a/simplyblock_cli/cli.py
+++ b/simplyblock_cli/cli.py
@@ -672,7 +672,7 @@ class CLIWrapper(CLIWrapperBase):
 
     def init_volume__delete(self, subparser):
         subcommand = self.add_sub_command(subparser, 'delete', 'Deletes a logical volume.')
-        subcommand.add_argument('volume_id', help='The logical volumes id or ids.', type=str, nargs='+')
+        subcommand.add_argument('volume_id', help='The logical volumes id.', type=str)
         subcommand.add_argument('--force', help='Force delete logical volume from the cluster.', dest='force', action='store_true')
 
     def init_volume__connect(self, subparser):

--- a/simplyblock_cli/clibase.py
+++ b/simplyblock_cli/clibase.py
@@ -596,9 +596,12 @@ class CLIWrapperBase:
     def volume__delete(self, sub_command, args):
         db = db_controller.DBController()
         try:
-            return lvol_controller.delete_lvol(db.get_lvol_by_id(args.volume_id), args.force)
+            lvol = db.get_lvol_by_id(args.volume_id)
         except KeyError:
             return False
+
+        lvol_controller.delete_lvol(lvol, args.force)
+        return True
 
     def volume__connect(self, sub_command, args):
         kwargs = {}

--- a/simplyblock_cli/clibase.py
+++ b/simplyblock_cli/clibase.py
@@ -594,7 +594,11 @@ class CLIWrapperBase:
         return lvol_controller.get_lvol(args.volume_id, args.json)
 
     def volume__delete(self, sub_command, args):
-        return lvol_controller.delete_lvol(args.volume_id, args.force)
+        db = db_controller.DBController()
+        try:
+            return lvol_controller.delete_lvol(db.get_lvol_by_id(args.volume_id), args.force)
+        except KeyError:
+            return False
 
     def volume__connect(self, sub_command, args):
         kwargs = {}

--- a/simplyblock_cli/clibase.py
+++ b/simplyblock_cli/clibase.py
@@ -594,9 +594,7 @@ class CLIWrapperBase:
         return lvol_controller.get_lvol(args.volume_id, args.json)
 
     def volume__delete(self, sub_command, args):
-        for id in args.volume_id:
-            force = args.force
-            return lvol_controller.delete_lvol(id, force)
+        return lvol_controller.delete_lvol(args.volume_id, args.force)
 
     def volume__connect(self, sub_command, args):
         kwargs = {}

--- a/simplyblock_core/controllers/lvol_controller.py
+++ b/simplyblock_core/controllers/lvol_controller.py
@@ -1243,43 +1243,38 @@ def _remove_lvol_subsys_from_node(lvol, rpc_client):
     return True
 
 
-def delete_lvol(lvol: LVol, force_delete: bool = False) -> bool:
+def delete_lvol(lvol: LVol, force_delete: bool = False) -> None:
     db_controller = DBController()
 
     # Block during restart Phase 5
+    snode = None
     try:
         snode = db_controller.get_storage_node_by_id(lvol.node_id)
         if snode.lvstore_status == "in_creation" and not force_delete:
-            logger.error(f"Cannot delete lvol {lvol.uuid}: node LVStore restart in progress")
-            return False
+            raise PreconditionError(f"Cannot delete lvol {lvol.uuid}: node LVStore restart in progress")
     except KeyError:
-        pass
+        if not force_delete:
+            raise PreconditionError(f"lvol node id not found: {lvol.node_id}")
 
     from simplyblock_core.controllers import migration_controller
     active_mig = migration_controller.get_active_migration_for_lvol(lvol.uuid)
-    if active_mig and not force_delete:
-        logger.error(f"Cannot delete lvol {lvol.uuid}: active migration {active_mig.uuid}")
-        return False
+    if active_mig:
+        raise PreconditionError(f"Cannot delete lvol {lvol.uuid}: active migration {active_mig.uuid}")
 
     if lvol.status == LVol.STATUS_RESTORING and not force_delete:
-        logger.error(f"Cannot delete lvol {lvol.uuid}: backup restore in progress")
-        return False
+        raise PreconditionError(f"Cannot delete lvol {lvol.uuid}: backup restore in progress")
+
     if lvol.status == LVol.STATUS_DELETED:
-        logger.error(f"lvol {lvol.uuid}: deleted already")
-        return False
+        raise PreconditionError(f"lvol {lvol.uuid}: deleted already")
 
     if lvol.status == LVol.STATUS_IN_DELETION:
         logger.info(f"lvol:{lvol.get_id()} status is in deletion")
         if not force_delete:
-            return True
+            return
 
     logger.debug(lvol)
-    try:
-        snode = db_controller.get_storage_node_by_id(lvol.node_id)
-    except KeyError:
+    if snode is None:
         logger.error(f"lvol node id not found: {lvol.node_id}")
-        if not force_delete:
-            return False
 
         lvol.remove(db_controller.kv_store)
 
@@ -1298,12 +1293,11 @@ def delete_lvol(lvol: LVol, force_delete: bool = False) -> bool:
                 pass # already removed
 
         logger.info("Done")
-        return True
+        return
 
     pool = db_controller.get_pool_by_id(lvol.pool_uuid)
     if pool.status == Pool.STATUS_INACTIVE:
-        logger.error("Pool is disabled")
-        return False
+        raise PreconditionError("Pool is disabled")
 
     # Persist deletion intent BEFORE any data-plane RPC. If the leader-side
     # delete then times out or errors (for example: SPDK back-pressure on
@@ -1325,9 +1319,8 @@ def delete_lvol(lvol: LVol, force_delete: bool = False) -> bool:
 
     if lvol.ha_type == 'single':
         ret = delete_lvol_from_node(lvol.get_id(), lvol.node_id, force=force_delete)
-        if not ret:
-            if not force_delete:
-                return False
+        if not ret and not force_delete:
+            raise RuntimeError("Failed to delete lvol from node")
 
     elif lvol.ha_type == "ha":
         from simplyblock_core.storage_node_ops import (
@@ -1400,9 +1393,11 @@ def delete_lvol(lvol: LVol, force_delete: bool = False) -> bool:
         success, actual_leader, result = execute_on_leader_with_failover(
             all_nodes, lvol.lvs_name, _delete_on_leader)
         if not success:
-            logger.error(f"Failed to delete lvol from leader: {result}")
+            msg = f"Failed to delete lvol from leader: {result}"
             if not force_delete:
-                return False
+                raise RuntimeError(msg)
+            else:
+                logger.warning(msg)
 
         # Step 2: Sync delete on non-leaders (leader op already completed)
         non_leaders = [n for n in all_nodes if actual_leader and n.get_id() != actual_leader.get_id()]
@@ -1470,7 +1465,6 @@ def delete_lvol(lvol: LVol, force_delete: bool = False) -> bool:
                 logger.exception("Failed to delete lvol key")
 
     logger.info("Done")
-    return True
 
 def connect_lvol_to_pool(lvol_id, node_id):
     db_controller = DBController()

--- a/simplyblock_core/controllers/lvol_controller.py
+++ b/simplyblock_core/controllers/lvol_controller.py
@@ -1243,17 +1243,8 @@ def _remove_lvol_subsys_from_node(lvol, rpc_client):
     return True
 
 
-def delete_lvol(id_or_name, force_delete=False):
+def delete_lvol(lvol: LVol, force_delete: bool = False) -> bool:
     db_controller = DBController()
-    try:
-        lvol = (
-                db_controller.get_lvol_by_id(id_or_name)
-                if utils.UUID_PATTERN.match(id_or_name) is not None
-                else db_controller.get_lvol_by_name(id_or_name)
-        )
-    except KeyError as e:
-        logger.error(e)
-        return False
 
     # Block during restart Phase 5
     try:

--- a/simplyblock_core/controllers/snapshot_controller.py
+++ b/simplyblock_core/controllers/snapshot_controller.py
@@ -11,6 +11,7 @@ from simplyblock_core.controllers import lvol_controller, snapshot_events, pool_
     migration_controller
 
 from simplyblock_core import utils
+from simplyblock_core.exceptions import PreconditionError
 from simplyblock_core.kms import create_kms_connection
 from simplyblock_core.kms._exceptions import KMSException
 from simplyblock_core.db_controller import DBController
@@ -626,7 +627,10 @@ def delete(snapshot_uuid, force_delete=False):
     try:
         base_lvol = db_controller.get_lvol_by_id(snap.lvol.get_id())
         if base_lvol and base_lvol.deleted is True:
-            lvol_controller.delete_lvol(base_lvol)
+            try:
+                lvol_controller.delete_lvol(base_lvol)
+            except (PreconditionError, RuntimeError):
+                logger.warning("Failed to delete volume", exc_info=True)
     except KeyError:
         pass
 

--- a/simplyblock_core/controllers/snapshot_controller.py
+++ b/simplyblock_core/controllers/snapshot_controller.py
@@ -626,7 +626,7 @@ def delete(snapshot_uuid, force_delete=False):
     try:
         base_lvol = db_controller.get_lvol_by_id(snap.lvol.get_id())
         if base_lvol and base_lvol.deleted is True:
-            lvol_controller.delete_lvol(base_lvol.get_id())
+            lvol_controller.delete_lvol(base_lvol)
     except KeyError:
         pass
 

--- a/simplyblock_core/storage_node_ops.py
+++ b/simplyblock_core/storage_node_ops.py
@@ -2313,7 +2313,7 @@ def remove_storage_node(node_id, force_remove=False, force_migrate=False):
                 # lvol_controller.migrate(lvol_id)
         elif force_remove:
             for lvol in lvols:
-                lvol_controller.delete_lvol(lvol.get_id(), True)
+                lvol_controller.delete_lvol(lvol, True)
         else:
             logger.warning("LVols found on the storage node, use --force-remove or --force-migrate")
             return False

--- a/simplyblock_core/storage_node_ops.py
+++ b/simplyblock_core/storage_node_ops.py
@@ -25,6 +25,7 @@ from simplyblock_core.controllers import lvol_controller, storage_events, snapsh
     device_controller, tasks_controller, health_controller, tcp_ports_events, qos_controller
 from simplyblock_core.controllers.host_auth import _reapply_allowed_hosts
 from simplyblock_core.db_controller import DBController
+from simplyblock_core.exceptions import PreconditionError
 from simplyblock_core.models.iface import IFace
 from simplyblock_core.models.job_schedule import JobSchedule
 from simplyblock_core.models.lvol_model import LVol
@@ -2313,7 +2314,10 @@ def remove_storage_node(node_id, force_remove=False, force_migrate=False):
                 # lvol_controller.migrate(lvol_id)
         elif force_remove:
             for lvol in lvols:
-                lvol_controller.delete_lvol(lvol, True)
+                try:
+                    lvol_controller.delete_lvol(lvol, True)
+                except (PreconditionError, RuntimeError):
+                    logger.warning("Failed to delete volume", exc_info=True)
         else:
             logger.warning("LVols found on the storage node, use --force-remove or --force-migrate")
             return False

--- a/simplyblock_web/api/v1/lvol.py
+++ b/simplyblock_web/api/v1/lvol.py
@@ -239,9 +239,14 @@ def delete_lvol(uuid):
     if pool.status == pool.STATUS_INACTIVE:
         return utils.get_response_error("Pool is disabled", 400)
 
-    ret = lvol_controller.delete_lvol(uuid)
+    try:
+        lvol_controller.delete_lvol(lvol)
+        return utils.get_response(True)
+    except PreconditionError as e:
+        return utils.get_response_error(str(e), 400)
+    except RuntimeError as e:
+        return utils.get_response_error(str(e), 500)
 
-    return utils.get_response(ret)
 
 
 @bp.route('/lvol/resize/<string:uuid>', methods=['PUT'])

--- a/simplyblock_web/api/v2/cluster/storage_pool/volume.py
+++ b/simplyblock_web/api/v2/cluster/storage_pool/volume.py
@@ -174,9 +174,9 @@ def update(cluster: Cluster, pool: StoragePool, volume: Volume, body: UpdatableL
 @instance_api.delete('/', name='clusters:storage-pools:volumes:delete', status_code=204, responses={204: {"content": None}})
 def delete(cluster: Cluster, pool: StoragePool, volume: Volume) -> Response:
     if volume.status == LVol.STATUS_DELETED:
-        return Response(status_code=404)
+        raise HTTPException(404, "Volume deleted")
 
-    if not lvol_controller.delete_lvol(volume.get_id()):
+    if not lvol_controller.delete_lvol(volume):
         raise ValueError('Failed to delete volume')
 
     return Response(status_code=204)

--- a/simplyblock_web/api/v2/cluster/storage_pool/volume.py
+++ b/simplyblock_web/api/v2/cluster/storage_pool/volume.py
@@ -176,9 +176,7 @@ def delete(cluster: Cluster, pool: StoragePool, volume: Volume) -> Response:
     if volume.status == LVol.STATUS_DELETED:
         raise HTTPException(404, "Volume deleted")
 
-    if not lvol_controller.delete_lvol(volume):
-        raise ValueError('Failed to delete volume')
-
+    lvol_controller.delete_lvol(volume)
     return Response(status_code=204)
 
 

--- a/tests/test_delete_lvol_intent.py
+++ b/tests/test_delete_lvol_intent.py
@@ -168,11 +168,11 @@ class TestDeleteLvolIntentPersisted(unittest.TestCase):
         lvol = _make_lvol(status=LVol.STATUS_ONLINE, ha_type="ha")
         mod, _db, _exec, _writes = self._patch(lvol, leader_op_fails=True)
 
-        result = mod.delete_lvol("lvol-uuid-1", force_delete=False)
+        with self.assertRaises(RuntimeError):
+            mod.delete_lvol(lvol, force_delete=False)
 
-        # API contract is unchanged (False on internal failure); the
-        # important invariant is the persisted state.
-        self.assertFalse(result)
+        # Exception signals failure to caller; the important invariant is
+        # the persisted state — the reconciler path relies on IN_DELETION.
         self.assertEqual(lvol.status, LVol.STATUS_IN_DELETION,
                          "lvol must stay in_deletion when leader op fails — "
                          "this is what enables the reconciler path")
@@ -182,9 +182,8 @@ class TestDeleteLvolIntentPersisted(unittest.TestCase):
         lvol = _make_lvol(status=LVol.STATUS_ONLINE, ha_type="ha")
         mod, _db, _exec, _writes = self._patch(lvol, leader_op_fails=False)
 
-        result = mod.delete_lvol("lvol-uuid-1", force_delete=False)
+        mod.delete_lvol(lvol, force_delete=False)  # must not raise
 
-        self.assertTrue(result)
         self.assertEqual(lvol.status, LVol.STATUS_IN_DELETION)
 
     def test_status_set_before_leader_op_call(self):
@@ -206,7 +205,8 @@ class TestDeleteLvolIntentPersisted(unittest.TestCase):
             return (False, _make_node(), "fail")
 
         exec_mock.side_effect = _exec_capture
-        mod.delete_lvol("lvol-uuid-1", force_delete=False)
+        with self.assertRaises(RuntimeError):
+            mod.delete_lvol(lvol, force_delete=False)
 
         self.assertEqual(seen_status.get("status_at_call_time"),
                          LVol.STATUS_IN_DELETION,
@@ -229,9 +229,8 @@ class TestDeleteLvolIntentPersisted(unittest.TestCase):
         lvol = _make_lvol(status=LVol.STATUS_IN_DELETION, ha_type="ha")
         mod, _db, exec_mock, _writes = self._patch(lvol, leader_op_fails=False)
 
-        result = mod.delete_lvol("lvol-uuid-1", force_delete=False)
+        mod.delete_lvol(lvol, force_delete=False)  # must not raise
 
-        self.assertTrue(result)
         exec_mock.assert_not_called()  # short-circuit before leader op
 
     def test_status_set_for_single_ha_type_too(self):
@@ -244,9 +243,8 @@ class TestDeleteLvolIntentPersisted(unittest.TestCase):
 
         # delete_lvol_from_node is patched to return True in our setup,
         # so the single-path completes successfully.
-        result = mod.delete_lvol("lvol-uuid-1", force_delete=False)
+        mod.delete_lvol(lvol, force_delete=False)  # must not raise
 
-        self.assertTrue(result)
         self.assertEqual(lvol.status, LVol.STATUS_IN_DELETION)
 
 

--- a/tests/test_delete_lvol_subsystem_order.py
+++ b/tests/test_delete_lvol_subsystem_order.py
@@ -197,7 +197,7 @@ class TestSubsystemDeleteOrder(unittest.TestCase):
         for p in self._patches:
             p.start()
 
-        return mod, events, primary, secondary, tertiary
+        return mod, events, lvol, primary, secondary, tertiary
 
     def tearDown(self):
         for p in getattr(self, "_patches", []):
@@ -205,10 +205,9 @@ class TestSubsystemDeleteOrder(unittest.TestCase):
 
     def test_all_online_order_tertiary_secondary_primary_sleep_leader(self):
         """All three peers online: order must be T -> S -> P -> sleep(2) -> leader_op."""
-        mod, events, _p, _s, _t = self._patch()
+        mod, events, lvol, _p, _s, _t = self._patch()
 
-        ok = mod.delete_lvol("lvol-uuid-1", force_delete=False)
-        self.assertTrue(ok)
+        mod.delete_lvol(lvol, force_delete=False)
 
         # Filter out anything other than the four signal events. (The
         # leader_op stub doesn't run delete_lvol_from_node, so there are
@@ -224,11 +223,10 @@ class TestSubsystemDeleteOrder(unittest.TestCase):
     def test_tertiary_offline_skipped(self):
         """If tertiary is not ONLINE its subsystem delete is skipped, but
         secondary + primary still run, sleep still fires after primary."""
-        mod, events, _p, _s, _t = self._patch(
+        mod, events, lvol, _p, _s, _t = self._patch(
             tertiary_status=StorageNode.STATUS_DOWN)
 
-        ok = mod.delete_lvol("lvol-uuid-1", force_delete=False)
-        self.assertTrue(ok)
+        mod.delete_lvol(lvol, force_delete=False)
 
         self.assertEqual(events, [
             ("subsystem_delete", "node-secondary"),
@@ -239,11 +237,10 @@ class TestSubsystemDeleteOrder(unittest.TestCase):
 
     def test_secondary_in_restart_skipped(self):
         """in_restart status is a skip case per the spec."""
-        mod, events, _p, _s, _t = self._patch(
+        mod, events, lvol, _p, _s, _t = self._patch(
             secondary_status=StorageNode.STATUS_RESTARTING)
 
-        ok = mod.delete_lvol("lvol-uuid-1", force_delete=False)
-        self.assertTrue(ok)
+        mod.delete_lvol(lvol, force_delete=False)
 
         self.assertEqual(events, [
             ("subsystem_delete", "node-tertiary"),
@@ -256,11 +253,10 @@ class TestSubsystemDeleteOrder(unittest.TestCase):
         """If the primary is not ONLINE we skip its subsystem delete AND
         the sleep — there is nothing to drain on a node that's already
         gone."""
-        mod, events, _p, _s, _t = self._patch(
+        mod, events, lvol, _p, _s, _t = self._patch(
             primary_status=StorageNode.STATUS_UNREACHABLE)
 
-        ok = mod.delete_lvol("lvol-uuid-1", force_delete=False)
-        self.assertTrue(ok)
+        mod.delete_lvol(lvol, force_delete=False)
 
         # No sleep event, no primary subsystem delete.
         self.assertEqual(events, [
@@ -272,8 +268,8 @@ class TestSubsystemDeleteOrder(unittest.TestCase):
     def test_only_one_sleep_total(self):
         """Even with all three peers online, there must be exactly one
         drain sleep and it must land immediately before the leader op."""
-        mod, events, _p, _s, _t = self._patch()
-        mod.delete_lvol("lvol-uuid-1", force_delete=False)
+        mod, events, lvol, _p, _s, _t = self._patch()
+        mod.delete_lvol(lvol, force_delete=False)
 
         sleeps = [e for e in events if e[0] == "sleep"]
         self.assertEqual(len(sleeps), 1)
@@ -287,8 +283,8 @@ class TestSubsystemDeleteOrder(unittest.TestCase):
     def test_rpc_called_with_short_timeout_and_retry(self):
         """The pre-leader rpc_client must be built with (timeout=5, retry=2)
         so a hung peer doesn't block the user-facing delete request."""
-        mod, _events, primary, secondary, tertiary = self._patch()
-        mod.delete_lvol("lvol-uuid-1", force_delete=False)
+        mod, _events, lvol, primary, secondary, tertiary = self._patch()
+        mod.delete_lvol(lvol, force_delete=False)
 
         for n in (primary, secondary, tertiary):
             n.rpc_client.assert_called_with(timeout=5, retry=2)


### PR DESCRIPTION
This converts lvol delete error handling to exceptions. This includes a fix for a CLI bug that caused deletion of multiple volumes to silently ignore any but the first volume. It also changes the signature s.t. the lvol is passed by value instead of ID, avoiding duplicate lookups, since all but one call-sites already retrieved the lvol from the database.

The motivation for this PR was a cleaner error handling through the API when the request was rejected due to an ongoing migration.