### PR TITLE
Harden database accessors

### DIFF
--- a/simplyblock_core/db_controller.py
+++ b/simplyblock_core/db_controller.py
@@ -60,7 +60,7 @@ class DBController(metaclass=Singleton):
         ret = sorted(ret, key=lambda x: x.create_dt)
         return ret
 
-    def get_storage_nodes_by_cluster_id(self, cluster_id) -> List[StorageNode]:
+    def get_storage_nodes_by_cluster_id(self, cluster_id: str) -> List[StorageNode]:
         ret = StorageNode().read_from_db(self.kv_store)
         nodes = []
         for n in ret:
@@ -68,27 +68,27 @@ class DBController(metaclass=Singleton):
                 nodes.append(n)
         return sorted(nodes, key=lambda x: x.create_dt)
 
-    def get_storage_nodes_by_system_id(self, system_id) -> List[StorageNode]:
+    def get_storage_nodes_by_system_id(self, system_id: str) -> List[StorageNode]:
         return [
             node for node
             in StorageNode().read_from_db(self.kv_store)
             if node.system_uuid == system_id
         ]
 
-    def get_storage_nodes_by_hostname(self, hostname) -> List[StorageNode]:
+    def get_storage_nodes_by_hostname(self, hostname: str) -> List[StorageNode]:
         return [
             node for node
             in self.get_storage_nodes()
             if node.hostname == hostname
         ]
 
-    def get_storage_node_by_id(self, id) -> StorageNode:
+    def get_storage_node_by_id(self, id: str) -> StorageNode:
         ret = StorageNode().read_from_db(self.kv_store, id)
         if len(ret) == 0:
             raise KeyError(f'StorageNode {id} not found')
         return ret[0]
 
