### PR TITLE
Restore compatibility with Python 3.9

### DIFF
--- a/.github/workflows/python-checks.yml
+++ b/.github/workflows/python-checks.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.12'
+        python-version: '3.9'
         cache: 'pip'
 
     - name: Checking cli.py status
@@ -46,7 +46,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.12'
+        python-version: '3.9'
         cache: 'pip'
 
     - name: Install linter
@@ -66,7 +66,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.12'
+        python-version: '3.9'
         cache: 'pip'
 
     - name: Install type checker

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,11 +16,10 @@ boto3
 jinja2
 argcomplete
 jc
-sentry-sdk
 prometheus-client
 ec2-metadata
 flask-swagger-ui
-sentry-sdk[flask]
+sentry-sdk[flask]>=1.40
 flask-openapi3
 jsonschema
 fastapi

--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,7 @@ console_scripts = list(set(console_scripts))
 setup(
     name=COMMAND_NAME,
     version=VERSION,
-    requires_python='>= 3.13',
+    requires_python='>= 3.9',
     packages=find_packages(exclude=["e2e*"]),
     url='https://www.simplyblock.io/',
     author='Hamdy',

--- a/simplyblock_core/cluster_ops.py
+++ b/simplyblock_core/cluster_ops.py
@@ -260,7 +260,7 @@ def create_cluster(blk_size, page_size_in_blocks, cli_pass,
     scripts.install_deps(mode)
     logger.info("Installing dependencies > Done")
 
-    db_connection: SecretStr | None = None
+    db_connection: t.Optional[SecretStr] = None
     if mode == "docker":
         if not ifname:
             ifname = "eth0"

--- a/simplyblock_core/services/snapshot_replication.py
+++ b/simplyblock_core/services/snapshot_replication.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 import time
 import uuid
+from typing import Optional
 
 from simplyblock_core import constants, db_controller, utils
 from simplyblock_core.controllers import lvol_controller, snapshot_events, snapshot_controller
@@ -154,8 +155,8 @@ def process_snap_replicate_finish(task, snapshot):
         replicate_as_snap_instance = task.function_params["replicate_as_snap_instance"]
     else:
         replicate_as_snap_instance = False
-    target_prev_snap: dict | None = None
-    _prev_snap_for_db: SnapShot | None = None
+    target_prev_snap: Optional[dict] = None
+    _prev_snap_for_db: Optional[SnapShot] = None
     if replicate_to_source:
         org_snap = db.get_snapshot_by_id(snapshot.snap_ref_id)
         try:

--- a/simplyblock_core/services/tasks_runner_lvol_migration.py
+++ b/simplyblock_core/services/tasks_runner_lvol_migration.py
@@ -1925,7 +1925,7 @@ def _handle_cleanup_target(migration, tgt_node, tgt_rpc, src_rpc=None):
 
         # Derive the migration bdev name in case it was pre-created but not yet
         # recorded in transfer_context (i.e. failure before LVOL_MIGRATE saved ctx).
-        _pre_nqn: str | None = None
+        _pre_nqn: Optional[str] = None
         try:
             _lvol = db.get_lvol_by_id(migration.lvol_id)
             _pre_bdev = f"{tgt_node.lvstore}/{_lvol.lvol_bdev}{_MIGRATION_BDEV_SUFFIX}"

--- a/simplyblock_core/snode_client.py
+++ b/simplyblock_core/snode_client.py
@@ -2,6 +2,7 @@ import json
 
 import requests
 import logging
+from typing import Optional
 
 from pydantic import SecretStr
 from requests.adapters import HTTPAdapter
@@ -116,8 +117,8 @@ class SNodeClient:
         return self._request("POST", "recalculate_cores_distribution", params)
 
     def spdk_process_start(self, l_cores, spdk_mem, spdk_image=None, spdk_debug=None, cluster_ip=None,
-                           fdb_connection: SecretStr | None = None, namespace=None, server_ip=None, rpc_port=None,
-                           rpc_username=None, rpc_password: SecretStr | None = None, multi_threading_enabled=False, timeout=0, ssd_pcie=None,
+                           fdb_connection: Optional[SecretStr] = None, namespace=None, server_ip=None, rpc_port=None,
+                           rpc_username=None, rpc_password: Optional[SecretStr] = None, multi_threading_enabled=False, timeout=0, ssd_pcie=None,
                            total_mem=None, system_mem=None, cluster_mode=None, socket=0, firewall_port=0, cluster_id=None,
                            spdk_proxy_image=None):
         params = {

--- a/simplyblock_core/utils/pci.py
+++ b/simplyblock_core/utils/pci.py
@@ -49,7 +49,7 @@ def list_devices(*, driver_name: Optional[str] = None, device_class: Optional[by
                 name
                 for device
                 in PCI_DEVICES.iterdir()
-                if int((device / 'class').read_text(), 16).to_bytes(3) == device_class
+                if int((device / 'class').read_text(), 16).to_bytes(3, 'big') == device_class
         ]
 
     raise AssertionError('unreachable')

--- a/simplyblock_core/utils/secrets.py
+++ b/simplyblock_core/utils/secrets.py
@@ -12,17 +12,15 @@ def unwrap_secrets_for_send(obj: Any) -> Any:
     wrapper's repr masks the value, while this function produces a plain
     JSON-serializable structure for the HTTP body.
     """
-    match obj:
-        case SecretStr() | SecretBytes():
-            return obj.get_secret_value()
-        case dict():
-            return {k: unwrap_secrets_for_send(v) for k, v in obj.items()}
-        case list():
-            return [unwrap_secrets_for_send(v) for v in obj]
-        case tuple():
-            return tuple(unwrap_secrets_for_send(v) for v in obj)
-        case _:
-            return obj
+    if isinstance(obj, (SecretStr, SecretBytes)):
+        return obj.get_secret_value()
+    if isinstance(obj, dict):
+        return {k: unwrap_secrets_for_send(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [unwrap_secrets_for_send(v) for v in obj]
+    if isinstance(obj, tuple):
+        return tuple(unwrap_secrets_for_send(v) for v in obj)
+    return obj
 
 
 def unwrap_secret(value: Union[SecretStr, str, None]) -> Optional[str]:
@@ -30,10 +28,8 @@ def unwrap_secret(value: Union[SecretStr, str, None]) -> Optional[str]:
 
     Removed once the surrounding code is type-correct on ``SecretStr``.
     """
-    match value:
-        case None:
-            return None
-        case SecretStr():
-            return value.get_secret_value()
-        case _:
-            return value
+    if value is None:
+        return None
+    if isinstance(value, SecretStr):
+        return value.get_secret_value()
+    return value

--- a/simplyblock_web/api/internal/storage_node/_cloud_info.py
+++ b/simplyblock_web/api/internal/storage_node/_cloud_info.py
@@ -1,16 +1,18 @@
+from typing import Callable, List, Optional
+
 import requests
 
 
-def get_cloud_info() -> dict | None:
+def get_cloud_info() -> Optional[dict]:
+    getters: List[Callable[[], Optional[dict]]] = [_google_info, _amazon_info, _equinix_info]
     return next((
         info
-        for getter
-        in [_google_info, _amazon_info, _equinix_info]
+        for getter in getters
         if (info := getter()) is not None
     ), None)
 
 
-def _google_info() -> dict | None:
+def _google_info() -> Optional[dict]:
     try:
         headers = {'Metadata-Flavor': 'Google'}
         response = requests.get("http://169.254.169.254/computeMetadata/v1/instance/?recursive=true", headers=headers, timeout=2)
@@ -26,7 +28,7 @@ def _google_info() -> dict | None:
         return None
 
 
-def _amazon_info() -> dict | None:
+def _amazon_info() -> Optional[dict]:
     try:
         import ec2_metadata
         session = requests.session()
@@ -42,7 +44,7 @@ def _amazon_info() -> dict | None:
         return None
 
 
-def _equinix_info(timeout: int = 2) -> dict | None:
+def _equinix_info(timeout: int = 2) -> Optional[dict]:
     try:
         response = requests.get("https://metadata.platformequinix.com/metadata", timeout=2)
         data = response.json()

--- a/simplyblock_web/api/v2/_auth.py
+++ b/simplyblock_web/api/v2/_auth.py
@@ -2,7 +2,7 @@ import base64
 import hmac
 import json
 import logging
-from typing import Annotated
+from typing import Annotated, Optional, Tuple
 from json.decoder import JSONDecodeError
 from uuid import UUID
 
@@ -17,11 +17,11 @@ from simplyblock_web.settings import Settings as WebSettings
 _db = DBController()
 security = HTTPBearer()
 _web_settings = WebSettings()
-_k8s_auth_api: kubernetes.client.AuthenticationV1Api | None = None
+_k8s_auth_api: Optional[kubernetes.client.AuthenticationV1Api] = None
 _logger = logging.getLogger(__name__)
 
 
-def _get_k8s_auth_api() -> kubernetes.client.AuthenticationV1Api | None:
+def _get_k8s_auth_api() -> Optional[kubernetes.client.AuthenticationV1Api]:
     global _k8s_auth_api
     if _k8s_auth_api is not None:
         return _k8s_auth_api
@@ -44,7 +44,7 @@ def _urlsafe_b64decode_unpadded(encoded: str) -> bytes:
     return base64.urlsafe_b64decode(encoded + padding)
 
 
-def _insecure_decode_jwt(token: str) -> tuple[dict, dict, bytes]:
+def _insecure_decode_jwt(token: str) -> Tuple[dict, dict, bytes]:
     """Decodes the given JWT without verifying its authenticty
 
     Attempts to decode the given JWT. *Not* meant for validation, the signature is not verified.
@@ -72,7 +72,7 @@ def _is_kubernetes_jwt(token: str) -> bool:
 
 def authenticated_service_account(
     credentials: Annotated[HTTPAuthorizationCredentials, Depends(security)],
-) -> str | None:
+) -> Optional[str]:
     """FastAPI dependency: identify which k8s service account a bearer token authenticates as.
 
     Returns the service account username when the token has JWT structure, the
@@ -106,7 +106,7 @@ def authenticated_service_account(
 
 def authorized_cluster(
     credentials: Annotated[HTTPAuthorizationCredentials, Depends(security)],
-) -> UUID | None:
+) -> Optional[UUID]:
     """FastAPI dependency: identify which cluster a bearer token authenticates as.
 
     Returns `None` immediately when cluster-secret authentication is disabled via
@@ -133,9 +133,9 @@ def authorized_cluster(
 
 
 def verify_api_token(
-    sa_name: Annotated[str | None, Depends(authenticated_service_account)],
-    authorized_cluster_id: Annotated[UUID | None, Depends(authorized_cluster)],
-    cluster_id: UUID | None = None,
+    sa_name: Annotated[Optional[str], Depends(authenticated_service_account)],
+    authorized_cluster_id: Annotated[Optional[UUID], Depends(authorized_cluster)],
+    cluster_id: Optional[UUID] = None,
 ) -> None:
     """FastAPI dependency: enforce authentication and per-cluster authorization.
 

--- a/simplyblock_web/api/v2/_dtos.py
+++ b/simplyblock_web/api/v2/_dtos.py
@@ -577,7 +577,7 @@ class MigrationDTO(BaseModel):
     connect_strings: list[NvmeConnectEntry] = []
 
     @staticmethod
-    def from_model(model: LVolMigration, connect_strings: list[NvmeConnectEntry] | None = None):
+    def from_model(model: LVolMigration, connect_strings: Optional[List[NvmeConnectEntry]] = None):
         return MigrationDTO(
             id=UUID(model.uuid),
             lvol_id=model.lvol_id,

--- a/simplyblock_web/api/v2/cluster/storage_pool/volume/migration.py
+++ b/simplyblock_web/api/v2/cluster/storage_pool/volume/migration.py
@@ -1,4 +1,4 @@
-from typing import Annotated, List
+from typing import Annotated, List, Optional
 from uuid import UUID
 
 from fastapi import APIRouter, HTTPException, Request, Response
@@ -27,7 +27,7 @@ def list_migrations(cluster: Cluster) -> List[MigrationDTO]:
 class _MigrationParams(BaseModel):
     target_node_id: UUID
     ctrl_loss_tmo: int = constants.LVOL_NVME_CONNECT_CTRL_LOSS_TMO
-    host_nqn: Annotated[str, Field(pattern=utils.NQN_PATTERN)] | None = None
+    host_nqn: Optional[Annotated[str, Field(pattern=utils.NQN_PATTERN)]] = None
 
 
 @api.post('/', name='cluster:storage-pools:volumes:migrations:create', status_code=201, responses={201: {"content": None}})

--- a/simplyblock_web/api/v2/util.py
+++ b/simplyblock_web/api/v2/util.py
@@ -1,4 +1,4 @@
-from typing import Annotated, Any, Callable, Literal
+from typing import Annotated, Any, Callable, Literal, Optional
 from urllib.parse import urlparse
 from uuid import UUID
 
@@ -40,16 +40,17 @@ def creation_response(
     route_name: str,
     route_kwargs: dict[str, UUID],
     get_full: Callable[[UUID], BaseModel],
-    extra_headers: dict[str, str] | None = None,
+    extra_headers: Optional[dict[str, str]] = None,
 ) -> Response:
     headers = {"Location": str(request.app.url_path_for(route_name, **route_kwargs))}
     if extra_headers:
         headers.update(extra_headers)
 
-    match response_format:
-        case "empty":
-            return Response(status_code=201, headers=headers)
-        case "identifier":
-            return JSONResponse(content=str(entity_id), status_code=201, headers=headers)
-        case "full":
-            return JSONResponse(content=jsonable_encoder(get_full(entity_id)), status_code=201, headers=headers)
+    if response_format == "empty":
+        return Response(status_code=201, headers=headers)
+    elif response_format == "identifier":
+        return JSONResponse(content=str(entity_id), status_code=201, headers=headers)
+    elif response_format == "full":
+        return JSONResponse(content=jsonable_encoder(get_full(entity_id)), status_code=201, headers=headers)
+    else:
+        raise ValueError(f"Unknown response format: {response_format!r}")

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,10 @@
 [tox]
 envlist = unit, integration, lint, types
 skipsdist = true
+requires = tox-uv>=1
 
 [testenv]
-basepython = python3.13
+basepython = python3.9
 deps =
     -r requirements.txt
     -r test-requirements.txt


### PR DESCRIPTION
This change drops the minimum requirements for this project back to Python 3.9 to maintain compatibility with Rocky 9's default interpreter. This removes new-style type annotations,  match-case statements, and adapts to the old standard library. Project metainformation and CI/testing instructions are also adapted.