### PR TITLE
register missing clusters:backups:detail route

### DIFF
--- a/simplyblock_web/api/v2/_dependencies.py
+++ b/simplyblock_web/api/v2/_dependencies.py
@@ -4,7 +4,7 @@ from uuid import UUID
 from fastapi import Depends, HTTPException
 
 from simplyblock_core.db_controller import DBController
-from simplyblock_core.models.backup import BackupPolicy
+from simplyblock_core.models.backup import Backup as BackupModel, BackupPolicy
 from simplyblock_core.models.cluster import Cluster as ClusterModel
 from simplyblock_core.models.job_schedule import JobSchedule
 from simplyblock_core.models.lvol_migration import LVolMigration
@@ -113,6 +113,19 @@ def _lookup_management_node(management_node_id: UUID) -> MgmtNode:
 
 
 ManagementNode = Annotated[MgmtNode, Depends(_lookup_management_node)]
+
+
+def _lookup_backup(backup_id: UUID, cluster: Cluster) -> BackupModel:
+    try:
+        backup = _db.get_backup_by_id(str(backup_id))
+    except KeyError as e:
+        raise HTTPException(404, str(e))
+    if backup.cluster_id != cluster.get_id():
+        raise HTTPException(404, f'Backup {backup_id} not found')
+    return backup
+
+
+BackupResource = Annotated[BackupModel, Depends(_lookup_backup)]
 
 
 def _lookup_backup_policy(policy_id: UUID, cluster: Cluster) -> BackupPolicy:

--- a/simplyblock_web/api/v2/cluster/backup.py
+++ b/simplyblock_web/api/v2/cluster/backup.py
@@ -9,7 +9,7 @@ from simplyblock_core.controllers import backup_controller
 from simplyblock_core.models.cluster import Cluster as ClusterModel
 from simplyblock_core.models.lvol_model import LVol
 
-from .._dependencies import Cluster, Policy
+from .._dependencies import BackupResource, Cluster, Policy
 from .._dtos import BackupDTO, BackupPolicyDTO
 from ..util import CreationResponseFormatParameter, creation_response
 
@@ -40,7 +40,7 @@ def create_backup(request: Request, cluster: Cluster, parameters: _BackupSnapsho
         request, response_format,
         entity_id=UUID(backup_id),
         route_name='clusters:backups:detail',
-        route_kwargs={'cluster_id': UUID(cluster.get_id())},
+        route_kwargs={'cluster_id': UUID(cluster.get_id()), 'backup_id': UUID(backup_id)},
         get_full=lambda id: BackupDTO.from_model(db.get_backup_by_id(str(id))),
         extra_headers={'X-Backup-Id': backup_id},  # For backwards compatibility
     )
@@ -218,3 +218,14 @@ def detach_policy(cluster: Cluster, policy: Policy, parameters: _AttachParams) -
 
 
 api.include_router(policy_api, prefix='/backup-policies')
+
+
+instance_api = APIRouter(prefix='/{backup_id}')
+
+
+@instance_api.get('/', name='clusters:backups:detail')
+def get_backup(cluster: Cluster, backup: BackupResource) -> BackupDTO:
+    return BackupDTO.from_model(backup)
+
+
+api.include_router(instance_api)


### PR DESCRIPTION
PR #1094 refactored `create_backup` to use the shared `creation_response()` helper, which generates a `Location` header via `url_path_for(route_name, **kwargs)`. It referenced `route_name='clusters:backups:detail'` but never
registered the matching `GET /{backup_id}` endpoint.