-    def get_storage_device_by_id(self, id) -> NVMeDevice:
+    def get_storage_device_by_id(self, id: str) -> NVMeDevice:
         nodes = self.get_storage_nodes()
         try:
             return next(
@@ -101,7 +101,7 @@ class DBController(metaclass=Singleton):
             raise KeyError(f'Device {id} not found')
 
 
-    def get_pools(self, cluster_id=None) -> List[Pool]:
+    def get_pools(self, cluster_id: Optional[str] = None) -> List[Pool]:
         pools = []
         if cluster_id:
             for pool in Pool().read_from_db(self.kv_store):
@@ -111,20 +111,20 @@ class DBController(metaclass=Singleton):
             pools = Pool().read_from_db(self.kv_store)
         return pools
 
-    def get_pool_by_id(self, id) -> Pool:
+    def get_pool_by_id(self, id: str) -> Pool:
         ret = Pool().read_from_db(self.kv_store, id)
         if not ret:
             raise KeyError(f'Pool {id} not found')
         return ret[0]
 
-    def get_pool_by_name(self, name) -> Pool:
+    def get_pool_by_name(self, name: str) -> Pool:
         pools = Pool().read_from_db(self.kv_store)
         for pool in pools:
             if pool.pool_name == name:
                 return pool
         raise KeyError(f'Pool {name} not found')
 
-    def get_lvols(self, cluster_id=None) -> List[LVol]:
+    def get_lvols(self, cluster_id: Optional[str] = None) -> List[LVol]:
         lvols = self.get_all_lvols()
         lvols = [lvol for lvol in lvols if lvol.status != LVol.STATUS_DELETED]
         if not cluster_id:
@@ -149,21 +149,21 @@ class DBController(metaclass=Singleton):
         logger.debug(f"time taken to read all LVols: {round(end_time - start_time, 2)}s")
         return ret
 
-    def get_lvols_by_node_id(self, node_id) -> List[LVol]:
+    def get_lvols_by_node_id(self, node_id: str) -> List[LVol]:
         lvols = []
         for lvol in self.get_lvols():
             if lvol.node_id == node_id:
                 lvols.append(lvol)
         return sorted(lvols, key=lambda x: x.create_dt)
 
-    def get_lvols_by_pool_id(self, pool_id) -> List[LVol]:
+    def get_lvols_by_pool_id(self, pool_id: str) -> List[LVol]:
         lvols = []
         for lvol in self.get_lvols():
             if lvol.pool_uuid == pool_id:
                 lvols.append(lvol)
         return sorted(lvols, key=lambda x: x.create_dt)
 
-    def get_hostnames_by_pool_id(self, pool_id) -> List[str]:
+    def get_hostnames_by_pool_id(self, pool_id: str) -> List[str]:
         lvols = self.get_lvols_by_pool_id(pool_id)
         hostnames = []
         for lv in lvols:
@@ -171,7 +171,7 @@ class DBController(metaclass=Singleton):
                 hostnames.append(lv.hostname)
         return hostnames
 
-    def get_snapshots(self, cluster_id=None) -> List[SnapShot]:
+    def get_snapshots(self, cluster_id: Optional[str] = None) -> List[SnapShot]:
         start_time = time.time()
         snaps = SnapShot().read_from_db(self.kv_store)
         if cluster_id:
@@ -197,13 +197,13 @@ class DBController(metaclass=Singleton):
         logger.debug(f"time taken to read all mini snapshots: {round(end_time - start_time, 2)}s")
         return ret
 
-    def get_snapshot_by_id(self, id) -> SnapShot:
+    def get_snapshot_by_id(self, id: str) -> SnapShot:
         ret = SnapShot().read_from_db(self.kv_store, id)
         if not ret:
             raise KeyError(f'Snapshot {id} not found')
         return ret[0]
 
-    def get_lvol_by_id(self, id) -> LVol:
+    def get_lvol_by_id(self, id: str) -> LVol:
         lvols = LVol().read_from_db(self.kv_store, id=id)
         if not lvols:
             raise KeyError(f'LVol {id} not found')
@@ -213,25 +213,25 @@ class DBController(metaclass=Singleton):
         ret = LVolReplication().read_from_db(self.kv_store)
         return sorted(ret, key=lambda x: x.create_dt)
 
-    def get_lvol_by_name(self, lvol_name) -> LVol:
+    def get_lvol_by_name(self, lvol_name: str) -> LVol:
         for lvol in self.get_lvols():
             if lvol.lvol_name == lvol_name:
                 return lvol
         raise KeyError(f'LVol {lvol_name} not found')
 
-    def get_mgmt_node_by_id(self, id) -> MgmtNode:
+    def get_mgmt_node_by_id(self, id: str) -> MgmtNode:
         ret = MgmtNode().read_from_db(self.kv_store, id)
         if not ret:
             raise KeyError(f'ManagementNode {id} not found')
         return ret[0]
 
-    def get_mgmt_nodes(self, cluster_id=None) -> List[MgmtNode]:
+    def get_mgmt_nodes(self, cluster_id: Optional[str] = None) -> List[MgmtNode]:
         nodes = MgmtNode().read_from_db(self.kv_store)
         if cluster_id:
             nodes = [n for n in nodes if n.cluster_id == cluster_id]
         return sorted(nodes, key=lambda x: x.create_dt)
 
-    def get_mgmt_node_by_hostname(self, hostname) -> MgmtNode:
+    def get_mgmt_node_by_hostname(self, hostname: str) -> MgmtNode:
         nodes = self.get_mgmt_nodes()
         for node in nodes:
             if node.hostname == hostname:
@@ -282,20 +282,20 @@ class DBController(metaclass=Singleton):
     def get_clusters(self) -> List[Cluster]:
         return Cluster().read_from_db(self.kv_store)
 
-    def get_cluster_by_id(self, cluster_id) -> Cluster:
+    def get_cluster_by_id(self, cluster_id: str) -> Cluster:
         ret = Cluster().read_from_db(self.kv_store, id=cluster_id)
         if not ret:
             raise KeyError(f'Cluster {cluster_id} not found')
         return ret[0]
 
-    def get_port_stats(self, node_id, port_id, limit=20) -> List[PortStat]:
+    def get_port_stats(self, node_id: str, port_id: str, limit: int = 20) -> List[PortStat]:
         stats = PortStat().read_from_db(self.kv_store, id="%s/%s" % (node_id, port_id), limit=limit, reverse=True)
         return stats
 
-    def get_events(self, event_id=" ", limit=0, reverse=False) -> List[EventObj]:
+    def get_events(self, event_id: str = " ", limit: int = 0, reverse: bool = False) -> List[EventObj]:
         return EventObj().read_from_db(self.kv_store, id=event_id, limit=limit, reverse=reverse)
 
-    def get_job_tasks(self, cluster_id, reverse=True, limit=0) -> List[JobSchedule]:
+    def get_job_tasks(self, cluster_id: str, reverse: bool = True, limit: int = 0) -> List[JobSchedule]:
         ret = JobSchedule().read_from_db(self.kv_store, id=cluster_id, reverse=reverse, limit=limit)
         return sorted(ret, key=lambda x: x.date)
 
@@ -308,13 +308,13 @@ class DBController(metaclass=Singleton):
             and t.status != JobSchedule.STATUS_DONE
         ]
 
