### PR TITLE
Speed up cluster duplicate check

### DIFF
--- a/tests/integration/test_cluster_duplicate_name.py
+++ b/tests/integration/test_cluster_duplicate_name.py
@@ -1,303 +1,257 @@
 # coding=utf-8
 """
-test_cluster_duplicate_name.py – unit tests for duplicate cluster name prevention.
+test_cluster_duplicate_name.py – integration tests for duplicate cluster
+name prevention, running against the real FoundationDB provisioned by
+``tests/integration/conftest.py``.
 
 Tests cover:
   - add_cluster() raises ValueError when a cluster with the same name exists
-  - add_cluster() succeeds when the name is unique
+  - add_cluster() succeeds (and persists) when the name is unique
+  - add_cluster() skips the uniqueness check when name is None
   - create_cluster() raises ValueError when a cluster with the same name exists
-  - create_cluster() does not raise when no clusters exist yet
-  - set_name() raises ValueError when another cluster already has the target name
+  - create_cluster() succeeds (and persists) when no clusters exist yet
+  - set_name() raises ValueError when another cluster already has the name
   - set_name() allows renaming a cluster to its own current name
-  - change_cluster_name() raises ValueError when another cluster already has the target name
+  - set_name() persists a unique new name
+  - change_cluster_name() raises ValueError when another cluster has the name
   - change_cluster_name() allows renaming a cluster to its own current name
+  - change_cluster_name() persists a unique new name
 
-All external dependencies (FDB, Docker, Kubernetes, RPC) are mocked.
+The database layer is NOT mocked: real ``Cluster`` objects are written to
+FoundationDB through ``DBController`` and read back through the same code
+paths ``cluster_ops`` uses. Only side-effects *above* the DB (docker swarm,
+deploy scripts, mgmt-node provisioning, interface-IP lookup) are mocked, and
+only for ``create_cluster`` — whose duplicate-name guard is the sole part
+exercised for the "raises" case, so those mocks never engage there.
 """
 
-import sys
-import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
-# ---------------------------------------------------------------------------
-# Stub out only the truly uninstallable C-extension (fdb / FoundationDB).
-# Everything else (docker, kubernetes, boto3, simplyblock_core modules) can
-# be imported cleanly and must NOT be stubbed here because this module-level
-# code runs during pytest collection – before any test in any file executes –
-# and permanent sys.modules replacements would break other test files that
-# import the same modules as real modules.
-# ---------------------------------------------------------------------------
+import pytest
+from pydantic import SecretStr
 
-# Provide a real Singleton class so the conftest autouse fixture can call
-# Singleton._instances.clear() without error.
-class _Singleton(type):
-    _instances: dict = {}
-
-_db_ctrl_mock = MagicMock()
-_db_ctrl_mock.Singleton = _Singleton
-_db_ctrl_mock.DBController = MagicMock()
-
-# Only stub the C-extension that cannot be pip-installed in dev environments.
-sys.modules.setdefault("fdb", MagicMock())
-sys.modules.setdefault("fdb.tuple", MagicMock())
-
-# NOTE: Do NOT replace sys.modules["simplyblock_core.db_controller"] — doing
-# so permanently poisons the DBController singleton for the entire pytest
-# session, causing test_backup, test_dual_ft_e2e, migration tests and others
-# to fail with MagicMock serialization errors. The fdb stubs above are
-# sufficient to allow the import below.
-
-# Now we can safely import simplyblock_core pieces.
-from simplyblock_core import cluster_ops  # noqa: E402  (needed so @patch can resolve the target)
-from simplyblock_core.models.cluster import Cluster  # noqa: E402
+from simplyblock_core import cluster_ops
+from simplyblock_core.db_controller import DBController
+from simplyblock_core.models.cluster import Cluster
 
 
 # ---------------------------------------------------------------------------
-# Helpers
+# Fixtures — real FDB, wiped before every test for isolation.
 # ---------------------------------------------------------------------------
 
-def _cluster(uuid="cluster-1", name="test-cluster"):
+@pytest.fixture()
+def db():
+    controller = DBController()
+    if controller.kv_store is None:
+        pytest.skip("FoundationDB is not available")
+    return controller
+
+
+@pytest.fixture(autouse=True)
+def _clean_keyspace(db):
+    # The tier-wide fixture only wipes once per module; wipe per-test here so
+    # clusters seeded by one test never leak into the next.
+    db.kv_store.clear_range(b"\x00", b"\xff")
+    yield
+
+
+def _seed_cluster(db, uuid="cluster-1", name="test-cluster", mode="docker"):
+    """Persist a real Cluster to FDB and return it."""
     c = Cluster()
     c.uuid = uuid
     c.cluster_name = name
