### PR TITLE
fix(restart): retry distrib (re)creation on stale cluster map, else abort

### DIFF
--- a/simplyblock_core/storage_node_ops.py
+++ b/simplyblock_core/storage_node_ops.py
@@ -7039,15 +7039,52 @@ def create_lvstore(snode, ndcs, npcs, distr_bs, distr_chunk_bs, page_size_in_blo
 
 
 
+# Seconds to wait before the single retry of a failed distrib (re)creation,
+# giving the control plane time to reconcile a peer that went offline mid-restart
+# so the rebuilt cluster map no longer references its devices as online.
+_DISTR_RECREATE_RETRY_DELAY_SEC = 5
+
+
 def _create_bdev_stack(snode, lvstore_stack=None, primary_node=None):
+    # Per-distrib creation outcome, keyed by bdev name. Threads write their own
+    # key (distinct keys -> GIL-safe), the main loop reads after join.
+    distr_results: dict = {}
+
     def _create_distr(snode, name, params):
-        try:
-            rpc_client.bdev_distrib_create(**params)
-        except Exception:
-            logger.error("Failed to create bdev distrib")
-        ret = distr_controller.send_cluster_map_to_distr(snode, name)
-        if not ret:
-            logger.error("Failed to send cluster map")
+        # If a peer node goes offline at the exact moment a distrib is
+        # (re)created, the cluster map can be briefly stale -- it still flags
+        # that peer's devices as online -- and bdev_distrib_create (or the
+        # subsequent map push) fails. That is transient: once the control plane
+        # marks the departed devices offline, a freshly built map succeeds. So
+        # try once more (send_cluster_map_to_distr rebuilds the map from the
+        # current DB view each call) before giving up. A failure that survives
+        # the retry is recorded so the caller aborts the restart -- the standard
+        # unrecoverable-error path -- instead of completing on a broken distrib.
+        for attempt in range(2):
+            if attempt > 0:
+                # Give the control plane a moment to reconcile the departed
+                # node, then clear any half-created distrib before retrying.
+                time.sleep(_DISTR_RECREATE_RETRY_DELAY_SEC)
+                try:
+                    rpc_client.bdev_distrib_delete(name)
+                except Exception:
+                    pass
+            try:
+                rpc_client.bdev_distrib_create(**params)
+                if distr_controller.send_cluster_map_to_distr(snode, name):
+                    distr_results[name] = True
+                    return
+                logger.error(
+                    "Failed to send cluster map to distrib %s (attempt %d/2)",
+                    name, attempt + 1)
+            except Exception as e:
+                logger.error(
+                    "Failed to create bdev distrib %s (attempt %d/2): %s",
+                    name, attempt + 1, e)
+        distr_results[name] = False
+
+    def _distr_failures():
+        return [n for n, ok in distr_results.items() if not ok]
 
     rpc_client = snode.rpc_client()
     db_controller = DBController()
@@ -7100,6 +7137,14 @@ def _create_bdev_stack(snode, lvstore_stack=None, primary_node=None):
             if thread_list:
                 for t in thread_list:
                     t.join()
+            # Never assemble the raid on top of distribs that failed to
+            # (re)create after the retry -- that is the unrecoverable case the
+            # restart must abort on.
+            failed = _distr_failures()
+            if failed:
+                if created_bdevs:
+                    _remove_bdev_stack(created_bdevs[::-1], rpc_client)
+                return False, f"Failed to (re)create distrib(s) after retry: {failed}"
             distribs_list = bdev["distribs_list"]
             strip_size_kb = params["strip_size_kb"]
             ret = rpc_client.bdev_raid_create(name, distribs_list, strip_size_kb=strip_size_kb)
@@ -7120,6 +7165,13 @@ def _create_bdev_stack(snode, lvstore_stack=None, primary_node=None):
     if thread_list:
         for t in thread_list:
             t.join()
+    # Catch distrib failures for stacks without a trailing raid (the raid
+    # branch checks before assembling its raid; this covers everything else).
+    failed = _distr_failures()
+    if failed:
+        if created_bdevs:
+            _remove_bdev_stack(created_bdevs[::-1], rpc_client)
+        return False, f"Failed to (re)create distrib(s) after retry: {failed}"
     return True, None
 
 

--- a/tests/test_distrib_recreate_retry.py
+++ b/tests/test_distrib_recreate_retry.py
@@ -1,0 +1,103 @@
+# coding=utf-8
+"""
+test_distrib_recreate_retry.py
+
+Regression test for the restart-time distrib (re)creation race:
+
+If a peer node goes offline at the exact moment a restarting node rebuilds its
+lvstore stack, the cluster map is briefly stale (the departed node's devices
+still flagged online) and bdev_distrib_create / the cluster-map push fails.
+
+Old behavior: _create_bdev_stack._create_distr swallowed the failure (logged
+only) and the loop marked the distrib branch ret=True unconditionally, so the
+restart "completed" on a broken distrib.
+
+New behavior:
+  - the failed distrib is retried exactly once (with a freshly built map);
+  - if the retry succeeds, the stack build succeeds;
+  - if the retry also fails, _create_bdev_stack returns (False, err) and rolls
+    back, so recreate_lvstore aborts the restart -> standard auto-restart.
+
+All external dependencies (RPC, DBController, cluster-map push, sleep) mocked.
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from simplyblock_core.models.storage_node import StorageNode
+
+
+def _stack():
+    return [
+        {"type": "bdev_distr", "name": "distrib_1", "params": {"vuid": 1}},
+        {"type": "bdev_raid", "name": "raid_1", "params": {"strip_size_kb": 64},
+         "distribs_list": ["distrib_1"]},
+    ]
+
+
+def _snode():
+    n = StorageNode()
+    n.uuid = "snode-1"
+    n.cluster_id = "cluster-1"
+    n.enable_ha_jm = False
+    n.ha_jm_count = 4
+    n.jm_device = MagicMock(jm_bdev="jm0")
+    n.distrib_cpu_cores = []
+    n.lvstore_stack = _stack()
+    return n
+
+
+@patch("simplyblock_core.storage_node_ops.time.sleep", return_value=None)
+@patch("simplyblock_core.storage_node_ops.distr_controller")
+@patch("simplyblock_core.storage_node_ops.DBController")
+class TestDistribRecreateRetry(unittest.TestCase):
+
+    def _wire(self, MockDB, mock_distr, *, create_effects, map_effects=None):
+        import simplyblock_core.storage_node_ops as ops
+        self.ops = ops
+        cluster = MagicMock(full_page_unmap=False)
+        MockDB.return_value.get_cluster_by_id.return_value = cluster
+        rpc = MagicMock()
+        rpc.get_bdevs.return_value = []
+        rpc.bdev_distrib_create.side_effect = create_effects
+        rpc.bdev_raid_create.return_value = True
+        snode = _snode()
+        snode.rpc_client = MagicMock(return_value=rpc)
+        mock_distr.send_cluster_map_to_distr.side_effect = (
+            map_effects if map_effects is not None else lambda *a, **k: True)
+        return ops, snode, rpc
+
+    def test_retry_succeeds_after_stale_map_failure(self, MockDB, mock_distr, _sleep):
+        # First create raises (stale map), second succeeds.
+        ops, snode, rpc = self._wire(
+            MockDB, mock_distr, create_effects=[Exception("stale map"), None])
+        ok, err = ops._create_bdev_stack(snode)
+        assert ok is True and err is None, (ok, err)
+        assert rpc.bdev_distrib_create.call_count == 2      # initial + retry
+        rpc.bdev_raid_create.assert_called_once()           # raid built on good distrib
+
+    def test_map_push_failure_then_retry_succeeds(self, MockDB, mock_distr, _sleep):
+        # Creation succeeds but the first cluster-map push fails, second works.
+        ops, snode, rpc = self._wire(
+            MockDB, mock_distr, create_effects=[None, None],
+            map_effects=[False, True])
+        ok, err = ops._create_bdev_stack(snode)
+        assert ok is True and err is None, (ok, err)
+        assert rpc.bdev_distrib_create.call_count == 2
+        rpc.bdev_raid_create.assert_called_once()
+
+    def test_abort_when_retry_also_fails(self, MockDB, mock_distr, _sleep):
+        # Both attempts raise -> propagate failure, no raid, rollback.
+        ops, snode, rpc = self._wire(
+            MockDB, mock_distr,
+            create_effects=[Exception("stale map"), Exception("still stale")])
+        ok, err = ops._create_bdev_stack(snode)
+        assert ok is False
+        assert "distrib" in err.lower(), err
+        rpc.bdev_raid_create.assert_not_called()            # never built on broken distrib
+        assert rpc.bdev_distrib_create.call_count == 2      # tried exactly once more
+        rpc.bdev_distrib_delete.assert_called()             # cleanup (retry and/or rollback)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem
During a node restart, if a peer node goes offline at the exact moment the restarting node rebuilds its lvstore stack, the cluster map is briefly stale (the departed node's devices still flagged online) and `bdev_distrib_create` / the cluster-map push fails. `_create_bdev_stack._create_distr` **swallowed** that failure (logged only) and the loop marked the distrib branch successful regardless — so the restart completed on a broken distrib.

## Fix
- Track each distrib's creation outcome.
- Retry a failed distrib **exactly once** (short delay for the CP to reconcile the departed node, delete any half-created distrib, rebuild a fresh map).
- If the retry also fails, `_create_bdev_stack` rolls back and returns an error — it never assembles the raid on top of a broken distrib — so `recreate_lvstore` aborts the restart and the task runner queues an **auto-restart** (the standard unrecoverable-error path), which succeeds once the map is fresh.

## Tests
`tests/test_distrib_recreate_retry.py`: retry-succeeds-after-stale-map, map-push-failure-then-retry, abort-when-retry-also-fails (asserts no raid built + rollback). Verified against the restart/recreate/dual-FT suites (80 passed / 6 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)