-    def get_task_by_id(self, task_id) -> JobSchedule:
+    def get_task_by_id(self, task_id: str) -> JobSchedule:
         for task in self.get_job_tasks(" "):
             if task.uuid == task_id:
                 return task
         raise KeyError(f'Task {task_id} not found')
 
-    def get_snapshots_by_node_id(self, node_id) -> List[SnapShot]:
+    def get_snapshots_by_node_id(self, node_id: str) -> List[SnapShot]:
         ret = []
         snaps = self.get_snapshots()
         for snap in snaps:
@@ -322,7 +322,7 @@ class DBController(metaclass=Singleton):
                 ret.append(snap)
         return sorted(ret, key=lambda x: x.create_dt)
 
-    def get_snapshots_by_pool_id(self, pool_id) -> List[SnapShot]:
+    def get_snapshots_by_pool_id(self, pool_id: str) -> List[SnapShot]:
         ret = []
         snaps = self.get_snapshots()
         for snap in snaps:
@@ -330,20 +330,20 @@ class DBController(metaclass=Singleton):
                 ret.append(snap)
         return sorted(ret, key=lambda x: x.create_dt)
 
-    def get_snapshots_by_lvol_id(self, lvol_id) -> List[SnapShot]:
+    def get_snapshots_by_lvol_id(self, lvol_id: str) -> List[SnapShot]:
         return [s for s in self.get_snapshots() if s.lvol and s.lvol.get_id() == lvol_id]
 
-    def get_snode_size(self, node_id) -> int:
+    def get_snode_size(self, node_id: str) -> int:
         snode = self.get_storage_node_by_id(node_id)
         return sum(dev.size for dev in snode.nvme_devices)
 
-    def get_jm_device_by_id(self, jm_id) -> JMDevice:
+    def get_jm_device_by_id(self, jm_id: str) -> JMDevice:
         for node in self.get_storage_nodes():
             if node.jm_device and node.jm_device.get_id() == jm_id:
                 return node.jm_device
         raise KeyError(f'JMDeviec {jm_id} not found')
 
-    def get_primary_storage_nodes_by_cluster_id(self, cluster_id) -> List[StorageNode]:
+    def get_primary_storage_nodes_by_cluster_id(self, cluster_id: str) -> List[StorageNode]:
         ret = StorageNode().read_from_db(self.kv_store)
         nodes = []
         for n in ret:
@@ -351,7 +351,7 @@ class DBController(metaclass=Singleton):
                 nodes.append(n)
         return sorted(nodes, key=lambda x: x.create_dt)
 
-    def get_primary_storage_nodes_by_secondary_node_id(self, node_id) -> List[StorageNode]:
+    def get_primary_storage_nodes_by_secondary_node_id(self, node_id: str) -> List[StorageNode]:
         ret = StorageNode().read_from_db(self.kv_store)
         nodes = []
         for node in ret:
@@ -359,7 +359,7 @@ class DBController(metaclass=Singleton):
                 nodes.append(node)
         return sorted(nodes, key=lambda x: x.create_dt)
 
-    def get_qos(self, cluster_id=None) -> List[QOSClass]:
+    def get_qos(self, cluster_id: Optional[str] = None) -> List[QOSClass]:
         classes = []
         if cluster_id:
             for qos in QOSClass().read_from_db(self.kv_store):
@@ -369,31 +369,31 @@ class DBController(metaclass=Singleton):
             classes = QOSClass().read_from_db(self.kv_store)
         return sorted(classes, key=lambda x: x.class_id)
 
-    def get_migrations(self, cluster_id=None) -> List[LVolMigration]:
+    def get_migrations(self, cluster_id: Optional[str] = None) -> List[LVolMigration]:
         """Return all LVolMigration records, optionally filtered by cluster."""
         prefix = cluster_id if cluster_id else " "
         return LVolMigration().read_from_db(self.kv_store, id=prefix)
 