-    c.mode = "docker"
-    c.db_connection = "user:pass@127.0.0.1:4500"
-    c.grafana_secret = "secret"
-    c.grafana_endpoint = "http://grafana:3000"
+    c.mode = mode
+    c.status = Cluster.STATUS_ACTIVE
+    c.write_to_db(db.kv_store)
     return c
 
 
 # ---------------------------------------------------------------------------
-# Tests for add_cluster()
+# add_cluster()
 # ---------------------------------------------------------------------------
 
-class TestAddClusterDuplicateName(unittest.TestCase):
+def _add_cluster(name):
+    return cluster_ops.add_cluster(
+        blk_size=4096,
+        page_size_in_blocks=2,
+        cap_warn=80,
+        cap_crit=90,
+        prov_cap_warn=80,
+        prov_cap_crit=90,
+        distr_ndcs=1,
+        distr_npcs=1,
+        distr_bs=4096,
+        distr_chunk_bs=4096,
+        ha_type="single",
+        enable_node_affinity=False,
+        qpair_count=4,
+        max_queue_size=128,
+        inflight_io_threshold=64,
+        strict_node_anti_affinity=False,
+        is_single_node=True,
+        name=name,
+    )
 
-    def _call(self, name):
-        return cluster_ops.add_cluster(
-            blk_size=4096,
-            page_size_in_blocks=2,
-            cap_warn=80,
-            cap_crit=90,
-            prov_cap_warn=80,
-            prov_cap_crit=90,
-            distr_ndcs=1,
-            distr_npcs=1,
-            distr_bs=4096,
-            distr_chunk_bs=4096,
-            ha_type="single",
-            enable_node_affinity=False,
-            qpair_count=4,
-            max_queue_size=128,
-            inflight_io_threshold=64,
-            strict_node_anti_affinity=False,
-            is_single_node=True,
-            name=name,
-        )
 
-    @patch("simplyblock_core.cluster_ops.db_controller")
-    def test_raises_when_name_already_exists(self, mock_db):
-        existing = _cluster(uuid="cluster-1", name="my-cluster")
-        mock_db.get_clusters.return_value = [existing]
+class TestAddClusterDuplicateName:
 
-        with self.assertRaises(ValueError) as ctx:
-            self._call("my-cluster")
+    def test_raises_when_name_already_exists(self, db):
+        _seed_cluster(db, uuid="cluster-1", name="my-cluster")
 
-        self.assertIn("my-cluster", str(ctx.exception))
+        with pytest.raises(ValueError, match="my-cluster"):
+            _add_cluster("my-cluster")
 
-    @patch("simplyblock_core.cluster_ops.db_controller")
-    def test_raises_when_one_of_many_clusters_matches(self, mock_db):
-        mock_db.get_clusters.return_value = [
-            _cluster(uuid="cluster-1", name="alpha"),
-            _cluster(uuid="cluster-2", name="beta"),
-        ]
+    def test_raises_when_one_of_many_clusters_matches(self, db):
+        _seed_cluster(db, uuid="cluster-1", name="alpha")
+        _seed_cluster(db, uuid="cluster-2", name="beta")
 
-        with self.assertRaises(ValueError) as ctx:
-            self._call("beta")
+        with pytest.raises(ValueError, match="beta"):
+            _add_cluster("beta")
 
-        self.assertIn("beta", str(ctx.exception))
+    def test_succeeds_and_persists_when_name_is_unique(self, db):
+        # An existing docker cluster makes add_cluster inherit its mode and
+        # skip the k8s/first-cluster provisioning branch entirely — no docker
+        # or deploy side-effects on this path, so nothing needs mocking.
+        _seed_cluster(db, uuid="cluster-1", name="other-cluster")
 
