### PR TITLE
Speed up API unit tests

### DIFF
--- a/tests/unit/web/api/v2/conftest.py
+++ b/tests/unit/web/api/v2/conftest.py
@@ -96,7 +96,7 @@ def db(monkeypatch):
     return mock
 
 
-@pytest.fixture()
+@pytest.fixture(scope='session')
 def app():
     app = FastAPI()
     app.include_router(v2.api, prefix='/api/v2')
@@ -104,7 +104,7 @@ def app():
     return app
 
 
-@pytest.fixture()
+@pytest.fixture(scope='session')
 def client(app):
     return TestClient(app)
 


### PR DESCRIPTION
Unit tests keep re-applying the API setup. This can be avoided by scoping the fixtures appropriately.

Integration test and lint failures are unrelated from upstream.