### PR TITLE
Fix incompatibility lvol deletion tests

### DIFF
--- a/simplyblock_cli/clibase.py
+++ b/simplyblock_cli/clibase.py
@@ -600,7 +600,7 @@ class CLIWrapperBase:
         except KeyError:
             return False
 
-        lvol_controller.delete_lvol(lvol, args.force)
+        lvol_controller.delete_lvol(lvol, force_delete=args.force)
         return True
 
     def volume__connect(self, sub_command, args):

--- a/simplyblock_core/controllers/lvol_controller.py
+++ b/simplyblock_core/controllers/lvol_controller.py
@@ -1243,7 +1243,7 @@ def _remove_lvol_subsys_from_node(lvol, rpc_client):
     return True
 
 
-def delete_lvol(lvol: LVol, force_delete: bool = False) -> None:
+def delete_lvol(lvol: LVol, *, force_delete: bool = False) -> None:
     db_controller = DBController()
 
     # Block during restart Phase 5

--- a/simplyblock_core/services/lvol_monitor.py
+++ b/simplyblock_core/services/lvol_monitor.py
@@ -274,7 +274,7 @@ def check_node(snode, all_lvols):
                     f"LVol {lvol.get_id()} stuck in {LVol.STATUS_IN_CREATION} "
                     f"since {lvol.create_dt}; cleaning up orphaned create")
                 try:
-                    lvol_controller.delete_lvol(lvol.get_id(), force_delete=True)
+                    lvol_controller.delete_lvol(lvol, force_delete=True)
                 except Exception as e:
                     logger.error(f"Failed to clean up orphaned in_creation lvol {lvol.get_id()}: {e}")
             continue

--- a/simplyblock_core/services/snapshot_replication.py
+++ b/simplyblock_core/services/snapshot_replication.py
@@ -249,7 +249,7 @@ def process_snap_replicate_finish(task, snapshot):
     # delete lvol object
     remote_lv.bdev_stack = []
     remote_lv.write_to_db()
-    lvol_controller.delete_lvol(remote_lv.get_id(), True)
+    lvol_controller.delete_lvol(remote_lv, force_delete=True)
     remote_lv.remove(db.kv_store)
     snapshot_events.replication_task_finished(snapshot)
     delete_last_snapshot_if_needed(task, snapshot.lvol)
@@ -293,7 +293,7 @@ def task_runner(task: JobSchedule):
 
         remote_lv = db.get_lvol_by_id(task.function_params["remote_lvol_id"])
         snode.rpc_client().bdev_nvme_detach_controller(remote_lv.top_bdev)
-        lvol_controller.delete_lvol(remote_lv.get_id(), True)
+        lvol_controller.delete_lvol(remote_lv, force_delete=True)
 
         return True
 

--- a/simplyblock_core/storage_node_ops.py
+++ b/simplyblock_core/storage_node_ops.py
@@ -2316,7 +2316,7 @@ def remove_storage_node(node_id, force_remove=False, force_migrate=False):
         elif force_remove:
             for lvol in lvols:
                 try:
-                    lvol_controller.delete_lvol(lvol, True)
+                    lvol_controller.delete_lvol(lvol, force_delete=True)
                 except (PreconditionError, RuntimeError):
                     logger.warning("Failed to delete volume", exc_info=True)
         else:

--- a/tests/ftt2/operation_runner.py
+++ b/tests/ftt2/operation_runner.py
@@ -183,8 +183,10 @@ class OperationRunner:
         """Delete a volume via lvol_controller.delete_lvol()."""
         def _do():
             from simplyblock_core.controllers import lvol_controller
-            result = lvol_controller.delete_lvol(lvol_id)
-            self._result.success = bool(result)
+            from simplyblock_core.db_controller import DBController
+            lvol = DBController().get_lvol_by_id(lvol_id)
+            lvol_controller.delete_lvol(lvol)
+            self._result.success = True
 
         self.start(_do)
         return self

--- a/tests/ftt2/test_restart_concurrent_ops.py
+++ b/tests/ftt2/test_restart_concurrent_ops.py
@@ -154,8 +154,8 @@ class StressRunner:
                 elif op == "delete" and created_lvols:
                     from simplyblock_core.controllers import lvol_controller
                     lvol = created_lvols.pop(random.randrange(len(created_lvols)))
-                    result = lvol_controller.delete_lvol(lvol.uuid, force_delete=True)
-                    self._record("delete", bool(result), t0, time.time(), lvol.uuid)
+                    lvol_controller.delete_lvol(lvol, force_delete=True)
+                    self._record("delete", True, t0, time.time(), lvol.uuid)
 
                 elif op == "resize" and created_lvols:
                     from simplyblock_core.controllers import lvol_controller

--- a/tests/migration/test_complex_tree.py
+++ b/tests/migration/test_complex_tree.py
@@ -32,7 +32,10 @@ Tests:
 
 import time
 
+import pytest
+
 from simplyblock_core.controllers import migration_controller, lvol_controller, snapshot_controller
+from simplyblock_core.exceptions import PreconditionError
 from simplyblock_core.models.lvol_migration import LVolMigration
 from simplyblock_core.models.storage_node import StorageNode
 
@@ -390,7 +393,7 @@ class TestConcurrentIndependentOperations:
         _seed_lvol(mock_src_server, new_lvol, ctx.node("src"))
 
         # Delete the independent lvol l_ind (not involved in any migration)
-        lvol_controller.delete_lvol(ctx.lvol_uuid("l_ind"))
+        lvol_controller.delete_lvol(ctx.lvol("l_ind"))
         # Must not be blocked by the l3 migration
         # (may fail for RPC reasons but not for migration protection)
 
@@ -471,9 +474,8 @@ class TestMigrationProtection:
         assert m.is_active()
 
         # Try to delete l2 — must be blocked
-        result = lvol_controller.delete_lvol(ctx.lvol_uuid("l2"))
-        assert result is False, \
-            "Deleting a volume with an active migration should be blocked"
+        with pytest.raises(PreconditionError, match="active migration"):
+            lvol_controller.delete_lvol(ctx.lvol("l2"))
 
         run_migration_task(mig_id, max_steps=2000, step_sleep=0.02)
 


### PR DESCRIPTION
The recent migration changes and the lvol-deletion change were not compatible with each other and introduced faults. This change adapts the changes to play nice.