-    @patch("simplyblock_core.cluster_ops.qos_controller")
-    @patch("simplyblock_core.cluster_ops.cluster_events")
-    @patch("simplyblock_core.cluster_ops._create_update_user")
-    @patch("simplyblock_core.cluster_ops.db_controller")
-    def test_succeeds_when_name_is_unique(self, mock_db, _mock_user, _mock_events, _mock_qos):
-        mock_db.get_clusters.return_value = [_cluster(uuid="cluster-1", name="other-cluster")]
-        mock_db.kv_store = MagicMock()
+        new_id = _add_cluster("new-cluster")
 
-        with patch("simplyblock_core.cluster_ops.utils") as mock_utils:
-            mock_utils.generate_string.return_value = "x" * 20
-            result = self._call("new-cluster")
+        stored = db.get_cluster_by_id(new_id)
+        assert stored.cluster_name == "new-cluster"
 
-        self.assertIsNotNone(result)
+    def test_no_name_skips_duplicate_check(self, db):
+        # name=None must bypass the uniqueness check: a second cluster is
+        # created even though one already exists. (The str-typed cluster_name
+        # field round-trips None as "None" through FDB, so assert on the
+        # created id / cluster count rather than the stored name.)
+        _seed_cluster(db, uuid="cluster-1", name="some-cluster")
 
-    @patch("simplyblock_core.cluster_ops.qos_controller")
-    @patch("simplyblock_core.cluster_ops.cluster_events")
-    @patch("simplyblock_core.cluster_ops._create_update_user")
-    @patch("simplyblock_core.cluster_ops.db_controller")
-    def test_no_name_skips_duplicate_check(self, mock_db, _mock_user, _mock_events, _mock_qos):
-        """name=None should bypass the uniqueness check."""
-        mock_db.get_clusters.return_value = [_cluster(uuid="cluster-1", name="some-cluster")]
-        mock_db.kv_store = MagicMock()
+        new_id = _add_cluster(None)
 
-        with patch("simplyblock_core.cluster_ops.utils") as mock_utils:
-            mock_utils.generate_string.return_value = "x" * 20
-            result = self._call(None)
-
-        self.assertIsNotNone(result)
+        assert db.get_cluster_by_id(new_id).uuid == new_id
+        assert len(db.get_clusters()) == 2
 
 
 # ---------------------------------------------------------------------------
-# Tests for create_cluster()
+# create_cluster()
 # ---------------------------------------------------------------------------
 
-class TestCreateClusterDuplicateName(unittest.TestCase):
+def _create_cluster(name):
+    return cluster_ops.create_cluster(
+        blk_size=4096,
+        page_size_in_blocks=2,
+        cli_pass=SecretStr("pass"),
+        cap_warn=80,
+        cap_crit=90,
+        prov_cap_warn=80,
+        prov_cap_crit=90,
+        ifname="eth0",
+        mgmt_ip=None,
+        log_del_interval=7,
+        metrics_retention_period=30,
+        contact_point=None,
+        grafana_endpoint=None,
+        distr_ndcs=1,
+        distr_npcs=1,
+        distr_bs=4096,
+        distr_chunk_bs=4096,
+        ha_type="single",
+        mode="docker",
+        enable_node_affinity=False,
+        qpair_count=4,
+        client_qpair_count=4,
+        max_queue_size=128,
+        inflight_io_threshold=64,
+        disable_monitoring=True,
+        strict_node_anti_affinity=False,
+        name=name,
+        tls_secret=None,
+        ingress_host_source=None,
+        dns_name=None,
+        fabric="tcp",
+        is_single_node=True,
+        client_data_nic="",
+    )
 
-    def _call(self, name, existing_clusters=None):
-        with patch("simplyblock_core.cluster_ops.db_controller") as mock_db, \
-             patch("simplyblock_core.cluster_ops.scripts"), \
-             patch("simplyblock_core.cluster_ops.utils") as mock_utils:
-            mock_db.get_clusters.return_value = existing_clusters or []
-            mock_db.kv_store = MagicMock()
-            mock_utils.get_iface_ip.return_value = "10.0.0.1"
-            mock_utils.generate_string.return_value = "generated"
 
