### PR TITLE
fix(health): parse node status as a token so SPDK's failure_domain field doesn't break health checks

### DIFF
--- a/simplyblock_core/distr_controller.py
+++ b/simplyblock_core/distr_controller.py
@@ -264,7 +264,14 @@ def get_distr_cluster_map(snodes, target_node, distr_name=""):
 
 def parse_distr_cluster_map(map_string, nodes=None, devices=None):
     db_controller = DBController()
-    node_pattern = re.compile(r".*uuid_node=(.*)  status=(.*)$", re.IGNORECASE)
+    # status is a single whitespace-free token (online/offline/unreachable/…).
+    # Capture it as such rather than greedily to end-of-line: SPDK appends
+    # trailing fields to the node line (e.g. "  failure_domain=-1"), and a greedy
+    # `status=(.*)` swallows them into the status value, so every node mismatched
+    # its DB status and flipped Health=False cluster-wide. The device line below
+    # keeps its `(.*)` capture because there the status is delimited by the
+    # following "  uuid_device=" field.
+    node_pattern = re.compile(r".*uuid_node=(.*)  status=(\S+)", re.IGNORECASE)
     device_pattern = re.compile(
         r".*storage_ID=(.*)  status=(.*)  uuid_device=(.*)  storage_bdev_name=(.*)$", re.IGNORECASE)
 

--- a/tests/unit/test_parse_distr_cluster_map.py
+++ b/tests/unit/test_parse_distr_cluster_map.py
@@ -1,0 +1,86 @@
+# coding=utf-8
+"""
+test_parse_distr_cluster_map.py — regression test for node-status parsing in
+``distr_controller.parse_distr_cluster_map``.
+
+The data-plane ``distr_dump_cluster_map`` output appends trailing fields to the
+node line, e.g.::
+
+    [0]  uuid_node=<uuid>  status=online  failure_domain=-1
+
+A greedy ``status=(.*)$`` capture swallowed the trailing ``failure_domain=-1``
+into the status value, so the parsed status (``"online  failure_domain=-1"``)
+never matched the control-plane DB status (``"online"``). Every node then
+reported ``failed`` and ``parse_distr_cluster_map`` returned ``passed=False``,
+flipping Health=False cluster-wide right after activation.
+"""
+
+import unittest
+from unittest.mock import MagicMock
+
+from simplyblock_core import distr_controller
+from simplyblock_core.models.nvme_device import NVMeDevice
+from simplyblock_core.models.storage_node import StorageNode
+
+
+def _node(node_id, status=StorageNode.STATUS_ONLINE):
+    n = MagicMock(spec=StorageNode)
+    n.get_id.return_value = node_id
+    n.status = status
+    return n
+
+
+def _device(dev_id, status=NVMeDevice.STATUS_ONLINE):
+    d = MagicMock(spec=NVMeDevice)
+    d.get_id.return_value = dev_id
+    d.status = status
+    return d
+
+
+# Mirrors the live SPDK dump format, including the trailing failure_domain field
+# on node lines and the physical_label field on device lines.
+_MAP_WITH_FAILURE_DOMAIN = """\
+    [0]  uuid_node=node-a  status=online  failure_domain=-1
+        [0]  storage_ID=0  physical_label=1  status=online  uuid_device=dev-0  storage_bdev_name=alceml_dev-0
+    [1]  uuid_node=node-b  status=online  failure_domain=-1
+        [0]  storage_ID=1  physical_label=2  status=online  uuid_device=dev-1  storage_bdev_name=remote_alceml_dev-1n1
+"""
+
+
+class TestParseDistrClusterMap(unittest.TestCase):
+
+    def _ctx(self):
+        nodes = {"node-a": _node("node-a"), "node-b": _node("node-b")}
+        devices = {"dev-0": _device("dev-0"), "dev-1": _device("dev-1")}
+        return nodes, devices
+
+    def test_trailing_failure_domain_does_not_break_node_status(self):
+        nodes, devices = self._ctx()
+        results, passed = distr_controller.parse_distr_cluster_map(
+            _MAP_WITH_FAILURE_DOMAIN, nodes, devices)
+
+        node_results = [r for r in results if r["Kind"] == "Node"]
+        self.assertEqual(len(node_results), 2)
+        for r in node_results:
+            self.assertEqual(
+                r["Found Status"], "online",
+                "trailing failure_domain field must not leak into the status")
+            self.assertEqual(r["Results"], "ok")
+
+        self.assertTrue(passed, "all-online map must parse as passed")
+
+    def test_genuine_node_status_mismatch_still_fails(self):
+        nodes, devices = self._ctx()
+        nodes["node-b"].status = StorageNode.STATUS_UNREACHABLE
+
+        results, passed = distr_controller.parse_distr_cluster_map(
+            _MAP_WITH_FAILURE_DOMAIN, nodes, devices)
+
+        self.assertFalse(passed)
+        node_b = next(r for r in results if r["UUID"] == "node-b")
+        self.assertEqual(node_b["Results"], "failed")
+        self.assertEqual(node_b["Found Status"], "online")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

After activation, every storage node reported `Health: False` (`sn list`), and `sbctl sn check` failed at:

```
Checking Distr map ... False
```

This was deterministic — it reproduced on every check and on every node, not just a freshly-added one.

## Root cause

SPDK's `distr_dump_cluster_map` now appends a trailing field to each **node** line:

```
[0]  uuid_node=<uuid>  status=online  failure_domain=-1
```

The node regex in `parse_distr_cluster_map` captured the status greedily to end-of-line:

```python
node_pattern = re.compile(r".*uuid_node=(.*)  status=(.*)$", re.IGNORECASE)
```

So `status` parsed as `'online  failure_domain=-1'`, which never equals the control-plane DB status `'online'`. Every node then mismatched and `parse_distr_cluster_map` returned `passed=False`, flipping `health_check=False` cluster-wide. (Device lines were unaffected — there the status is delimited by the following `  uuid_device=` field.)

This is purely a control-plane parse bug; no node-side state was actually wrong. Confirmed against a live cluster — the dump showed `status=online  failure_domain=-1` and `parse_distr_cluster_map` reported every node as `failed`.

## Fix

Capture the status as a single whitespace-free token, which stops before any trailing field and is robust to future additions (and to stray `\r`):

```python
node_pattern = re.compile(r".*uuid_node=(.*)  status=(\S+)", re.IGNORECASE)
```

Node statuses are a closed enum (`online`/`offline`/`unreachable`/`in_restart`/`in_shutdown`/`schedulable`/`down`/`removed`) — none contain whitespace, so a token capture loses nothing.

## Tests

Adds `tests/unit/test_parse_distr_cluster_map.py`, parsing a map in the live SPDK format (including the trailing `failure_domain` field):
- trailing `failure_domain` must not leak into the parsed status; an all-online map parses as `passed=True`
- a genuine node-status mismatch still fails

`ruff` + `mypy` clean; new tests and the existing `test_distr_cluster_map_weight.py` pass.

> Note: a follow-up will re-enable the commented-out node `health_check` assertion in the e2e base (`cluster_test_base.py`, SFAM-1930/1929) so this class of SPDK↔parser format drift is caught against a live cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)