### PR TITLE
prevent lvol monitor from handling states for lvol restore

### DIFF
--- a/simplyblock_core/services/lvol_monitor.py
+++ b/simplyblock_core/services/lvol_monitor.py
@@ -253,6 +253,10 @@ def check_node(snode, all_lvols):
         if lvol.node_id != snode.get_id():
             continue
 
+        if lvol.status in (LVol.STATUS_RESTORING, LVol.STATUS_RESTORE_FAILED):
+            # tasks_runner_backup.py owns status transitions for these states
+            continue
+
         if lvol.status == LVol.STATUS_IN_CREATION:
             # A create that died (process killed) between writing the
             # IN_CREATION record and the final ONLINE transition leaves a


### PR DESCRIPTION
The lvol monitor runs periodic health checks on all volumes and promotes any healthy volume to online. This works correctly for normal volumes, but caused a silent data corruption bug for volumes undergoing S3 restore

When a backup restore starts, the volume's bdev is fully registered in SPDK and its NVMe subsystem is live. So health checks pass immediately. Even though the S3 data transfer hasn't finished yet.