-            return cluster_ops.create_cluster(
-                blk_size=4096,
-                page_size_in_blocks=2,
-                cli_pass="pass",
-                cap_warn=80,
-                cap_crit=90,
-                prov_cap_warn=80,
-                prov_cap_crit=90,
-                ifname="eth0",
-                mgmt_ip=None,
-                log_del_interval=7,
-                metrics_retention_period=30,
-                contact_point=None,
-                grafana_endpoint=None,
-                distr_ndcs=1,
-                distr_npcs=1,
-                distr_bs=4096,
-                distr_chunk_bs=4096,
-                ha_type="single",
-                mode="docker",
-                enable_node_affinity=False,
-                qpair_count=4,
-                client_qpair_count=4,
-                max_queue_size=128,
-                inflight_io_threshold=64,
-                disable_monitoring=True,
-                strict_node_anti_affinity=False,
-                name=name,
-                tls_secret=None,
-                ingress_host_source=None,
-                dns_name=None,
-                fabric="tcp",
-                is_single_node=True,
-                client_data_nic="",
-            )
+class TestCreateClusterDuplicateName:
 
-    def test_raises_when_name_already_exists(self):
-        existing = _cluster(uuid="cluster-1", name="first-cluster")
+    def test_raises_when_name_already_exists(self, db):
+        # The duplicate-name guard fires before any docker/deploy work, so no
+        # infra mocking is needed — the ValueError is raised straight away.
+        _seed_cluster(db, uuid="cluster-1", name="first-cluster")
 
-        with self.assertRaises(ValueError) as ctx:
-            self._call("first-cluster", existing_clusters=[existing])
+        with pytest.raises(ValueError, match="first-cluster"):
+            _create_cluster("first-cluster")
 
-        self.assertIn("first-cluster", str(ctx.exception))
+    def test_succeeds_and_persists_when_no_clusters_exist(self, db):
+        # No pre-existing cluster → the guard passes and create_cluster runs
+        # its full docker deploy flow. Mock only the side-effects above the DB
+        # (docker swarm, deploy scripts, mgmt-node provisioning, iface lookup);
+        # the cluster is still written to and read back from the real FDB.
+        with patch("simplyblock_core.cluster_ops.scripts"), \
+             patch("simplyblock_core.cluster_ops.docker"), \
+             patch("simplyblock_core.cluster_ops.mgmt_node_ops"), \
+             patch("simplyblock_core.cluster_ops.utils.get_iface_ip", return_value="10.0.0.1"):
+            new_id = _create_cluster("brand-new")
 
-    def test_no_existing_clusters_skips_name_check(self):
-        """When no clusters exist the duplicate-name check must not fire."""
-        # If any exception surfaces it must not be our duplicate-name ValueError.
-        try:
-            self._call("brand-new", existing_clusters=[])
-        except Exception as exc:
-            self.assertNotIn("already exists", str(exc))
+        stored = db.get_cluster_by_id(new_id)
+        assert stored.cluster_name == "brand-new"
 
 
 # ---------------------------------------------------------------------------
-# Tests for set_name()
+# set_name()
 # ---------------------------------------------------------------------------
 
-class TestSetNameDuplicateName(unittest.TestCase):
+class TestSetNameDuplicateName:
 
-    @patch("simplyblock_core.cluster_ops.db_controller")
-    def test_raises_when_another_cluster_has_the_name(self, mock_db):
-        target = _cluster(uuid="cluster-1", name="old-name")
-        other = _cluster(uuid="cluster-2", name="taken-name")
-        mock_db.get_cluster_by_id.return_value = target
-        mock_db.get_clusters.return_value = [target, other]
+    def test_raises_when_another_cluster_has_the_name(self, db):
+        _seed_cluster(db, uuid="cluster-1", name="old-name")
+        _seed_cluster(db, uuid="cluster-2", name="taken-name")
 
-        with self.assertRaises(ValueError) as ctx:
+        with pytest.raises(ValueError, match="taken-name"):
             cluster_ops.set_name("cluster-1", "taken-name")
 
-        self.assertIn("taken-name", str(ctx.exception))
+    def test_allows_renaming_to_own_current_name(self, db):
+        _seed_cluster(db, uuid="cluster-1", name="my-cluster")
 
-    @patch("simplyblock_core.cluster_ops.cluster_events")
-    @patch("simplyblock_core.cluster_ops.db_controller")
-    def test_allows_renaming_to_own_current_name(self, mock_db, _mock_events):
-        target = _cluster(uuid="cluster-1", name="my-cluster")
-        mock_db.get_cluster_by_id.return_value = target
-        mock_db.get_clusters.return_value = [target]
-        mock_db.kv_store = MagicMock()
+        result = cluster_ops.set_name("cluster-1", "my-cluster")  # must not raise
 
