### PR TITLE
Run complete integration test suite

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,7 +33,6 @@ jobs:
   integration:
     name: Integration tests
     runs-on: ubuntu-latest
-    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -47,4 +46,4 @@ jobs:
       - name: Install tox
         run: pip install tox
       - name: Run integration tests
-        run: tox run -e integration -- -v
+        run: tox run -e integration -- -v --durations=0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,33 +1,13 @@
 # coding=utf-8
 """
 conftest.py – shared fixtures for all tests in tests/.
+
+The ``fdb`` module stub used by the unit tier lives in ``tests/unit/conftest.py``
+so it does not leak into integration tests, which need the real
+``foundationdb`` client.
 """
 
-import sys
-import types
-
 import pytest
-
-# ---------------------------------------------------------------------------
-# Stub out native/unavailable dependencies before any simplyblock import so
-# that unit tests can run without a FoundationDB installation or a running
-# Docker / Kubernetes environment.
-# ---------------------------------------------------------------------------
-
-def _stub(name, **attrs):
-    """Create a minimal stub module and register it in sys.modules."""
-    m = types.ModuleType(name)
-    for k, v in attrs.items():
-        setattr(m, k, v)
-    sys.modules[name] = m
-    return m
-
-
-if 'fdb' not in sys.modules:
-    class _FDBError(Exception):
-        pass
-    _stub('fdb', open=lambda *a, **kw: None, FDBError=_FDBError)
-    _stub('fdb.tuple')
 
 
 @pytest.fixture(autouse=True)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,19 +1,25 @@
 # coding=utf-8
-"""Session-scoped FoundationDB provisioning for the integration tier.
+"""FoundationDB provisioning for the integration tier.
 
-Resolution order:
+Resolution order (evaluated at conftest module load, before any test file
+imports ``simplyblock_core.constants`` — whose ``KVD_DB_FILE_PATH`` reads
+``$FDB_CLUSTER_FILE`` once at import time):
+
   1. If FDB_CLUSTER_FILE is already set and points at a readable file
      (developer's docker-compose-dev.yml, existing cluster, etc.),
      reuse it.
   2. Otherwise, start a foundationdb/foundationdb container via
-     testcontainers, wait until it accepts writes, expose its cluster
-     file on the host, and set FDB_CLUSTER_FILE for the session.
-  3. If neither path works (no docker, no testcontainers), skip every
-     test in tests/integration/ with a clear message.
+     testcontainers, wait until it accepts writes, write its cluster
+     contents to a temp file, and set FDB_CLUSTER_FILE for the session.
+  3. If neither path works (no docker, no testcontainers), defer the
+     skip to the session fixture below so every integration test shows
+     a clear "FDB unavailable" message instead of an obscure crash.
 
-This fixture only owns the FDB process lifecycle. Per-test keyspace
-cleanup and cluster-record bootstrap live in the sub-package conftests
-(ftt2/, migration/, expansion_sim/).
+Provisioning runs at module-load time (not inside a pytest fixture) so
+``simplyblock_core.constants.KVD_DB_FILE_PATH`` — captured at import — sees
+the testcontainers-provisioned path. Per-test keyspace cleanup and
+cluster-record bootstrap live in the sub-package conftests (ftt2/,
+migration/, expansion_sim/).
 """
 import os
 import shutil
@@ -79,27 +85,49 @@ def _start_fdb_container():
     )
 
 
-@pytest.fixture(scope="session", autouse=True)
-def fdb_cluster():
+_provisioned_container = None
+_provisioning_error: str = ""
+
+
+def _provision_fdb_at_module_load():
+    global _provisioned_container, _provisioning_error
+
     if _existing_cluster_file_works():
-        yield os.environ["FDB_CLUSTER_FILE"]
         return
 
     try:
         import testcontainers.core.container  # noqa: F401
     except ImportError:
-        pytest.skip("testcontainers not installed — `pip install testcontainers`")
+        _provisioning_error = "testcontainers not installed — `pip install testcontainers`"
+        return
 
     if shutil.which("docker") is None:
-        pytest.skip("docker not available — integration tier requires Docker")
+        _provisioning_error = "docker not available — integration tier requires Docker"
+        return
 
-    container = _start_fdb_container()
     try:
-        tmp = Path(tempfile.mkdtemp(prefix="sbcli-fdb-"))
-        cluster_file = tmp / "fdb.cluster"
-        cluster_file.write_text(FDB_CLUSTER_CONTENTS)
-        os.environ["FDB_CLUSTER_FILE"] = str(cluster_file)
-        yield str(cluster_file)
+        container = _start_fdb_container()
+    except Exception as exc:
+        _provisioning_error = f"FoundationDB container failed to start: {exc}"
+        return
+
+    tmp = Path(tempfile.mkdtemp(prefix="sbcli-fdb-"))
+    cluster_file = tmp / "fdb.cluster"
+    cluster_file.write_text(FDB_CLUSTER_CONTENTS)
+    os.environ["FDB_CLUSTER_FILE"] = str(cluster_file)
+    _provisioned_container = container
+
+
+_provision_fdb_at_module_load()
+
+
+@pytest.fixture(scope="session", autouse=True)
+def fdb_cluster():
+    if not _existing_cluster_file_works():
+        pytest.skip(_provisioning_error or "FoundationDB cluster file unavailable")
+    try:
+        yield os.environ["FDB_CLUSTER_FILE"]
     finally:
-        container.stop()
-        os.environ.pop("FDB_CLUSTER_FILE", None)
+        if _provisioned_container is not None:
+            _provisioned_container.stop()
+            os.environ.pop("FDB_CLUSTER_FILE", None)

--- a/tests/integration/expansion_sim/conftest.py
+++ b/tests/integration/expansion_sim/conftest.py
@@ -1,13 +1,14 @@
 # coding=utf-8
 """Pytest fixtures for the expansion simulator framework.
 
-Connects to a real FoundationDB (no in-memory shortcut) and patches every
-known import site of ``simplyblock_core.rpc_client.RPCClient`` with the
-``RpcRouter`` so all RPC traffic is routed to the simulators.
+Connects to the integration tier's FoundationDB (provisioned in
+``tests/integration/conftest.py``) and patches every known import site of
+``simplyblock_core.rpc_client.RPCClient`` with the ``RpcRouter`` so all RPC
+traffic is routed to the simulators.
 
 Requires:
-* a reachable FDB cluster file at the path indicated by
-  ``$FDB_CLUSTER_FILE`` (or ``/etc/foundationdb/fdb.cluster``)
+* the integration FDB cluster file at ``$FDB_CLUSTER_FILE`` (or
+  ``/etc/foundationdb/fdb.cluster``)
 * the ``foundationdb`` Python client + the matching libfdb shared library
 
 Tests in this directory mutate FDB. The ``fdb_clean`` fixture wipes the
@@ -16,46 +17,12 @@ matter.
 """
 
 import os
-import sys
 import pytest
+
+import fdb
 
 _FDB_CLUSTER_FILE = os.environ.get(
     "FDB_CLUSTER_FILE", "/etc/foundationdb/fdb.cluster")
-
-
-def _ensure_real_fdb():
-    """Restore the real FoundationDB client, replacing the stub that the
-    repo-wide ``tests/conftest.py`` installs for the stubbed unit suite.
-
-    Because ``simplyblock_core.db_controller`` does a top-level ``import fdb``,
-    it binds whatever ``sys.modules['fdb']`` is at first import. The unit-suite
-    stub (no ``api_version``) shadows the real client, so the expansion_sim
-    suite could never connect regardless of a running FDB. We pop the stub,
-    re-import the genuine package (needs ``libfdb_c`` on ``LD_LIBRARY_PATH``),
-    and rebind it on any simplyblock module that already grabbed the stub.
-
-    NOTE: this mutates global ``sys.modules``, so the expansion_sim suite must
-    run as its own pytest invocation, separate from the stubbed unit suite
-    (the intended multi-step layout: fast unit tier, then FDB-backed tier).
-    """
-    import importlib
-
-    current = sys.modules.get("fdb")
-    if current is not None and hasattr(current, "api_version"):
-        real = current  # real client already active
-    else:
-        sys.modules.pop("fdb", None)
-        sys.modules.pop("fdb.tuple", None)
-        real = importlib.import_module("fdb")
-        importlib.import_module("fdb.tuple")
-
-    # Rebind on modules that did `import fdb` at top level against the stub.
-    for mod_name in ("simplyblock_core.db_controller",
-                     "simplyblock_core.utils.hublvol_reconnect"):
-        mod = sys.modules.get(mod_name)
-        if mod is not None and getattr(mod, "fdb", None) is not real:
-            mod.fdb = real
-    return real
 
 
 @pytest.fixture(autouse=True)
@@ -88,24 +55,11 @@ def fast_sleep(monkeypatch):
     yield _real_sleep
 
 
-def _require_fdb():
-    if not os.path.isfile(_FDB_CLUSTER_FILE):
-        pytest.skip(f"FDB cluster file not found at {_FDB_CLUSTER_FILE}; "
-                    f"set FDB_CLUSTER_FILE or run on the EC2 sim host.")
-    try:
-        fdb = _ensure_real_fdb()
-    except ImportError:
-        pytest.skip("foundationdb python client not installed")
-    if not hasattr(fdb, "api_version"):
-        pytest.skip("real foundationdb client unavailable (stub active); "
-                    "run the expansion_sim suite as its own pytest invocation")
-    return fdb
-
-
 @pytest.fixture(scope="session")
 def fdb_db():
     """Session-level real-FDB connection. Reused across tests."""
-    fdb = _require_fdb()
+    if not os.path.isfile(_FDB_CLUSTER_FILE):
+        pytest.skip(f"FDB cluster file not found at {_FDB_CLUSTER_FILE}")
     fdb.api_version(730)
     db = fdb.open(_FDB_CLUSTER_FILE)
     db.options.set_transaction_timeout(10000)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,27 @@
+# coding=utf-8
+"""Unit-tier conftest: stub out native/unavailable dependencies before any
+simplyblock import so unit tests can run without a FoundationDB client.
+
+This stub stays scoped to ``tests/unit/`` so it does not leak into the
+integration tier, which needs the real ``foundationdb`` Python client to
+talk to the testcontainers-managed FDB.
+"""
+
+import sys
+import types
+
+
+def _stub(name, **attrs):
+    """Create a minimal stub module and register it in sys.modules."""
+    m = types.ModuleType(name)
+    for k, v in attrs.items():
+        setattr(m, k, v)
+    sys.modules[name] = m
+    return m
+
+
+if 'fdb' not in sys.modules:
+    class _FDBError(Exception):
+        pass
+    _stub('fdb', open=lambda *a, **kw: None, FDBError=_FDBError)
+    _stub('fdb.tuple')


### PR DESCRIPTION
#1136 split tests into unit and integration tests. Integration tests now run with an FDB, allowing us to run tests that were previously skipped: `ftt2`, `expansion-sim`, and `migration`. This PR adapts the harness, s.t. this is correctly picked up by the tests. Because they were not executed before, some failures of the new tests went unnoticed. Fixes for these faults will be introduced in this PR as well to keep things working on main.