-    def get_migration_by_id(self, migration_id) -> LVolMigration:
+    def get_migration_by_id(self, migration_id: str) -> LVolMigration:
         for m in self.get_migrations():
             if m.uuid == migration_id:
                 return m
         raise KeyError(f'LVolMigration {migration_id} not found')
 
-    def get_migration_by_lvol_id(self, lvol_id) -> Optional[LVolMigration]:
+    def get_migration_by_lvol_id(self, lvol_id: str) -> Optional[LVolMigration]:
         for m in self.get_migrations():
             if m.lvol_id == lvol_id and m.is_active():
                 return m
         return None
 
-    def get_lvol_del_lock(self, node_id) -> Optional[NodeLVolDelLock]:
+    def get_lvol_del_lock(self, node_id: str) -> Optional[NodeLVolDelLock]:
         ret = NodeLVolDelLock().read_from_db(self.kv_store, id=node_id)
         if ret:
             return ret[0]
         else:
             return None
 
-    def get_backup_chain_lock(self, snapshot_id) -> Optional[BackupChainLock]:
+    def get_backup_chain_lock(self, snapshot_id: str) -> Optional[BackupChainLock]:
         ret = BackupChainLock().read_from_db(self.kv_store, id=snapshot_id)
         if ret:
             return ret[0]
@@ -452,7 +452,7 @@ class DBController(metaclass=Singleton):
 
     # ---- Cluster node-add mesh lock (Single FDB Transaction) ----
 
-    def get_cluster_add_lock(self, cluster_id) -> Optional[ClusterAddNodeLock]:
+    def get_cluster_add_lock(self, cluster_id: str) -> Optional[ClusterAddNodeLock]:
         ret = ClusterAddNodeLock().read_from_db(self.kv_store, id=cluster_id)
         if ret:
             return ret[0]
@@ -785,23 +785,23 @@ class DBController(metaclass=Singleton):
 
     # ---- S3 Backup ----
 
-    def get_backups(self, cluster_id=None) -> List[Backup]:
+    def get_backups(self, cluster_id: Optional[str] = None) -> List[Backup]:
         prefix = cluster_id if cluster_id else " "
         return Backup().read_from_db(self.kv_store, id=prefix)
 
-    def get_backup_by_id(self, backup_id) -> Backup:
+    def get_backup_by_id(self, backup_id: str) -> Backup:
         for b in self.get_backups():
             if b.uuid == backup_id:
                 return b
         raise KeyError(f'Backup {backup_id} not found')
 
-    def get_backups_by_lvol_id(self, lvol_id) -> List[Backup]:
+    def get_backups_by_lvol_id(self, lvol_id: str) -> List[Backup]:
         return [b for b in self.get_backups() if b.lvol_id == lvol_id]
 
-    def get_backups_by_snapshot_id(self, snapshot_id) -> List[Backup]:
+    def get_backups_by_snapshot_id(self, snapshot_id: str) -> List[Backup]:
         return [b for b in self.get_backups() if b.snapshot_id == snapshot_id]
 
-    def get_backup_chain(self, backup_id) -> List[Backup]:
+    def get_backup_chain(self, backup_id: str) -> List[Backup]:
         """Return the full backup chain ending at backup_id, oldest first."""
         chain = []
         current_id = backup_id
@@ -817,17 +817,17 @@ class DBController(metaclass=Singleton):
         chain.reverse()
         return chain
 
-    def get_backup_policies(self, cluster_id=None) -> List[BackupPolicy]:
+    def get_backup_policies(self, cluster_id: Optional[str] = None) -> List[BackupPolicy]:
         prefix = cluster_id if cluster_id else " "
         return BackupPolicy().read_from_db(self.kv_store, id=prefix)
 
-    def get_backup_policy_by_id(self, policy_id) -> BackupPolicy:
+    def get_backup_policy_by_id(self, policy_id: str) -> BackupPolicy:
         for p in self.get_backup_policies():
             if p.uuid == policy_id:
                 return p
         raise KeyError(f'BackupPolicy {policy_id} not found')
 
-    def get_backup_policy_attachments(self, cluster_id=None) -> List[BackupPolicyAttachment]:
+    def get_backup_policy_attachments(self, cluster_id: Optional[str] = None) -> List[BackupPolicyAttachment]:
         prefix = cluster_id if cluster_id else " "
         return BackupPolicyAttachment().read_from_db(self.kv_store, id=prefix)
 

