### PR TITLE
Expose is_secondary on StorageNodeDTO (v2 storage-nodes API)

### DIFF
--- a/simplyblock_web/api/v2/_dtos.py
+++ b/simplyblock_web/api/v2/_dtos.py
@@ -299,6 +299,7 @@ class StorageNodeDTO(BaseModel):
     id: UUID
     cluster_id: UUID
     secondary_node_id: Optional[UUID]
+    is_secondary: bool
     status: StorageNodeStatus
     uptime: Optional[timedelta]
     hostname: str
@@ -330,6 +331,7 @@ class StorageNodeDTO(BaseModel):
             id=UUID(model.get_id()),
             cluster_id=UUID(model.cluster_id),
             secondary_node_id=UUID(model.secondary_node_id) if model.secondary_node_id else None,
+            is_secondary=model.is_secondary_node,
             status=cast(StorageNodeStatus, model.status),
             uptime=model.uptime(),
             hostname=model.hostname,


### PR DESCRIPTION
## Summary
- Adds `is_secondary` to `StorageNodeDTO` (v2 `GET /storage-nodes/`), a passthrough of the existing `model.is_secondary_node` field. No behavior change.
- The v2 API previously only exposed `secondary_node_id` (a primary's pointer to its own secondary) — a secondary node's own record wasn't distinguishable via the API.

## Why
Needed by simplyblock-operator's new load-aware primary node placement webhook (companion branch: `feature/primary-node-placement` in simplyblock-operator), which excludes secondary nodes from placement candidates when choosing the best primary node for a new volume at creation time.

## Test plan
- [x] `pytest tests/unit/web/api/v2/test_storage_node_endpoints.py` — 11 passed
- [x] `ruff check simplyblock_web/api/v2/_dtos.py` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)