### PR TITLE
Fix type check errors

### DIFF
--- a/simplyblock_core/controllers/device_controller.py
+++ b/simplyblock_core/controllers/device_controller.py
@@ -945,10 +945,10 @@ def add_device(device_id, add_migration_task=True):
     device_obj.cluster_device_order = dev_order
     logger.info("Setting device online")
     device_obj.status = NVMeDevice.STATUS_ONLINE
-    _atomic_device_set(
-        db_controller, snode.get_id(), device_id,
-        lambda d, o=dev_order: (setattr(d, "cluster_device_order", o),
-                                setattr(d, "status", NVMeDevice.STATUS_ONLINE)))
+    def _apply_online(d, o=dev_order):
+        d.cluster_device_order = o
+        d.status = NVMeDevice.STATUS_ONLINE
+    _atomic_device_set(db_controller, snode.get_id(), device_id, _apply_online)
     device_events.device_create(device_obj)
 
     logger.info("Make other nodes connect to the node devices")

--- a/simplyblock_core/services/lvol_monitor.py
+++ b/simplyblock_core/services/lvol_monitor.py
@@ -62,10 +62,10 @@ def set_snapshot_health_check(snap, health_check_status):
     if snap.health_check == health_check_status:
         return
     now = str(datetime.now())
-    db.atomic_update(
-        snap,
-        lambda s, v=health_check_status, t=now: (setattr(s, "health_check", v),
-                                                 setattr(s, "updated_at", t)))
+    def _apply_health_check(s, v=health_check_status, t=now):
+        s.health_check = v
+        s.updated_at = t
+    db.atomic_update(snap, _apply_health_check)
 
 
 lvol_del_start_time = 0.0


### PR DESCRIPTION
The type checker complains about the lambda return value being used. Introducing inline functions to bundle the transactions avoids this issue.