--- a/simplyblock_core/db_controller.py
+++ b/simplyblock_core/db_controller.py
@@ -24,6 +24,7 @@ from simplyblock_core.models.stats import DeviceStatObject, NodeStatObject, Clus
     PoolStatObject, CachedLVolStatObject
 from simplyblock_core.models.storage_node import StorageNode, NodeLVolDelLock
 from simplyblock_core.models.lvstore_lock import LVStoreMutationLock
+from simplyblock_core.utils.helpers import single_or_none
 
 logger = logging.getLogger(__name__)
 
@@ -83,22 +84,21 @@ class DBController(metaclass=Singleton):
         ]
 
     def get_storage_node_by_id(self, id: str) -> StorageNode:
-        ret = StorageNode().read_from_db(self.kv_store, id)
-        if len(ret) == 0:
+        node = single_or_none(StorageNode().read_from_db(self.kv_store, id))
+        if node is None:
             raise KeyError(f'StorageNode {id} not found')
-        return ret[0]
+        return node
 
     def get_storage_device_by_id(self, id: str) -> NVMeDevice:
-        nodes = self.get_storage_nodes()
-        try:
-            return next(
-                device
-                for node in nodes
-                for device in node.nvme_devices
-                if device.get_id() == id
-            )
-        except StopIteration:
+        device = single_or_none(
+            device
+            for node in self.get_storage_nodes()
+            for device in node.nvme_devices
+            if device.get_id() == id
+        )
+        if device is None:
             raise KeyError(f'Device {id} not found')
+        return device
 
 
     def get_pools(self, cluster_id: Optional[str] = None) -> List[Pool]:
@@ -112,17 +112,16 @@ class DBController(metaclass=Singleton):
         return pools
 
     def get_pool_by_id(self, id: str) -> Pool:
-        ret = Pool().read_from_db(self.kv_store, id)
-        if not ret:
+        pool = single_or_none(Pool().read_from_db(self.kv_store, id))
+        if pool is None:
             raise KeyError(f'Pool {id} not found')
-        return ret[0]
+        return pool
 
     def get_pool_by_name(self, name: str) -> Pool:
-        pools = Pool().read_from_db(self.kv_store)
-        for pool in pools:
-            if pool.pool_name == name:
-                return pool
-        raise KeyError(f'Pool {name} not found')
+        pool = single_or_none(p for p in Pool().read_from_db(self.kv_store) if p.pool_name == name)
+        if pool is None:
+            raise KeyError(f'Pool {name} not found')
+        return pool
 
     def get_lvols(self, cluster_id: Optional[str] = None) -> List[LVol]:
         lvols = self.get_all_lvols()
@@ -198,32 +197,32 @@ class DBController(metaclass=Singleton):
         return ret
 
     def get_snapshot_by_id(self, id: str) -> SnapShot:
-        ret = SnapShot().read_from_db(self.kv_store, id)
-        if not ret:
+        snap = single_or_none(SnapShot().read_from_db(self.kv_store, id))
+        if snap is None:
             raise KeyError(f'Snapshot {id} not found')
-        return ret[0]
+        return snap
 
     def get_lvol_by_id(self, id: str) -> LVol:
-        lvols = LVol().read_from_db(self.kv_store, id=id)
-        if not lvols:
+        lvol = single_or_none(LVol().read_from_db(self.kv_store, id=id))
+        if lvol is None:
             raise KeyError(f'LVol {id} not found')
-        return lvols[0]
+        return lvol
 
     def get_lvol_replication_objects(self) -> List[LVolReplication]:
         ret = LVolReplication().read_from_db(self.kv_store)
         return sorted(ret, key=lambda x: x.create_dt)
 
     def get_lvol_by_name(self, lvol_name: str) -> LVol:
-        for lvol in self.get_lvols():
-            if lvol.lvol_name == lvol_name:
-                return lvol
-        raise KeyError(f'LVol {lvol_name} not found')
+        lvol = single_or_none(lvol for lvol in self.get_lvols() if lvol.lvol_name == lvol_name)
+        if lvol is None:
+            raise KeyError(f'LVol {lvol_name} not found')
+        return lvol
 
     def get_mgmt_node_by_id(self, id: str) -> MgmtNode:
-        ret = MgmtNode().read_from_db(self.kv_store, id)
-        if not ret:
+        node = single_or_none(MgmtNode().read_from_db(self.kv_store, id))
+        if node is None:
             raise KeyError(f'ManagementNode {id} not found')
-        return ret[0]
+        return node
 
     def get_mgmt_nodes(self, cluster_id: Optional[str] = None) -> List[MgmtNode]:
         nodes = MgmtNode().read_from_db(self.kv_store)
@@ -232,11 +231,10 @@ class DBController(metaclass=Singleton):
         return sorted(nodes, key=lambda x: x.create_dt)
 
     def get_mgmt_node_by_hostname(self, hostname: str) -> MgmtNode:
-        nodes = self.get_mgmt_nodes()
-        for node in nodes:
-            if node.hostname == hostname:
-                return node
-        raise KeyError(f'No management node found for hostname {hostname}')
+        node = single_or_none(node for node in self.get_mgmt_nodes() if node.hostname == hostname)
+        if node is None:
+            raise KeyError(f'No management node found for hostname {hostname}')
+        return node
 
     def get_lvol_stats(self, lvol, limit=20) -> List[LVolStatObject]:
         if isinstance(lvol, str):
@@ -283,10 +281,10 @@ class DBController(metaclass=Singleton):
         return Cluster().read_from_db(self.kv_store)
 
     def get_cluster_by_id(self, cluster_id: str) -> Cluster:
-        ret = Cluster().read_from_db(self.kv_store, id=cluster_id)
-        if not ret:
+        cluster = single_or_none(Cluster().read_from_db(self.kv_store, id=cluster_id))
+        if cluster is None:
             raise KeyError(f'Cluster {cluster_id} not found')
-        return ret[0]
+        return cluster
 
     def get_port_stats(self, node_id: str, port_id: str, limit: int = 20) -> List[PortStat]:
         stats = PortStat().read_from_db(self.kv_store, id="%s/%s" % (node_id, port_id), limit=limit, reverse=True)
@@ -309,10 +307,10 @@ class DBController(metaclass=Singleton):
         ]
 
     def get_task_by_id(self, task_id: str) -> JobSchedule:
-        for task in self.get_job_tasks(" "):
-            if task.uuid == task_id:
-                return task
-        raise KeyError(f'Task {task_id} not found')
+        task = single_or_none(t for t in self.get_job_tasks(" ") if t.uuid == task_id)
+        if task is None:
+            raise KeyError(f'Task {task_id} not found')
+        return task
 
     def get_snapshots_by_node_id(self, node_id: str) -> List[SnapShot]:
         ret = []
@@ -338,10 +336,14 @@ class DBController(metaclass=Singleton):
         return sum(dev.size for dev in snode.nvme_devices)
 
     def get_jm_device_by_id(self, jm_id: str) -> JMDevice:
-        for node in self.get_storage_nodes():
-            if node.jm_device and node.jm_device.get_id() == jm_id:
-                return node.jm_device
-        raise KeyError(f'JMDeviec {jm_id} not found')
+        device = single_or_none(
+            node.jm_device
+            for node in self.get_storage_nodes()
+            if node.jm_device and node.jm_device.get_id() == jm_id
+        )
+        if device is None:
+            raise KeyError(f'JMDevice {jm_id} not found')
+        return device
 
     def get_primary_storage_nodes_by_cluster_id(self, cluster_id: str) -> List[StorageNode]:
         ret = StorageNode().read_from_db(self.kv_store)
@@ -375,29 +377,21 @@ class DBController(metaclass=Singleton):
         return LVolMigration().read_from_db(self.kv_store, id=prefix)
 
     def get_migration_by_id(self, migration_id: str) -> LVolMigration:
-        for m in self.get_migrations():
-            if m.uuid == migration_id:
-                return m
-        raise KeyError(f'LVolMigration {migration_id} not found')
+        migration = single_or_none(m for m in self.get_migrations() if m.uuid == migration_id)
+        if migration is None:
+            raise KeyError(f'LVolMigration {migration_id} not found')
+        return migration
 
     def get_migration_by_lvol_id(self, lvol_id: str) -> Optional[LVolMigration]:
-        for m in self.get_migrations():
-            if m.lvol_id == lvol_id and m.is_active():
-                return m
-        return None
+        return single_or_none(
+            m for m in self.get_migrations() if m.lvol_id == lvol_id and m.is_active()
+        )
 
     def get_lvol_del_lock(self, node_id: str) -> Optional[NodeLVolDelLock]:
-        ret = NodeLVolDelLock().read_from_db(self.kv_store, id=node_id)
-        if ret:
-            return ret[0]
-        else:
-            return None
+        return single_or_none(NodeLVolDelLock().read_from_db(self.kv_store, id=node_id))
 
     def get_backup_chain_lock(self, snapshot_id: str) -> Optional[BackupChainLock]:
-        ret = BackupChainLock().read_from_db(self.kv_store, id=snapshot_id)
-        if ret:
-            return ret[0]
-        return None
+        return single_or_none(BackupChainLock().read_from_db(self.kv_store, id=snapshot_id))
 
     def _acquire_backup_chain_locks_tx(self, tr, snapshot_ids, requested_snapshot_id, lvol_id):
         import time
@@ -453,10 +447,7 @@ class DBController(metaclass=Singleton):
     # ---- Cluster node-add mesh lock (Single FDB Transaction) ----
 
     def get_cluster_add_lock(self, cluster_id: str) -> Optional[ClusterAddNodeLock]:
-        ret = ClusterAddNodeLock().read_from_db(self.kv_store, id=cluster_id)
-        if ret:
-            return ret[0]
-        return None
+        return single_or_none(ClusterAddNodeLock().read_from_db(self.kv_store, id=cluster_id))
 
     def _try_acquire_cluster_add_lock_tx(self, tr, cluster_id, owner, now):
         lock = ClusterAddNodeLock()
@@ -790,10 +781,10 @@ class DBController(metaclass=Singleton):
         return Backup().read_from_db(self.kv_store, id=prefix)
 
     def get_backup_by_id(self, backup_id: str) -> Backup:
-        for b in self.get_backups():
-            if b.uuid == backup_id:
-                return b
-        raise KeyError(f'Backup {backup_id} not found')
+        backup = single_or_none(b for b in self.get_backups() if b.uuid == backup_id)
+        if backup is None:
+            raise KeyError(f'Backup {backup_id} not found')
+        return backup
 
     def get_backups_by_lvol_id(self, lvol_id: str) -> List[Backup]:
         return [b for b in self.get_backups() if b.lvol_id == lvol_id]
@@ -822,10 +813,10 @@ class DBController(metaclass=Singleton):
         return BackupPolicy().read_from_db(self.kv_store, id=prefix)
 
     def get_backup_policy_by_id(self, policy_id: str) -> BackupPolicy:
-        for p in self.get_backup_policies():
-            if p.uuid == policy_id:
-                return p
-        raise KeyError(f'BackupPolicy {policy_id} not found')
+        policy = single_or_none(p for p in self.get_backup_policies() if p.uuid == policy_id)
+        if policy is None:
+            raise KeyError(f'BackupPolicy {policy_id} not found')
+        return policy
 
     def get_backup_policy_attachments(self, cluster_id: Optional[str] = None) -> List[BackupPolicyAttachment]:
         prefix = cluster_id if cluster_id else " "

--- a/simplyblock_core/utils/helpers.py
+++ b/simplyblock_core/utils/helpers.py
@@ -21,6 +21,26 @@ def single(xs):
         return x
 
 
+def single_or_none(xs):
+    """Returns the single value in the passed collection, or None if empty.
+
+    If `xs` contains multiple values, a ValueError error is raised.
+    """
+
+    it = iter(xs)
+
+    try:
+        x = next(it)
+    except StopIteration:
+        return None
+
+    try:
+        next(it)
+        raise ValueError('Multiple values present')
+    except StopIteration:
+        return x
+
+
 def parse_thread_siblings_list(siblings: str) -> list[int]:
     if not siblings or not siblings.strip():
         return []


### PR DESCRIPTION
Internals in the database make it easy to get multiple or no values when they are expected. The same functions are used to return multiple or a single values, differentiated by passing an optional value. If a value is passed that is semantically expected to be present, but None for whatever reason, this causes fault that depend on the individual helper. `get_cluster_by_id` returns a random cluster in that case, for example.

This PR attempts to alleviate this without touching the database internals:
- type annotations are added to indicate values passed to the database accessors are non-optional. This can expose the faults before runtime in some situations
- the accessors are reworked to use a helper that explicitly raises when multiple return values are encountered, but only one is expected