### PR TITLE
Validate Host NQN in API

### DIFF
--- a/simplyblock_web/api/v2/cluster/storage_pool/__init__.py
+++ b/simplyblock_web/api/v2/cluster/storage_pool/__init__.py
@@ -1,8 +1,8 @@
-from typing import List, Optional
+from typing import Annotated, List, Optional
 from uuid import UUID
 
 from fastapi import APIRouter, HTTPException, Request, Response
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from simplyblock_core.db_controller import DBController
 from simplyblock_core.controllers import pool_controller
@@ -127,7 +127,7 @@ def iostats(cluster: Cluster, pool: StoragePool, limit: int = 20):
 
 
 class PoolHostParams(BaseModel):
-    host_nqn: str
+    host_nqn: Annotated[str, Field(pattern=core_utils.NQN_PATTERN)]
 
 
 @instance_api.post('/host', name='clusters:storage-pools:add-host', status_code=204,


### PR DESCRIPTION
The validation happens also in the controller, but the API can produce more meaningful errors and communicate intent.