### PR TITLE
Run migration tests in separate job

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,3 +52,24 @@ jobs:
         run: tox run -e integration
         env:
           PYTEST_ADDOPTS: -v
+
+  integration-slow:
+    name: Integration tests (slow)
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+          cache: 'pip'
+      - name: Install FoundationDB client library
+        run: |
+          curl -fsSL https://github.com/apple/foundationdb/releases/download/7.3.63/foundationdb-clients_7.3.63-1_amd64.deb -o /tmp/fdb-clients.deb
+          sudo dpkg -i /tmp/fdb-clients.deb
+      - name: Install tox
+        run: pip install tox
+      - name: Run slow integration tests
+        run: tox run -e integration-slow
+        env:
+          PYTEST_ADDOPTS: -v

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,9 @@ follow_untyped_imports = true
 pythonpath = "."
 testpaths = ['simplyblock_core/test', 'tests']
 norecursedirs = ['tests/perf']
+markers = [
+    "slow: long-running integration tests (e.g. live migration); excluded from the default integration run, opt in with -m slow",
+]
 # Safety net against hung tests: a genuinely stuck test fails with a stack dump
 # instead of hanging until an external SIGKILL (which silently masks every other
 # failure in the run). 900s is ~3x the slowest legitimate test (the scalability

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -51,9 +51,25 @@ What you *may* still mock: everything **above** the database. Storage nodes are 
 ## Running tests
 
 ```bash
-tox run -e unit          # Fast; no infra.
-tox run -e integration   # Requires Docker + libfdb_c on host.
+tox run -e unit             # Fast; no infra.
+tox run -e integration      # Requires Docker + libfdb_c on host. EXCLUDES slow tests.
+tox run -e integration-slow # Slow tier only (the migration suite, ~20min).
 ```
+
+### Slow tests (the `slow` marker)
+
+The migration suite (`tests/integration/migration/`, ~138 tests, ~20min) is tagged
+`slow` and **excluded from the default `integration` run**. Tests there are tagged
+automatically by `tests/integration/migration/conftest.py` — you don't mark them
+individually. To mark a slow test elsewhere, add `@pytest.mark.slow` (the marker is
+registered in `pyproject.toml`).
+
+- `tox run -e integration` → runs `-m "not slow"` (fast tier; what `tox run` and the
+  default CI job use).
+- `tox run -e integration-slow` → runs `-m slow` (the migration suite; CI runs this in
+  a separate `integration-slow` job with a longer timeout).
+- Targeted runs still opt in via posargs (posargs replace the default filter):
+  `tox run -e integration -- tests/integration/migration -m slow`.
 
 The `integration` env brings up FoundationDB through `testcontainers` (image `foundationdb/foundationdb:7.3.63`, ~3–5s boot, pulled on first run). **By default, always run the integration tests through tox and rely on this testcontainers-provisioned FDB** — do not point them at another cluster.
 

--- a/tests/integration/migration/conftest.py
+++ b/tests/integration/migration/conftest.py
@@ -27,6 +27,19 @@ from tests.integration.migration.topology_loader import (
 
 logger = logging.getLogger(__name__)
 
+_MIGRATION_DIR = os.path.dirname(__file__)
+
+
+def pytest_collection_modifyitems(items):
+    """Tag every migration test as ``slow`` so the default integration run can
+    deselect them (see ``-m "not slow"`` in tox.ini). Applied here rather than
+    on each of the ~138 test functions so new migration tests inherit it
+    automatically."""
+    for item in items:
+        if str(item.fspath).startswith(_MIGRATION_DIR):
+            item.add_marker(pytest.mark.slow)
+
+
 # ---------------------------------------------------------------------------
 # Cluster bootstrap
 # ---------------------------------------------------------------------------

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,8 @@
 [tox]
 envlist = lint, types, unit, integration
+# integration-slow is intentionally omitted from envlist so `tox run` (no -e)
+# skips the long-running migration suite. Invoke it explicitly with
+# `tox run -e integration-slow` (CI does this in a dedicated job).
 skipsdist = true
 requires = tox-uv>=1
 
@@ -35,6 +38,17 @@ commands = mypy simplyblock_web simplyblock_cli simplyblock_core
 passenv = PYTEST_ADDOPTS
 commands = pytest {posargs:tests/unit/ simplyblock_core/test/}
 
+# The default integration run EXCLUDES slow tests (migration, ~20min) via the
+# `slow` marker (registered in pyproject.toml; migration tests are auto-tagged
+# in tests/integration/migration/conftest.py). Because posargs REPLACE the
+# `{posargs:...}` default, a targeted run still works and is NOT filtered:
+#   tox run -e integration -- tests/integration/migration -m slow   # opt back in
 [testenv:integration]
 passenv = PYTEST_ADDOPTS
-commands = pytest {posargs:tests/integration/}
+commands = pytest {posargs:tests/integration/ -m "not slow"}
+
+# Long-running integration tests only (the `slow`-marked migration suite).
+# Kept out of envlist; run explicitly (CI has a dedicated job for it).
+[testenv:integration-slow]
+passenv = PYTEST_ADDOPTS
+commands = pytest {posargs:tests/integration/ -m slow}


### PR DESCRIPTION
Half of the integration test execution time is due to migration tests. This marks them as long running and splits those out into a separate CI job to speed up feedback.

Failures are unrelated because of direct pushs to main.