-        cluster_ops.set_name("cluster-1", "my-cluster")  # must not raise
+        assert result.cluster_name == "my-cluster"
 
-    @patch("simplyblock_core.cluster_ops.cluster_events")
-    @patch("simplyblock_core.cluster_ops.db_controller")
-    def test_allows_unique_new_name(self, mock_db, _mock_events):
-        target = _cluster(uuid="cluster-1", name="old-name")
-        other = _cluster(uuid="cluster-2", name="other-cluster")
-        mock_db.get_cluster_by_id.return_value = target
-        mock_db.get_clusters.return_value = [target, other]
-        mock_db.kv_store = MagicMock()
+    def test_persists_unique_new_name(self, db):
+        _seed_cluster(db, uuid="cluster-1", name="old-name")
+        _seed_cluster(db, uuid="cluster-2", name="other-cluster")
 
-        result = cluster_ops.set_name("cluster-1", "brand-new-name")
+        cluster_ops.set_name("cluster-1", "brand-new-name")
 
-        self.assertEqual(result.cluster_name, "brand-new-name")
+        assert db.get_cluster_by_id("cluster-1").cluster_name == "brand-new-name"
 
 
 # ---------------------------------------------------------------------------
-# Tests for change_cluster_name()
+# change_cluster_name()
 # ---------------------------------------------------------------------------
 
-class TestChangeClusterNameDuplicateName(unittest.TestCase):
+class TestChangeClusterNameDuplicateName:
 
-    @patch("simplyblock_core.cluster_ops.db_controller")
-    def test_raises_when_another_cluster_has_the_name(self, mock_db):
-        target = _cluster(uuid="cluster-1", name="old-name")
-        other = _cluster(uuid="cluster-2", name="taken-name")
-        mock_db.get_cluster_by_id.return_value = target
-        mock_db.get_clusters.return_value = [target, other]
+    def test_raises_when_another_cluster_has_the_name(self, db):
+        _seed_cluster(db, uuid="cluster-1", name="old-name")
+        _seed_cluster(db, uuid="cluster-2", name="taken-name")
 
-        with self.assertRaises(ValueError) as ctx:
+        with pytest.raises(ValueError, match="taken-name"):
             cluster_ops.change_cluster_name("cluster-1", "taken-name")
 
-        self.assertIn("taken-name", str(ctx.exception))
-
-    @patch("simplyblock_core.cluster_ops.cluster_events")
-    @patch("simplyblock_core.cluster_ops.db_controller")
-    def test_allows_renaming_to_own_current_name(self, mock_db, _mock_events):
-        target = _cluster(uuid="cluster-1", name="my-cluster")
-        mock_db.get_cluster_by_id.return_value = target
-        mock_db.get_clusters.return_value = [target]
-        mock_db.kv_store = MagicMock()
+    def test_allows_renaming_to_own_current_name(self, db):
+        _seed_cluster(db, uuid="cluster-1", name="my-cluster")
 
         cluster_ops.change_cluster_name("cluster-1", "my-cluster")  # must not raise
 
-    @patch("simplyblock_core.cluster_ops.cluster_events")
-    @patch("simplyblock_core.cluster_ops.db_controller")
-    def test_allows_unique_new_name(self, mock_db, _mock_events):
-        target = _cluster(uuid="cluster-1", name="old-name")
-        other = _cluster(uuid="cluster-2", name="other-cluster")
-        mock_db.get_cluster_by_id.return_value = target
-        mock_db.get_clusters.return_value = [target, other]
-        mock_db.kv_store = MagicMock()
+        assert db.get_cluster_by_id("cluster-1").cluster_name == "my-cluster"
+
+    def test_persists_unique_new_name(self, db):
+        _seed_cluster(db, uuid="cluster-1", name="old-name")
+        _seed_cluster(db, uuid="cluster-2", name="other-cluster")
 
         cluster_ops.change_cluster_name("cluster-1", "unique-name")
 
-        self.assertEqual(target.cluster_name, "unique-name")
-
-
-if __name__ == "__main__":
-    unittest.main()
+        assert db.get_cluster_by_id("cluster-1").cluster_name == "unique-name"


### PR DESCRIPTION
The check failed to spoof the FDB completely and was stuck on timeouts, leading to it running for >60s. This rewrites the check to use the proper database, speeding it up to negligible execution time.