### PR TITLE
Remove user-agent from API log

### DIFF
--- a/simplyblock_web/app.py
+++ b/simplyblock_web/app.py
@@ -28,7 +28,7 @@ access_logger = logging.getLogger('simplyblock_web.access')
 _access_handler = logging.StreamHandler(stream=sys.stdout)
 _access_handler.setFormatter(logging.Formatter(
     '%(asctime)s %(levelname)s %(client_ip)s'
-    ' "%(message)s" %(status_code)s %(request_size)s %(response_size)s %(duration_ms).2fms "%(user_agent)s"'
+    ' "%(message)s" %(status_code)s %(request_size)s %(response_size)s %(duration_ms).2fms'
 ))
 access_logger.addHandler(_access_handler)
 access_logger.propagate = False
@@ -40,7 +40,6 @@ core_utils.init_sentry_sdk()
 class AccessLogMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next):
         client_ip = request.client.host if request.client else '-'
-        user_agent = request.headers.get('user-agent', '-')
         request_size = request.headers.get('content-length', '-')
 
         path = request.url.path
@@ -59,7 +58,6 @@ class AccessLogMiddleware(BaseHTTPMiddleware):
             path,
             extra={
                 'client_ip': client_ip,
-                'user_agent': user_agent,
                 'request_size': request_size,
                 'status_code': response.status_code,
                 'response_size': response_size,


### PR DESCRIPTION
This was introduces to distinguish CSI and operator clients, but those both use the same user agent. The IP is probably a better discriminator.