### PR TITLE
Fixed hyphenated JSON properties on NvmeConnectEntry

### DIFF
--- a/simplyblock_core/controllers/lvol_controller.py
+++ b/simplyblock_core/controllers/lvol_controller.py
@@ -2789,7 +2789,7 @@ def replicate_lvol_on_target_cluster(lvol_id):
     if conn_err:
         logger.warning(f"Fail-over lvol created but connection-string build failed: {conn_err}")
     else:
-        connection_strings = [c.model_dump() for c in conn]
+        connection_strings = [c.model_dump(by_alias=True) for c in conn]
 
     return {
         "lvol_id": new_lvol.uuid,

--- a/simplyblock_core/models/nvme_connect.py
+++ b/simplyblock_core/models/nvme_connect.py
@@ -1,7 +1,12 @@
 # coding=utf-8
 from typing import Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
+
+
+def _hyphenate(field_name: str) -> str:
+    """Map a snake_case field name to its hyphenated JSON key (``nr_io_queues`` -> ``nr-io-queues``)."""
+    return field_name.replace("_", "-")
 
 
 class NvmeConnectEntry(BaseModel):
@@ -9,7 +14,15 @@ class NvmeConnectEntry(BaseModel):
 
     Returned by connect_lvol and create_migration.  Replaces the ad-hoc dicts
     that were built in both places with hyphenated keys.
+
+    Python attributes and constructor keywords use snake_case
+    (``nr_io_queues``); the JSON representation uses hyphenated keys
+    (``nr-io-queues``) to match the ``nvme connect`` option names.  Serialize
+    with ``by_alias=True`` (FastAPI response models do this by default) to emit
+    the hyphenated keys.
     """
+    model_config = ConfigDict(alias_generator=_hyphenate, populate_by_name=True)
+
     transport: str
     ip: str
     port: int

--- a/simplyblock_web/api/v1/lvol.py
+++ b/simplyblock_web/api/v1/lvol.py
@@ -283,7 +283,7 @@ def connect_lvol(uuid):
     ret, err = lvol_controller.connect_lvol(uuid, host_nqn=host_nqn)
     if err:
         return utils.get_response_error(err, 400)
-    return utils.get_response([e.model_dump() for e in ret])
+    return utils.get_response([e.model_dump(by_alias=True) for e in ret])
 
 
 @bp.route('/lvol/create_snapshot', methods=['POST'])


### PR DESCRIPTION
With the introduction of `NvmeConnectEntry` which is used instead of the default `dict`, an accidental API change happened. While documented correctly, that the object should return hyphenated properties, it returned Python-Snake-Case style properties.