### PR TITLE
Enable migration integration tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,7 +33,7 @@ jobs:
   integration:
     name: Integration tests
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/simplyblock_core/controllers/migration_controller.py
+++ b/simplyblock_core/controllers/migration_controller.py
@@ -411,11 +411,20 @@ def get_snapshot_chain(lvol_id, source_node_id=None):
 
 
 def _is_snap_on_node(snap_id, node_id):
-    """Return True if *snap_id* already has an instance on *node_id*."""
+    """Return True if *snap_id* already has a copy on *node_id*.
+
+    Checks both the canonical location (``snap.lvol.node_id`` — set when the
+    snapshot's own owning lvol has migrated directly, without going through
+    the ``.instances`` bookkeeping) and the ``.instances`` list (set when a
+    *different* lvol's migration deposited a copy while sharing this
+    snapshot's ancestry, e.g. via ``cloned_from_snap`` or an inherited chain).
+    """
     try:
         snap = db.get_snapshot_by_id(snap_id)
     except KeyError:
         return False
+    if snap.lvol.node_id == node_id:
+        return True
     return any(
         inst.get('lvol', {}).get('node_id') == node_id
         for inst in (snap.instances or [])

--- a/simplyblock_core/services/tasks_runner_lvol_migration.py
+++ b/simplyblock_core/services/tasks_runner_lvol_migration.py
@@ -714,7 +714,7 @@ def _setup_snap_transfer(snap, snap_index, migration, src_node, tgt_node,
     Callers are responsible for rolling back any previously launched transfers.
     """
     snap_uuid = snap.uuid
-    snap_short = _snap_short_name(snap) + _MIGRATION_BDEV_SUFFIX
+    snap_short = _snap_tgt_short_name(snap)
     src_composite = _snap_composite(src_node.lvstore, snap)
     tgt_composite = f"{tgt_node.lvstore}/{snap_short}"
 
@@ -832,7 +832,7 @@ def _post_process_snap(snap: SnapShot, tgt_node: StorageNode, tgt_rpc: RPCClient
             # Predecessor was created on target with the migration suffix — build
             # composite from the source short name + suffix, not from snap_bdev
             # (which still holds the source path until apply_migration_to_db runs).
-            pred_composite = f"{tgt_node.lvstore}/{_snap_short_name(pred_snap) + _MIGRATION_BDEV_SUFFIX}"
+            pred_composite = f"{tgt_node.lvstore}/{_snap_tgt_short_name(pred_snap)}"
             ret = tgt_rpc.bdev_lvol_add_clone(tgt_composite, pred_composite)
             if not ret:
                 return False, f"bdev_lvol_add_clone failed for {snap_uuid}"
@@ -959,8 +959,7 @@ def _handle_snap_copy(migration, src_node, tgt_node, src_rpc, tgt_rpc):
                 except KeyError:
                     return False, True, f"Snapshot {snap_uuid} not found in DB"
 
-                snap_short_src = _snap_short_name(snap)
-                snap_short_tgt = snap_short_src + _MIGRATION_BDEV_SUFFIX
+                snap_short_tgt = _snap_tgt_short_name(snap)
                 src_composite = _snap_composite(src_node.lvstore, snap)
                 tgt_composite = f"{tgt_node.lvstore}/{snap_short_tgt}"
 
@@ -1171,8 +1170,7 @@ def _handle_snap_copy(migration, src_node, tgt_node, src_rpc, tgt_rpc):
             if tgt_sec:
                 sec_rpc = _make_rpc(tgt_sec)
 
-        snap_short_src = _snap_short_name(snap)
-        snap_short_tgt = snap_short_src + _MIGRATION_BDEV_SUFFIX
+        snap_short_tgt = _snap_tgt_short_name(snap)
         src_composite  = _snap_composite(src_node.lvstore, snap)
         tgt_composite  = f"{tgt_node.lvstore}/{snap_short_tgt}"
 
@@ -1420,7 +1418,7 @@ def _handle_lvol_migrate(migration, src_node, tgt_node, src_rpc, tgt_rpc):
                 src_rpc.bdev_nvme_detach_controller(ctrl_name)
                 _delete_bdev_blocking(tgt_lvol_composite, tgt_rpc, secondary_rpc=sec_setup_rpc)
                 return False, True, f"Last snapshot {last_snap_uuid} not found"
-            tgt_snap_composite = f"{tgt_node.lvstore}/{_snap_short_name(last_snap) + _MIGRATION_BDEV_SUFFIX}"
+            tgt_snap_composite = f"{tgt_node.lvstore}/{_snap_tgt_short_name(last_snap)}"
         else:
             last_snap_uuid = migration.snaps_preexisting_on_target[-1]
             last_snap = db.get_snapshot_by_id(last_snap_uuid)

--- a/tests/integration/migration/conftest.py
+++ b/tests/integration/migration/conftest.py
@@ -137,11 +137,17 @@ def mock_tgt_server():
 
 @pytest.fixture(scope="session")
 def mock_sec_server():
-    """Mock RPC server for the target secondary node (HA tests)."""
+    """Mock RPC server for the target secondary node (HA tests).
+
+    Shares the primary target's lvstore name ("lvs_tgt"): the migration
+    runner always builds secondary-bound composites from ``tgt_node.lvstore``
+    (the primary's), never the secondary's own lvstore field, matching the
+    real-world convention that HA peers mirror the same lvstore name.
+    """
     offset = _worker_port_offset()
     srv = MockRpcServer(
         host="127.0.0.1", port=_BASE_PORT_SEC + offset,
-        lvstore="lvs_tgt_sec", node_id="tgt-sec",
+        lvstore="lvs_tgt", node_id="tgt-sec",
     )
     srv.start()
     yield srv

--- a/tests/integration/migration/conftest.py
+++ b/tests/integration/migration/conftest.py
@@ -94,6 +94,7 @@ def ensure_cluster():
 _BASE_PORT_SRC = 9901
 _BASE_PORT_TGT = 9902
 _BASE_PORT_SEC = 9903
+_BASE_PORT_SRC_SEC = 9904
 
 
 def _worker_port_offset() -> int:
@@ -154,6 +155,27 @@ def mock_sec_server():
     srv.stop()
 
 
+@pytest.fixture(scope="session")
+def mock_src_sec_server():
+    """Mock RPC server for the source node's own HA secondary.
+
+    Some data-plane operations against an ha_type="ha" lvol (e.g. taking an
+    intermediate snapshot mid-migration) unconditionally resolve the current
+    host node's secondary/tertiary peers. The source node needs a real,
+    resolvable secondary for those code paths — sharing the source's own
+    lvstore name ("lvs_src"), per the same HA-peer-naming convention as
+    ``mock_sec_server``.
+    """
+    offset = _worker_port_offset()
+    srv = MockRpcServer(
+        host="127.0.0.1", port=_BASE_PORT_SRC_SEC + offset,
+        lvstore="lvs_src", node_id="src-sec",
+    )
+    srv.start()
+    yield srv
+    srv.stop()
+
+
 # ---------------------------------------------------------------------------
 # Per-test helpers
 # ---------------------------------------------------------------------------
@@ -192,9 +214,10 @@ def topology_two_node(ensure_cluster, mock_src_server, mock_tgt_server):
 
 
 @pytest.fixture()
-def topology_two_node_ha(ensure_cluster, mock_src_server, mock_tgt_server, mock_sec_server):
-    """Two-node HA topology (primary + secondary on target)."""
-    _reset_servers(mock_src_server, mock_tgt_server, mock_sec_server)
+def topology_two_node_ha(ensure_cluster, mock_src_server, mock_tgt_server, mock_sec_server,
+                         mock_src_sec_server):
+    """Two-node HA topology (primary + secondary on both source and target)."""
+    _reset_servers(mock_src_server, mock_tgt_server, mock_sec_server, mock_src_sec_server)
 
     spec = _load_spec("two_node_ha.json")
 
@@ -206,6 +229,8 @@ def topology_two_node_ha(ensure_cluster, mock_src_server, mock_tgt_server, mock_
             node["rpc_port"] = _BASE_PORT_TGT + offset
         elif node["id"] == "tgt-sec":
             node["rpc_port"] = _BASE_PORT_SEC + offset
+        elif node["id"] == "src-sec":
+            node["rpc_port"] = _BASE_PORT_SRC_SEC + offset
 
     ctx = load_topology(spec)
     yield ctx
@@ -323,6 +348,7 @@ def start_migration(lvol_id, target_node_id, max_retries=None, deadline_seconds=
     """
     from simplyblock_core.controllers import migration_controller
     from simplyblock_core.exceptions import MigrationConflictError, PreconditionError
+    from simplyblock_core.rpc_client import RPCException
 
     create_kwargs = {}
     if ctrl_loss_tmo is not None:
@@ -333,7 +359,7 @@ def start_migration(lvol_id, target_node_id, max_retries=None, deadline_seconds=
     try:
         migration_id, _connect_strings = migration_controller.create_migration(
             lvol_id, target_node_id, **create_kwargs)
-    except (ValueError, MigrationConflictError, PreconditionError) as e:
+    except (ValueError, MigrationConflictError, PreconditionError, RPCException) as e:
         return False, str(e)
 
     start_kwargs = {}
@@ -344,7 +370,7 @@ def start_migration(lvol_id, target_node_id, max_retries=None, deadline_seconds=
 
     try:
         migration_controller.start_migration(migration_id, **start_kwargs)
-    except ValueError as e:
+    except (ValueError, RPCException) as e:
         return False, str(e)
 
     return migration_id, None

--- a/tests/integration/migration/conftest.py
+++ b/tests/integration/migration/conftest.py
@@ -31,18 +31,23 @@ logger = logging.getLogger(__name__)
 # Cluster bootstrap
 # ---------------------------------------------------------------------------
 
-@pytest.fixture(scope="session")
+@pytest.fixture()
 def ensure_cluster():
     """
-    Guarantee that at least one Cluster record exists in FDB before any test
+    Guarantee that at least one Cluster record exists in FDB before a test
     runs.  This covers two scenarios:
 
     1. **Real control-plane deployment** – a cluster was already created by
        ``sbcli cluster create``.  This fixture detects it and does nothing.
 
     2. **Standalone dev / CI** – only FDB is running, no control-plane setup.
-       The fixture creates a minimal cluster record for the test session and
-       removes it afterward.
+       The fixture creates a minimal cluster record for the test and removes
+       it afterward.
+
+    Function-scoped (not session-scoped) because ``tests/integration/conftest.py``
+    wipes the FDB keyspace once per test module; a session-scoped cluster
+    created before the first module's wipe would vanish for every module
+    after the first.
 
     Either way, topology fixtures always find an existing cluster to attach to.
     """
@@ -59,7 +64,7 @@ def ensure_cluster():
         yield
         return
 
-    # No cluster found – create a minimal one for this test session.
+    # No cluster found – create a minimal one for this test.
     cluster = Cluster()
     cluster.uuid = f"test-session-{_uuid_mod.uuid4().hex[:12]}"
     cluster.status = Cluster.STATUS_ACTIVE
@@ -71,7 +76,7 @@ def ensure_cluster():
     cluster.distr_chunk_bs = 4096
     cluster.nqn = f"nqn.2023-02.io.simplyblock:{cluster.uuid[:8]}"
     cluster.write_to_db(db.kv_store)
-    logger.info(f"Created test cluster {cluster.uuid} for this session")
+    logger.info(f"Created test cluster {cluster.uuid}")
 
     yield
 
@@ -291,6 +296,52 @@ def custom_topology(ensure_cluster, mock_src_server, mock_tgt_server, mock_sec_s
 
     for ctx in created:
         ctx.teardown()
+
+
+# ---------------------------------------------------------------------------
+# start_migration adapter
+# ---------------------------------------------------------------------------
+
+def start_migration(lvol_id, target_node_id, max_retries=None, deadline_seconds=None,
+                    ctrl_loss_tmo=None, host_nqn=None):
+    """
+    Test-only adapter over the real two-step migration API.
+
+    ``migration_controller`` split the old single-call ``start_migration(lvol_id,
+    target_node_id)`` into ``create_migration(lvol_id, target_node_id)`` (sets up
+    target infra, returns a PHASE_PRE_CREATED migration_id) followed by
+    ``start_migration(migration_id)`` (validates preconditions and launches the
+    task runner). This suite's tests were written against the old single-call,
+    ``(migration_id, error)``-tuple shape, so this adapter composes the two real
+    calls and reports the first failure either one raises.
+    """
+    from simplyblock_core.controllers import migration_controller
+    from simplyblock_core.exceptions import MigrationConflictError, PreconditionError
+
+    create_kwargs = {}
+    if ctrl_loss_tmo is not None:
+        create_kwargs["ctrl_loss_tmo"] = ctrl_loss_tmo
+    if host_nqn is not None:
+        create_kwargs["host_nqn"] = host_nqn
+
+    try:
+        migration_id, _connect_strings = migration_controller.create_migration(
+            lvol_id, target_node_id, **create_kwargs)
+    except (ValueError, MigrationConflictError, PreconditionError) as e:
+        return False, str(e)
+
+    start_kwargs = {}
+    if max_retries is not None:
+        start_kwargs["max_retries"] = max_retries
+    if deadline_seconds is not None:
+        start_kwargs["deadline_seconds"] = deadline_seconds
+
+    try:
+        migration_controller.start_migration(migration_id, **start_kwargs)
+    except ValueError as e:
+        return False, str(e)
+
+    return migration_id, None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/migration/mock_rpc_server.py
+++ b/tests/integration/migration/mock_rpc_server.py
@@ -13,7 +13,7 @@ Each MockRpcServer instance:
 
 Async-operation simulation
 --------------------------
-`delete_lvol(sync=False)` and `bdev_lvol_transfer` / `bdev_lvol_final_migration`
+`delete_lvol(sync=False)` and `bdev_lvol_transfer` / `bdev_lvol_transfer_final_step`
 are modelled as asynchronous: they record a ``complete_at`` timestamp drawn from an
 exponential distribution centred around 0.2 s (λ = 5), clipped to [0.1, 100] s.
 Subsequent poll calls (`bdev_lvol_get_lvol_delete_status`,
@@ -220,7 +220,7 @@ _METHOD_ERROR_CODES: Dict[str, list] = {
     "bdev_lvol_add_clone":           [-1, -22, -2],
     "bdev_lvol_convert":             [-1, -22],
     "bdev_lvol_get_lvols":           [-1],
-    "bdev_lvol_final_migration":     [-1, -22, -2],
+    "bdev_lvol_transfer_final_step": [-1, -22, -2],
     "bdev_lvol_register":            [-1, -22, -17],
     "bdev_lvol_snapshot_register":   [-1, -22],
     "bdev_get_bdevs":                [-1],
@@ -558,8 +558,12 @@ def _bdev_lvol_transfer_stat(s: NodeState, p: dict):
     return {'transfer_state': op['state'], 'offset': 0}
 
 
-def _bdev_lvol_final_migration(s: NodeState, p: dict):
-    """Start async final-migration (source lvol → target blobstore)."""
+def _bdev_lvol_transfer_final_step(s: NodeState, p: dict):
+    """Start async final-migration (source lvol → target blobstore).
+
+    Wire name for ``RPCClient.bdev_lvol_final_migration`` (a deprecated alias
+    for ``bdev_lvol_transfer_final_step``).
+    """
     lvol_name = _req(p, 'lvol_name')
     composite = lvol_name if lvol_name in s.lvols else s.composite(lvol_name)
     if composite not in s.lvols:
@@ -568,7 +572,7 @@ def _bdev_lvol_final_migration(s: NodeState, p: dict):
         'complete_at': time.time() + _async_delay(),
         'state': 'In progress',
     }
-    logger.debug("mock bdev_lvol_final_migration started for %s", composite)
+    logger.debug("mock bdev_lvol_transfer_final_step started for %s", composite)
     return True
 
 
@@ -788,7 +792,7 @@ _DISPATCH = {
     'ultra21_lvol_set':                      _ultra21_lvol_set,
     'bdev_lvol_transfer':                    _bdev_lvol_transfer,
     'bdev_lvol_transfer_stat':               _bdev_lvol_transfer_stat,
-    'bdev_lvol_final_migration':             _bdev_lvol_final_migration,
+    'bdev_lvol_transfer_final_step':         _bdev_lvol_transfer_final_step,
     'nvmf_create_subsystem':                 _nvmf_create_subsystem,
     'nvmf_delete_subsystem':                 _nvmf_delete_subsystem,
     'nvmf_get_subsystems':                   _nvmf_get_subsystems,

--- a/tests/integration/migration/mock_rpc_server.py
+++ b/tests/integration/migration/mock_rpc_server.py
@@ -64,6 +64,10 @@ class NodeState:
         self.subsystems: Dict[str, dict] = {}
         # ctrl_name → {nqn, traddr, trsvcid, trtype}
         self.nvme_controllers: Dict[str, dict] = {}
+        # remote bdev name (e.g. "<ctrl_name>n1") → {name, controller} — mirrors
+        # the local bdev(s) real SPDK creates when bdev_nvme_attach_controller
+        # succeeds, so get_bdevs()-based "already attached" checks work.
+        self.nvme_bdevs: Dict[str, dict] = {}
         # async-delete: composite_name → complete_at float
         self.delete_ops: Dict[str, float] = {}
         # async-transfer: composite_name → {complete_at, state}
@@ -105,6 +109,9 @@ class NodeState:
         return composite
 
     def all_bdevs(self) -> Dict[str, dict]:
+        """Lvol-store bdevs only (lvols + snapshots) — excludes NVMe-attached
+        remote bdevs, which have a different shape and are looked up separately
+        (see ``_bdev_get_bdevs``)."""
         return {**self.lvols, **self.snapshots}
 
 
@@ -484,7 +491,7 @@ def _bdev_lvol_snapshot_register(s: NodeState, p: dict):
 
 def _bdev_get_bdevs(s: NodeState, p: dict):
     name: Optional[str] = p.get('name')
-    all_bdevs = s.all_bdevs()
+    all_bdevs = {**s.all_bdevs(), **s.nvme_bdevs}
     if name:
         composite = name if name in all_bdevs else s.composite(name)
         entry = all_bdevs.get(composite)
@@ -717,8 +724,12 @@ def _bdev_nvme_set_options(s: NodeState, p: dict):
 
 def _bdev_nvme_attach_controller(s: NodeState, p: dict):
     name = _req(p, 'name')
+    remote_bdev = f"{name}n1"
     if name in s.nvme_controllers:
-        raise _RpcError(-17, f"controller {name} already attached")
+        # Idempotent: real SPDK keeps the existing controller (and its bdev)
+        # when the same name/subnqn is re-attached, rather than erroring.
+        logger.debug("mock attach_controller %s already attached — idempotent", name)
+        return [remote_bdev]
     s.nvme_controllers[name] = {
         'name': name,
         'nqn': _req(p, 'subnqn'),
@@ -726,15 +737,28 @@ def _bdev_nvme_attach_controller(s: NodeState, p: dict):
         'trsvcid': p.get('trsvcid', ''),
         'trtype': p.get('trtype', 'TCP'),
     }
+    # Real SPDK exposes the attached controller's namespaces as local bdevs
+    # (convention: ctrlname + "n1"); mirror that so get_bdevs()-based
+    # "already attached" checks in the migration hub logic can find it.
+    s.nvme_bdevs[remote_bdev] = {'name': remote_bdev, 'composite': remote_bdev, 'controller': name}
     logger.debug("mock attach_controller %s → %s", name, p.get('subnqn'))
-    # Return list of remote bdev names (convention: ctrlname + "n1")
-    return [f"{name}n1"]
+    return [remote_bdev]
 
 
 def _bdev_nvme_detach_controller(s: NodeState, p: dict):
     name = _req(p, 'name')
     s.nvme_controllers.pop(name, None)
+    s.nvme_bdevs.pop(f"{name}n1", None)
     return True
+
+
+def _bdev_nvme_controller_list(s: NodeState, p: dict):
+    """Return controller entries matching ``name`` (or all, if omitted)."""
+    name = p.get('name')
+    if name:
+        entry = s.nvme_controllers.get(name)
+        return [entry] if entry else []
+    return list(s.nvme_controllers.values())
 
 
 # ---- misc / version ----
@@ -777,6 +801,7 @@ _DISPATCH = {
     'bdev_nvme_set_options':                 _bdev_nvme_set_options,
     'bdev_nvme_attach_controller':           _bdev_nvme_attach_controller,
     'bdev_nvme_detach_controller':           _bdev_nvme_detach_controller,
+    'bdev_nvme_controller_list':              _bdev_nvme_controller_list,
 }
 
 

--- a/tests/integration/migration/mock_rpc_server.py
+++ b/tests/integration/migration/mock_rpc_server.py
@@ -74,6 +74,7 @@ class NodeState:
         self.nvme_options: Dict[str, Any] = {}
 
         self._blobid_counter = 1000
+        self._map_id_counter = 1
         self._nsid_counter: Dict[str, int] = {}  # nqn → next nsid
         self.lock = threading.Lock()
 
@@ -83,6 +84,11 @@ class NodeState:
         bid = self._blobid_counter
         self._blobid_counter += 1
         return bid
+
+    def next_map_id(self) -> int:
+        mid = self._map_id_counter
+        self._map_id_counter += 1
+        return mid
 
     def next_nsid(self, nqn: str) -> int:
         self._nsid_counter.setdefault(nqn, 1)
@@ -254,12 +260,14 @@ def _bdev_lvol_create(s: NodeState, p: dict):
     if composite in s.lvols or composite in s.snapshots:
         raise _RpcError(-17, f"bdev {composite} already exists")
     blobid = s.next_blobid()
+    map_id = s.next_map_id()
     obj_uuid = p.get('uuid') or str(_uuid_mod.uuid4())
     s.lvols[composite] = {
         'name': name,
         'composite': composite,
         'uuid': obj_uuid,
         'blobid': blobid,
+        'map_id': map_id,
         'size_mib': size_mib,
         'migration_flag': False,
         'driver_specific': {
@@ -336,6 +344,7 @@ def _bdev_lvol_snapshot(s: NodeState, p: dict):
         raise _RpcError(-17, f"snapshot {composite_snap} already exists")
     src = s.lvols[composite_src]
     blobid = s.next_blobid()
+    map_id = s.next_map_id()
     snap_uuid = str(_uuid_mod.uuid4())
     src_size_mib = src.get('size_mib', 1024)
     s.snapshots[composite_snap] = {
@@ -343,6 +352,7 @@ def _bdev_lvol_snapshot(s: NodeState, p: dict):
         'composite': composite_snap,
         'uuid': snap_uuid,
         'blobid': blobid,
+        'map_id': map_id,
         'size_mib': src_size_mib,
         'driver_specific': {
             'lvol': {
@@ -370,6 +380,7 @@ def _bdev_lvol_clone(s: NodeState, p: dict):
     if composite_clone in s.lvols:
         raise _RpcError(-17, f"clone {composite_clone} already exists")
     blobid = s.next_blobid()
+    map_id = s.next_map_id()
     clone_uuid = str(_uuid_mod.uuid4())
     snap_size_mib = s.snapshots[composite_snap].get('size_mib', 1024)
     s.lvols[composite_clone] = {
@@ -377,6 +388,7 @@ def _bdev_lvol_clone(s: NodeState, p: dict):
         'composite': composite_clone,
         'uuid': clone_uuid,
         'blobid': blobid,
+        'map_id': map_id,
         'size_mib': snap_size_mib,
         'migration_flag': False,
         'driver_specific': {
@@ -437,6 +449,7 @@ def _bdev_lvol_register(s: NodeState, p: dict):
         'composite': composite,
         'uuid': registered_uuid,
         'blobid': blobid,
+        'map_id': s.next_map_id(),
         'migration_flag': False,
         'driver_specific': {'lvol': {'blobid': blobid, 'lvs_name': lvs_name,
                                      'base_snapshot': None, 'clone': False, 'snapshot': False,
@@ -459,6 +472,7 @@ def _bdev_lvol_snapshot_register(s: NodeState, p: dict):
         'composite': composite,
         'uuid': registered_uuid,
         'blobid': blobid,
+        'map_id': s.next_map_id(),
         'driver_specific': {'lvol': {'blobid': blobid, 'lvs_name': s.lvstore,
                                      'base_snapshot': lvol_name, 'clone': False, 'snapshot': True,
                                      'num_allocated_clusters': 1024}}
@@ -490,6 +504,7 @@ def _bdev_lvol_get_lvols(s: NodeState, p: dict):
             'lvol_name': entry['name'],
             'uuid': entry['uuid'],
             'blobid': entry['blobid'],
+            'map_id': entry.get('map_id'),
         })
     return result
 

--- a/tests/integration/migration/test_complex_tree.py
+++ b/tests/integration/migration/test_complex_tree.py
@@ -39,7 +39,9 @@ from simplyblock_core.exceptions import PreconditionError
 from simplyblock_core.models.lvol_migration import LVolMigration
 from simplyblock_core.models.storage_node import StorageNode
 
-from tests.integration.migration.conftest import run_migration_task, run_migration_with_crashes, set_node_status
+from tests.integration.migration.conftest import (
+    run_migration_task, run_migration_with_crashes, set_node_status, start_migration,
+)
 from tests.integration.migration.topology_loader import TestContext
 
 # ---------------------------------------------------------------------------
@@ -145,7 +147,7 @@ def _assert_failed(mig_id):
 def _migrate_one(lvol_uuid, tgt_uuid, max_steps=1500, step_sleep=0.02,
                   max_retries=20):
     """Start and run a migration to completion. Returns migration_id."""
-    mig_id, err = migration_controller.start_migration(
+    mig_id, err = start_migration(
         lvol_uuid, tgt_uuid, max_retries=max_retries)
     assert err is None, f"start_migration failed: {err}"
     run_migration_task(mig_id, max_steps=max_steps, step_sleep=step_sleep)
@@ -240,7 +242,7 @@ class TestComplexTreeFailures:
         tgt = ctx.node("tgt")
         _seed_all(mock_src_server, ctx, "src")
 
-        mig_id, err = migration_controller.start_migration(
+        mig_id, err = start_migration(
             ctx.lvol_uuid("l4"), tgt.uuid, max_retries=3)
         assert err is None
 
@@ -261,7 +263,7 @@ class TestComplexTreeFailures:
         _seed_all(mock_src_server, ctx, "src")
 
         # Very short deadline: 2 seconds
-        mig_id, err = migration_controller.start_migration(
+        mig_id, err = start_migration(
             ctx.lvol_uuid("l5"), tgt.uuid, deadline_seconds=2)
         assert err is None
 
@@ -285,7 +287,7 @@ class TestComplexTreeFailures:
         _seed_all(mock_src_server, ctx, "src")
 
         # Short deadline (3s)
-        mig_id, err = migration_controller.start_migration(
+        mig_id, err = start_migration(
             ctx.lvol_uuid("l6"), tgt.uuid, deadline_seconds=3)
         assert err is None
 
@@ -339,7 +341,7 @@ class TestConcurrentIndependentOperations:
         tgt = ctx.node("tgt")
         _seed_all(mock_src_server, ctx, "src")
 
-        mig_id, err = migration_controller.start_migration(
+        mig_id, err = start_migration(
             ctx.lvol_uuid("l2"), tgt.uuid)
         assert err is None
 
@@ -374,7 +376,7 @@ class TestConcurrentIndependentOperations:
         tgt = ctx.node("tgt")
         _seed_all(mock_src_server, ctx, "src")
 
-        mig_id, err = migration_controller.start_migration(
+        mig_id, err = start_migration(
             ctx.lvol_uuid("l3"), tgt.uuid)
         assert err is None
 
@@ -419,7 +421,7 @@ class TestMigrationProtection:
         tgt = ctx.node("tgt")
         _seed_all(mock_src_server, ctx, "src")
 
-        mig_id, err = migration_controller.start_migration(
+        mig_id, err = start_migration(
             ctx.lvol_uuid("l1"), tgt.uuid)
         assert err is None
 
@@ -457,7 +459,7 @@ class TestMigrationProtection:
         tgt = ctx.node("tgt")
         _seed_all(mock_src_server, ctx, "src")
 
-        mig_id, err = migration_controller.start_migration(
+        mig_id, err = start_migration(
             ctx.lvol_uuid("l2"), tgt.uuid)
         assert err is None
 
@@ -486,7 +488,7 @@ class TestMigrationProtection:
         tgt = ctx.node("tgt")
         _seed_all(mock_src_server, ctx, "src")
 
-        mig_id, err = migration_controller.start_migration(
+        mig_id, err = start_migration(
             ctx.lvol_uuid("l3"), tgt.uuid)
         assert err is None
 
@@ -519,7 +521,7 @@ class TestMigrationProtection:
         tgt = ctx.node("tgt")
         _seed_all(mock_src_server, ctx, "src")
 
-        mig_id, err = migration_controller.start_migration(
+        mig_id, err = start_migration(
             ctx.lvol_uuid("l2"), tgt.uuid)
         assert err is None
 
@@ -547,7 +549,7 @@ class TestMigrationProtection:
         tgt = ctx.node("tgt")
         _seed_all(mock_src_server, ctx, "src")
 
-        mig_id, err = migration_controller.start_migration(
+        mig_id, err = start_migration(
             ctx.lvol_uuid("l1"), tgt.uuid)
         assert err is None
 
@@ -587,7 +589,7 @@ class TestCrashRestartResilience:
         tgt = ctx.node("tgt")
         _seed_all(mock_src_server, ctx, "src")
 
-        mig_id, err = migration_controller.start_migration(
+        mig_id, err = start_migration(
             ctx.lvol_uuid("l2"), tgt.uuid, max_retries=50)
         assert err is None
 
@@ -609,7 +611,7 @@ class TestCrashRestartResilience:
         _seed_all(mock_src_server, ctx, "src")
 
         # l3 has only 1 snap (s1) — snap_copy finishes fast, crash hits lvol_migrate
-        mig_id, err = migration_controller.start_migration(
+        mig_id, err = start_migration(
             ctx.lvol_uuid("l3"), tgt.uuid, max_retries=50)
         assert err is None
 
@@ -630,7 +632,7 @@ class TestCrashRestartResilience:
         _seed_all(mock_src_server, ctx, "src")
 
         # l3 (1 snap) — let it get far enough into cleanup_source before crashing
-        mig_id, err = migration_controller.start_migration(
+        mig_id, err = start_migration(
             ctx.lvol_uuid("l3"), tgt.uuid, max_retries=50)
         assert err is None
 
@@ -650,7 +652,7 @@ class TestCrashRestartResilience:
         tgt = ctx.node("tgt")
         _seed_all(mock_src_server, ctx, "src")
 
-        mig_id, err = migration_controller.start_migration(
+        mig_id, err = start_migration(
             ctx.lvol_uuid("l1"), tgt.uuid, max_retries=100)
         assert err is None
 
@@ -675,7 +677,7 @@ class TestCrashRestartResilience:
         mock_src_server.set_failure_rate(0.05, timeout_seconds=0.1)
         mock_tgt_server.set_failure_rate(0.05, timeout_seconds=0.1)
 
-        mig_id, err = migration_controller.start_migration(
+        mig_id, err = start_migration(
             ctx.lvol_uuid("l2"), tgt.uuid, max_retries=500)
         assert err is None
 

--- a/tests/integration/migration/test_migration_flow.py
+++ b/tests/integration/migration/test_migration_flow.py
@@ -408,8 +408,7 @@ class TestCancellation:
             time.sleep(0.02)
 
         # Cancel
-        ok, cerr = migration_controller.cancel_migration(mig_id)
-        assert ok, f"cancel_migration failed: {cerr}"
+        migration_controller.cancel_migration(mig_id)
 
         # Run to completion
         run_migration_task(mig_id, max_steps=300, step_sleep=0.02)

--- a/tests/integration/migration/test_migration_flow.py
+++ b/tests/integration/migration/test_migration_flow.py
@@ -5,7 +5,7 @@ test_migration_flow.py – integration tests for the live volume migration featu
 Each test:
 1. Populates FDB via db_setup helpers.
 2. Seeds the source mock server with the expected in-memory bdev state.
-3. Calls migration_controller.start_migration() to create the LVolMigration
+3. Calls start_migration() to create the LVolMigration
    record and its backing JobSchedule task.
 4. Drives the task runner to completion via conftest.run_migration_task().
 5. Asserts on the final DB state and on the mock server's in-memory state.
@@ -23,7 +23,7 @@ from simplyblock_core.controllers import migration_controller
 from simplyblock_core.models.lvol_migration import LVolMigration
 from simplyblock_core.models.storage_node import StorageNode
 
-from tests.integration.migration.conftest import run_migration_task, set_node_status
+from tests.integration.migration.conftest import run_migration_task, set_node_status, start_migration
 from tests.integration.migration.topology_loader import TestContext
 
 # Lazily initialised so the module can be imported without FDB installed.
@@ -142,7 +142,7 @@ class TestBasicMigration:
         # Seed source mock with bdev state matching the FDB records
         _seed_all(mock_src_server, ctx, "src")
 
-        mig_id, err = migration_controller.start_migration(lvol.uuid, tgt_node.uuid)
+        mig_id, err = start_migration(lvol.uuid, tgt_node.uuid)
         assert err is None, f"start_migration failed: {err}"
         assert mig_id
 
@@ -192,14 +192,14 @@ class TestBasicMigration:
         _seed_all(mock_src_server, ctx, "src")
 
         # Migrate l1 first
-        mig1_id, err = migration_controller.start_migration(
+        mig1_id, err = start_migration(
             ctx.lvol_uuid("l1"), tgt_node.uuid)
         assert err is None
         run_migration_task(mig1_id, max_steps=500, step_sleep=0.02)
         _assert_migration_done(mig1_id)
 
         # Migrate l2 (l1 is done; same-source constraint lifted)
-        mig2_id, err = migration_controller.start_migration(
+        mig2_id, err = start_migration(
             ctx.lvol_uuid("l2"), tgt_node.uuid)
         assert err is None
         run_migration_task(mig2_id, max_steps=500, step_sleep=0.02)
@@ -233,7 +233,7 @@ class TestSharedSnapshotChain:
 
         _seed_all(mock_src_server, ctx, "src")
 
-        mig_id, err = migration_controller.start_migration(
+        mig_id, err = start_migration(
             ctx.lvol_uuid("c1"), tgt_node.uuid)
         assert err is None, err
         run_migration_task(mig_id, max_steps=500, step_sleep=0.02)
@@ -260,14 +260,14 @@ class TestSharedSnapshotChain:
         _seed_all(mock_src_server, ctx, "src")
 
         # Migrate c1 first → s1 + s2 land on target
-        mig1_id, err = migration_controller.start_migration(
+        mig1_id, err = start_migration(
             ctx.lvol_uuid("c1"), tgt_node.uuid)
         assert err is None
         run_migration_task(mig1_id, max_steps=500, step_sleep=0.02)
         _assert_migration_done(mig1_id)
 
         # Migrate l1 now
-        mig2_id, err = migration_controller.start_migration(
+        mig2_id, err = start_migration(
             ctx.lvol_uuid("l1"), tgt_node.uuid)
         assert err is None
         run_migration_task(mig2_id, max_steps=500, step_sleep=0.02)
@@ -292,13 +292,13 @@ class TestSharedSnapshotChain:
         _seed_all(mock_src_server, ctx, "src")
 
         # Migrate c1 first to deposit s1, s2 on target
-        mig1_id, err = migration_controller.start_migration(
+        mig1_id, err = start_migration(
             ctx.lvol_uuid("c1"), tgt_node.uuid)
         assert err is None
         run_migration_task(mig1_id, max_steps=500, step_sleep=0.02)
         _assert_migration_done(mig1_id)
 
-        mig2_id, err = migration_controller.start_migration(
+        mig2_id, err = start_migration(
             ctx.lvol_uuid("l1"), tgt_node.uuid)
         assert err is None
 
@@ -329,7 +329,7 @@ class TestPreconditions:
         ctx = topology_two_node
         src_uuid = ctx.node_uuid("src")
         set_node_status(src_uuid, StorageNode.STATUS_OFFLINE)
-        mig_id, err = migration_controller.start_migration(
+        mig_id, err = start_migration(
             ctx.lvol_uuid("l1"), ctx.node_uuid("tgt"))
         assert mig_id is False
         assert "Source node is not online" in err
@@ -337,10 +337,10 @@ class TestPreconditions:
 
     def test_reject_same_source_and_target(self, topology_two_node):
         ctx = topology_two_node
-        mig_id, err = migration_controller.start_migration(
+        mig_id, err = start_migration(
             ctx.lvol_uuid("l1"), ctx.node_uuid("src"))
         assert mig_id is False
-        assert "different" in err.lower()
+        assert "same node" in err.lower()
 
     def test_reject_duplicate_active_migration_on_node(
             self, custom_topology, mock_src_server, mock_tgt_server):
@@ -367,12 +367,12 @@ class TestPreconditions:
         ctx = custom_topology(spec)
         _seed_all(mock_src_server, ctx, "src")
 
-        mig1_id, err = migration_controller.start_migration(
+        mig1_id, err = start_migration(
             ctx.lvol_uuid("l1"), ctx.node_uuid("tgt"))
         assert err is None
 
         # Second migration from same source node must fail
-        mig2_id, err2 = migration_controller.start_migration(
+        mig2_id, err2 = start_migration(
             ctx.lvol_uuid("l2"), ctx.node_uuid("tgt"))
         assert mig2_id is False
         assert "active on source node" in err2
@@ -392,7 +392,7 @@ class TestCancellation:
 
         _seed_all(mock_src_server, ctx, "src")
 
-        mig_id, err = migration_controller.start_migration(
+        mig_id, err = start_migration(
             ctx.lvol_uuid("l1"), tgt_node.uuid)
         assert err is None
 
@@ -441,7 +441,7 @@ class TestRandomFailureMode:
         mock_src_server.set_failure_rate(failure_rate, timeout_seconds=0.05)
         mock_tgt_server.set_failure_rate(failure_rate, timeout_seconds=0.05)
 
-        mig_id, err = migration_controller.start_migration(
+        mig_id, err = start_migration(
             ctx.lvol_uuid("l1"), tgt_node.uuid)
         assert err is None
 
@@ -467,7 +467,7 @@ class TestRandomFailureMode:
         mock_src_server.set_failure_rate(1.0, timeout_seconds=0.05)
         mock_tgt_server.set_failure_rate(1.0, timeout_seconds=0.05)
 
-        mig_id, err = migration_controller.start_migration(
+        mig_id, err = start_migration(
             ctx.lvol_uuid("l1"), tgt_node.uuid)
         assert err is None
 
@@ -501,7 +501,7 @@ class TestHASecondaryRegistration:
         lvol = ctx.lvol("l1")
         snap = ctx.snap("s1")
 
-        mig_id, err = migration_controller.start_migration(lvol.uuid, tgt_node.uuid)
+        mig_id, err = start_migration(lvol.uuid, tgt_node.uuid)
         assert err is None
         run_migration_task(mig_id, max_steps=500, step_sleep=0.02)
         _assert_migration_done(mig_id)
@@ -527,7 +527,7 @@ class TestHASecondaryRegistration:
         lvol = ctx.lvol("l1")
         ctx.snap("s1")
 
-        mig_id, err = migration_controller.start_migration(lvol.uuid, tgt_node.uuid)
+        mig_id, err = start_migration(lvol.uuid, tgt_node.uuid)
         assert err is None
         run_migration_task(mig_id, max_steps=500, step_sleep=0.02)
         _assert_migration_done(mig_id)
@@ -558,7 +558,7 @@ class TestHASecondaryRegistration:
         # Put secondary into a bad state (not online and not offline)
         set_node_status(sec_uuid, "in_restart")
 
-        mig_id, err = migration_controller.start_migration(lvol.uuid, tgt_node.uuid)
+        mig_id, err = start_migration(lvol.uuid, tgt_node.uuid)
         assert err is None
 
         from simplyblock_core.services.tasks_runner_lvol_migration import task_runner
@@ -609,7 +609,7 @@ class TestFourNodeFourSnapshotMigration:
         # Seed source mock with bdev state matching FDB records
         _seed_all(mock_src_server, ctx, "n1")
 
-        mig_id, err = migration_controller.start_migration(lvol.uuid, tgt_node.uuid)
+        mig_id, err = start_migration(lvol.uuid, tgt_node.uuid)
         assert err is None, f"start_migration failed: {err}"
         assert mig_id
 
@@ -636,7 +636,7 @@ class TestFourNodeFourSnapshotMigration:
 
         _seed_all(mock_src_server, ctx, "n1")
 
-        mig_id, err = migration_controller.start_migration(lvol.uuid, tgt_node.uuid)
+        mig_id, err = start_migration(lvol.uuid, tgt_node.uuid)
         assert err is None
         run_migration_task(mig_id, max_steps=1000, step_sleep=0.02)
         _assert_migration_done(mig_id)
@@ -665,7 +665,7 @@ class TestFourNodeFourSnapshotMigration:
 
         _seed_all(mock_src_server, ctx, "n1")
 
-        mig_id, err = migration_controller.start_migration(lvol.uuid, tgt_node.uuid)
+        mig_id, err = start_migration(lvol.uuid, tgt_node.uuid)
         assert err is None
         run_migration_task(mig_id, max_steps=1000, step_sleep=0.02)
         _assert_migration_done(mig_id)
@@ -693,7 +693,7 @@ class TestFourNodeFourSnapshotMigration:
 
         _seed_all(mock_src_server, ctx, "n1")
 
-        mig_id, err = migration_controller.start_migration(lvol.uuid, tgt_node.uuid)
+        mig_id, err = start_migration(lvol.uuid, tgt_node.uuid)
         assert err is None
         run_migration_task(mig_id, max_steps=1000, step_sleep=0.02)
         _assert_migration_done(mig_id)
@@ -717,7 +717,7 @@ class TestFourNodeFourSnapshotMigration:
 
         _seed_all(mock_src_server, ctx, "n1")
 
-        mig_id, err = migration_controller.start_migration(lvol.uuid, tgt_node.uuid)
+        mig_id, err = start_migration(lvol.uuid, tgt_node.uuid)
         assert err is None
         run_migration_task(mig_id, max_steps=1000, step_sleep=0.02)
         _assert_migration_done(mig_id)
@@ -760,7 +760,7 @@ class TestFourNodeFourSnapshotMigration:
         offline_sym = random.choice(["n1", "n2", "n3", "n4"])
         offline_uuid = ctx.node_uuid(offline_sym)
 
-        mig_id, err = migration_controller.start_migration(lvol.uuid, tgt_node.uuid)
+        mig_id, err = start_migration(lvol.uuid, tgt_node.uuid)
         assert err is None, f"start_migration failed: {err}"
 
         # Background thread: wait 0.3 s (let migration get started), take the

--- a/tests/integration/migration/test_migration_flow.py
+++ b/tests/integration/migration/test_migration_flow.py
@@ -19,6 +19,7 @@ import threading
 import time
 import pytest
 
+from simplyblock_core import constants
 from simplyblock_core.controllers import migration_controller
 from simplyblock_core.models.lvol_migration import LVolMigration
 from simplyblock_core.models.storage_node import StorageNode
@@ -287,7 +288,6 @@ class TestSharedSnapshotChain:
         """
         ctx = topology_clone_chain
         tgt_node = ctx.node("tgt")
-        tgt_lvstore = tgt_node.lvstore
 
         _seed_all(mock_src_server, ctx, "src")
 
@@ -309,13 +309,19 @@ class TestSharedSnapshotChain:
 
         _assert_migration_failed(mig2_id)
 
-        # s1 and s2 must still be on target. Fetch fresh from DB (not ctx's
-        # cached pre-migration objects) since c1's migration already updated
-        # snap_bdev to the target path with the migration suffix.
+        # s1 and s2 must still be on target. s1/s2 are owned by l1, not c1, so
+        # c1's migration recorded its target-side copy as an ``instances``
+        # entry rather than mutating the canonical (still source-side)
+        # snap_bdev — look up that instance's bdev, which carries the
+        # migration suffix (e.g. SNAP_xxxm).
         for snap_sym in ["s1", "s2"]:
             snap = db.get_snapshot_by_id(ctx.snap_uuid(snap_sym))
-            short = snap.snap_bdev.split('/', 1)[1] if '/' in snap.snap_bdev else snap.snap_bdev
-            tgt_composite = f"{tgt_lvstore}/{short}"
+            instance = next(
+                (i for i in snap.instances if i.get('lvol', {}).get('node_id') == tgt_node.uuid),
+                None)
+            assert instance is not None, \
+                f"No target-side instance recorded for pre-existing snap {snap.snap_name}"
+            tgt_composite = instance['snap_bdev']
             with mock_tgt_server.state.lock:
                 assert tgt_composite in mock_tgt_server.state.snapshots, \
                     f"Pre-existing snap {snap.snap_name} was incorrectly deleted from target"
@@ -344,8 +350,13 @@ class TestPreconditions:
         assert mig_id is False
         assert "same node" in err.lower()
 
-    def test_reject_duplicate_active_migration_on_node(
+    def test_second_migration_from_same_source_node_is_allowed(
             self, custom_topology, mock_src_server, mock_tgt_server):
+        """
+        Migration is only serialized per-lvol (``create_migration`` checks
+        ``get_active_migration_for_lvol``), not per-source-node — a second,
+        distinct lvol on the same source may migrate concurrently.
+        """
         spec = {
             "cluster": {},
             "nodes": [
@@ -373,11 +384,11 @@ class TestPreconditions:
             ctx.lvol_uuid("l1"), ctx.node_uuid("tgt"))
         assert err is None
 
-        # Second migration from same source node must fail
+        # Second migration for a different lvol on the same source node succeeds.
         mig2_id, err2 = start_migration(
             ctx.lvol_uuid("l2"), ctx.node_uuid("tgt"))
-        assert mig2_id is False
-        assert "active on source node" in err2
+        assert err2 is None
+        assert mig2_id
 
 
 # ---------------------------------------------------------------------------
@@ -438,13 +449,16 @@ class TestRandomFailureMode:
 
         _seed_all(mock_src_server, ctx, "src")
 
-        # Enable failure injection
-        mock_src_server.set_failure_rate(failure_rate, timeout_seconds=0.05)
-        mock_tgt_server.set_failure_rate(failure_rate, timeout_seconds=0.05)
-
+        # create_migration()/start_migration() perform synchronous target
+        # setup RPCs with no retry of their own, so failure injection starts
+        # only once the migration exists — exercising the task runner's own
+        # retry logic, which is what "retries carry it through" means here.
         mig_id, err = start_migration(
             ctx.lvol_uuid("l1"), tgt_node.uuid)
         assert err is None
+
+        mock_src_server.set_failure_rate(failure_rate, timeout_seconds=0.05)
+        mock_tgt_server.set_failure_rate(failure_rate, timeout_seconds=0.05)
 
         run_migration_task(mig_id, max_steps=2000, step_sleep=0.01)
 
@@ -465,12 +479,16 @@ class TestRandomFailureMode:
 
         _seed_all(mock_src_server, ctx, "src")
 
-        mock_src_server.set_failure_rate(1.0, timeout_seconds=0.05)
-        mock_tgt_server.set_failure_rate(1.0, timeout_seconds=0.05)
-
+        # create_migration()/start_migration() perform synchronous target
+        # setup RPCs with no retry of their own, so the failure rate is only
+        # injected once the migration exists — exercising the task runner's
+        # own retry-then-give-up behavior instead of the one-shot setup call.
         mig_id, err = start_migration(
             ctx.lvol_uuid("l1"), tgt_node.uuid)
         assert err is None
+
+        mock_src_server.set_failure_rate(1.0, timeout_seconds=0.05)
+        mock_tgt_server.set_failure_rate(1.0, timeout_seconds=0.05)
 
         run_migration_task(mig_id, max_steps=500, step_sleep=0.01)
 
@@ -507,9 +525,10 @@ class TestHASecondaryRegistration:
         run_migration_task(mig_id, max_steps=500, step_sleep=0.02)
         _assert_migration_done(mig_id)
 
-        # The secondary mock should have a snapshot registered
+        # The secondary mock should have a snapshot registered. Target bdevs
+        # carry the migration suffix (e.g. SNAP_xxxm).
         short = snap.snap_bdev.split('/', 1)[1] if '/' in snap.snap_bdev else snap.snap_bdev
-        sec_composite = f"{ctx.node('tgt-sec').lvstore}/{short}"
+        sec_composite = f"{ctx.node('tgt-sec').lvstore}/{short}{constants.LVOL_MIG_BDEV_SUFFIX}"
         with mock_sec_server.state.lock:
             assert sec_composite in mock_sec_server.state.snapshots, \
                 f"Snapshot not registered on secondary: {sec_composite}"
@@ -650,7 +669,8 @@ class TestFourNodeFourSnapshotMigration:
             snap = ctx.snap(snap_sym)
             short = snap.snap_bdev.split('/', 1)[1] if '/' in snap.snap_bdev \
                 else snap.snap_bdev
-            composite = f"{tgt_lvstore}/{short}"
+            # Target bdevs carry the migration suffix (e.g. SNAP_xxxm).
+            composite = f"{tgt_lvstore}/{short}{constants.LVOL_MIG_BDEV_SUFFIX}"
             assert composite in tgt_snaps, (
                 f"Snapshot {snap.snap_name} ({composite}) missing from target")
 

--- a/tests/integration/migration/test_migration_flow.py
+++ b/tests/integration/migration/test_migration_flow.py
@@ -409,16 +409,23 @@ class TestCancellation:
             ctx.lvol_uuid("l1"), tgt_node.uuid)
         assert err is None
 
-        # Run a few steps, then cancel
+        # Force failures so the migration cannot race to completion before
+        # we cancel it — with a single snapshot it can otherwise finish
+        # within a handful of task_runner() calls.
+        mock_tgt_server.set_failure_rate(1.0, timeout_seconds=0.1)
+
         from simplyblock_core.services.tasks_runner_lvol_migration import task_runner
         from tests.integration.migration.conftest import _find_migration_task
         task = _find_migration_task(db, mig_id)
         for _ in range(5):
             task = db.get_task_by_id(task.uuid)
-            done = task_runner(task)
-            if done:
-                break
+            task_runner(task)
             time.sleep(0.02)
+
+        mock_tgt_server.set_failure_rate(0.0)
+
+        m = db.get_migration_by_id(mig_id)
+        assert m.is_active(), f"Migration should still be active, got {m.status}"
 
         # Cancel
         migration_controller.cancel_migration(mig_id)

--- a/tests/integration/migration/test_migration_flow.py
+++ b/tests/integration/migration/test_migration_flow.py
@@ -309,9 +309,11 @@ class TestSharedSnapshotChain:
 
         _assert_migration_failed(mig2_id)
 
-        # s1 and s2 must still be on target
+        # s1 and s2 must still be on target. Fetch fresh from DB (not ctx's
+        # cached pre-migration objects) since c1's migration already updated
+        # snap_bdev to the target path with the migration suffix.
         for snap_sym in ["s1", "s2"]:
-            snap = ctx.snap(snap_sym)
+            snap = db.get_snapshot_by_id(ctx.snap_uuid(snap_sym))
             short = snap.snap_bdev.split('/', 1)[1] if '/' in snap.snap_bdev else snap.snap_bdev
             tgt_composite = f"{tgt_lvstore}/{short}"
             with mock_tgt_server.state.lock:

--- a/tests/integration/migration/test_scalability.py
+++ b/tests/integration/migration/test_scalability.py
@@ -537,8 +537,12 @@ class TestLargeVolumeMigration:
         assert lvol.node_id == tgt.uuid, "node_id not updated"
         assert lvol.hostname == tgt.hostname, "hostname not updated"
 
-        # All snapshots should have updated snap_bdev prefix
+        # All snapshots should have updated snap_bdev prefix. Intermediate
+        # snapshots are removed from FDB during cleanup, so skip those.
+        intermediate_uuids = set(m.intermediate_snaps)
         for snap_uuid in m.snaps_migrated:
+            if snap_uuid in intermediate_uuids:
+                continue
             snap = db.get_snapshot_by_id(snap_uuid)
             if snap and snap.snap_bdev and '/' in snap.snap_bdev:
                 assert snap.snap_bdev.startswith(tgt.lvstore + "/"), (

--- a/tests/integration/migration/test_scalability.py
+++ b/tests/integration/migration/test_scalability.py
@@ -19,10 +19,9 @@ import random
 import time
 import pytest
 
-from simplyblock_core.controllers import migration_controller
 from simplyblock_core.models.lvol_migration import LVolMigration
 
-from tests.integration.migration.conftest import run_migration_task
+from tests.integration.migration.conftest import run_migration_task, start_migration
 from tests.integration.migration.topology_loader import TestContext, load_topology
 
 # ---------------------------------------------------------------------------
@@ -262,7 +261,7 @@ class TestScalability:
 
         for vol_sym in vol_syms:
             lvol_uuid = ctx.lvol_uuid(vol_sym)
-            mig_id, err = migration_controller.start_migration(
+            mig_id, err = start_migration(
                 lvol_uuid, tgt.uuid, max_retries=30)
             assert err is None, f"start_migration({vol_sym}) failed: {err}"
 
@@ -302,7 +301,7 @@ class TestScalability:
 
         for i, vol_sym in enumerate(group_vols):
             lvol_uuid = ctx.lvol_uuid(vol_sym)
-            mig_id, err = migration_controller.start_migration(
+            mig_id, err = start_migration(
                 lvol_uuid, tgt.uuid, max_retries=30)
             assert err is None, f"start_migration({vol_sym}) failed: {err}"
 
@@ -347,7 +346,7 @@ class TestScalability:
                 break
 
         # Migrate it
-        mig_id, err = migration_controller.start_migration(
+        mig_id, err = start_migration(
             vol_with_many_snaps, tgt.uuid, max_retries=30)
         assert err is None
         m = run_migration_task(mig_id, max_steps=3000, step_sleep=0.01)
@@ -361,7 +360,7 @@ class TestScalability:
                 other_vol = sym
                 break
 
-        mig_id2, err2 = migration_controller.start_migration(
+        mig_id2, err2 = start_migration(
             ctx.lvol_uuid(other_vol), tgt.uuid, max_retries=30)
         assert err2 is None
         m2 = run_migration_task(mig_id2, max_steps=3000, step_sleep=0.01)
@@ -381,7 +380,7 @@ class TestScalability:
         t0 = time.time()
         for vol_sym in vol_syms:
             lvol_uuid = ctx.lvol_uuid(vol_sym)
-            mig_id, err = migration_controller.start_migration(
+            mig_id, err = start_migration(
                 lvol_uuid, tgt.uuid, max_retries=30)
             assert err is None, f"start_migration({vol_sym}) failed: {err}"
 
@@ -511,7 +510,7 @@ class TestLargeVolumeMigration:
         tgt = ctx.node("tgt")
 
         lvol_uuid = ctx.lvol_uuid("bigvol")
-        mig_id, err = migration_controller.start_migration(
+        mig_id, err = start_migration(
             lvol_uuid, tgt.uuid, max_retries=30)
         assert err is None, f"start_migration failed: {err}"
 

--- a/tests/integration/migration/topologies/two_node_ha.json
+++ b/tests/integration/migration/topologies/two_node_ha.json
@@ -37,7 +37,7 @@
       "rpc_port": 9903,
       "rpc_username": "spdkuser",
       "rpc_password": "spdkpass",
-      "lvstore": "lvs_tgt_sec",
+      "lvstore": "lvs_tgt",
       "lvol_subsys_port": 9090,
       "status": "online",
       "data_nics": [

--- a/tests/integration/migration/topologies/two_node_ha.json
+++ b/tests/integration/migration/topologies/two_node_ha.json
@@ -10,6 +10,7 @@
       "rpc_password": "spdkpass",
       "lvstore": "lvs_src",
       "lvol_subsys_port": 9090,
+      "secondary_node_id": "src-sec",
       "status": "online",
       "data_nics": [
         {"if_name": "eth0", "ip": "127.0.0.1", "trtype": "TCP"}
@@ -38,6 +39,20 @@
       "rpc_username": "spdkuser",
       "rpc_password": "spdkpass",
       "lvstore": "lvs_tgt",
+      "lvol_subsys_port": 9090,
+      "status": "online",
+      "data_nics": [
+        {"if_name": "eth0", "ip": "127.0.0.1", "trtype": "TCP"}
+      ]
+    },
+    {
+      "id": "src-sec",
+      "hostname": "host-src-sec",
+      "mgmt_ip": "127.0.0.1",
+      "rpc_port": 9904,
+      "rpc_username": "spdkuser",
+      "rpc_password": "spdkpass",
+      "lvstore": "lvs_src",
       "lvol_subsys_port": 9090,
       "status": "online",
       "data_nics": [

--- a/tox.ini
+++ b/tox.ini
@@ -24,6 +24,4 @@ commands = mypy simplyblock_web simplyblock_cli simplyblock_core
 commands = pytest tests/unit/ simplyblock_core/test/ {posargs}
 
 [testenv:integration]
-commands = pytest tests/integration/ \
-    --ignore=tests/integration/migration \
-    {posargs}
+commands = pytest tests/integration/ {posargs}


### PR DESCRIPTION
The migration tests have been disabled so far and needed fixes to pre-existing failures, as well as adapting to logic changes.