### PR TITLE
Filter subsystems on server-side

### DIFF
--- a/simplyblock_core/rpc_client.py
+++ b/simplyblock_core/rpc_client.py
@@ -2,17 +2,18 @@ import json
 from json import JSONDecodeError
 from typing import Any, Optional
 
-import requests
-from pydantic import SecretStr
-from requests.exceptions import ConnectionError, HTTPError, Timeout, TooManyRedirects
 import jsonschema
+import requests
 from jsonschema.exceptions import ValidationError
+from pydantic import SecretStr
+from requests.adapters import HTTPAdapter
+from requests.exceptions import ConnectionError, HTTPError, Timeout, TooManyRedirects
+from urllib3 import Retry
 
 from simplyblock_core import utils, constants
 from simplyblock_core.settings import Settings
+from simplyblock_core.utils.helpers import single_or_none
 from simplyblock_core.utils.secrets import unwrap_secrets_for_send
-from requests.adapters import HTTPAdapter
-from urllib3 import Retry
 
 logger = utils.get_logger()
 
@@ -209,12 +210,7 @@ class RPCClient:
         return self._request3("nvmf_get_subsystems")
 
     def subsystem_get(self, nqn: str) -> Optional[dict]:
-        return next((
-            subsystem
-            for subsystem
-            in self.subsystem_list()
-            if subsystem["nqn"] == nqn
-        ), None)
+        return single_or_none(self._request3("nvmf_get_subsystems", nqn=nqn))
 
     def subsystem_delete(self, nqn):
         return self._request("nvmf_delete_subsystem", params={'nqn': nqn})

--- a/tests/unit/rpc/test_client.py
+++ b/tests/unit/rpc/test_client.py
@@ -56,17 +56,18 @@ class TestSubsystem(unittest.TestCase):
         self.assertEqual(r1, r2)
 
     @patch.object(RPCClient, "_request3")
-    def test_subsystem_get_filters_by_nqn(self, mock_req):
-        mock_req.return_value = [
-            {"nqn": "nqn.a", "namespaces": []},
-            {"nqn": "nqn.b", "namespaces": []},
-        ]
+    def test_subsystem_get_delegates_filtering_to_rpc(self, mock_req):
+        # nvmf_get_subsystems filters server-side, so the RPC returns only the
+        # matching subsystem when queried by nqn.
+        mock_req.return_value = [{"nqn": "nqn.b", "namespaces": []}]
         client = _make_client()
+
         self.assertEqual(client.subsystem_get("nqn.b")["nqn"], "nqn.b")
+        mock_req.assert_called_once_with("nvmf_get_subsystems", nqn="nqn.b")
 
     @patch.object(RPCClient, "_request3")
-    def test_subsystem_get_filter_miss_returns_empty(self, mock_req):
-        mock_req.return_value = [{"nqn": "nqn.a", "namespaces": []}]
+    def test_subsystem_get_filter_miss_returns_none(self, mock_req):
+        mock_req.return_value = []
         client = _make_client()
         self.assertIsNone(client.subsystem_get("nqn.nonexistent"))
 

--- a/tests/unit/rpc/test_subsystem_add_ns_idempotent.py
+++ b/tests/unit/rpc/test_subsystem_add_ns_idempotent.py
@@ -58,13 +58,13 @@ class TestAddNsIdempotent(unittest.TestCase):
     def test_successful_add_never_probes(self):
         """The happy path pays no nvmf_get_subsystems dump at all."""
         c = _client()
-        with patch.object(c, "subsystem_list") as mock_list, \
+        with patch.object(c, "subsystem_get") as mock_get, \
              patch.object(c, "_request2", return_value=(1, None)) as mock_req:
             ret = c.nvmf_subsystem_add_ns("nqn.test:lvol:abc", "bdev0", uuid="u1", nsid=1)
 
         self.assertEqual(ret, 1)
         mock_req.assert_called_once()
-        mock_list.assert_not_called()
+        mock_get.assert_not_called()
 
     def test_missing_namespace_fires_rpc(self):
         """When the bdev is not yet in the subsystem, the real RPC fires."""
@@ -72,10 +72,10 @@ class TestAddNsIdempotent(unittest.TestCase):
         nqn = "nqn.test:lvol:abc"
         bdev = "LVS_345/LVOL_8403"
 
-        with patch.object(c, "subsystem_list", return_value=[{
+        with patch.object(c, "subsystem_get", return_value={
                 "nqn": nqn,
                 "namespaces": [],
-            }]), \
+            }), \
              patch.object(c, "_request2", return_value=(1, None)) as mock_req:
             ret = c.nvmf_subsystem_add_ns(nqn, bdev, uuid="u1", nsid=1)
 
@@ -88,7 +88,7 @@ class TestAddNsIdempotent(unittest.TestCase):
         """A rejected add with no matching namespace is a real failure — the
         original error must reach the caller (subsystem gone / full)."""
         c = _client()
-        with patch.object(c, "subsystem_list", return_value=[]), \
+        with patch.object(c, "subsystem_get", return_value=None), \
              patch.object(c, "_request2", return_value=(None, _DUP_ERR)) as mock_req:
             ret, err = c.nvmf_subsystem_add_ns2("nqn.test", "bdev0", uuid="u1")
         mock_req.assert_called_once()
@@ -102,12 +102,12 @@ class TestAddNsIdempotent(unittest.TestCase):
         nqn = "nqn.test:lvol:abc"
         bdev = "LVS_345/LVOL_8403"
 
-        with patch.object(c, "subsystem_list", return_value=[{
+        with patch.object(c, "subsystem_get", return_value={
                 "nqn": nqn,
                 "namespaces": [{
                     "nsid": 1, "bdev_name": bdev, "uuid": "old-uuid",
                 }],
-            }]), \
+            }), \
              patch.object(c, "_request2", return_value=(None, _DUP_ERR)) as mock_req:
             ret, err = c.nvmf_subsystem_add_ns2(nqn, bdev, uuid="new-uuid", nsid=1)
 
@@ -121,12 +121,12 @@ class TestAddNsIdempotent(unittest.TestCase):
         nqn = "nqn.test:lvol:abc"
         bdev = "LVS_345/LVOL_8403"
 
-        with patch.object(c, "subsystem_list") as mock_list, \
+        with patch.object(c, "subsystem_get") as mock_get, \
              patch.object(c, "_request2", return_value=(None, _DUP_ERR)) as mock_req:
             ret, err = c.nvmf_subsystem_add_ns2(nqn, bdev, uuid="u1", nsid=1,
                                                 idempotent=False)
 
-        mock_list.assert_not_called()
+        mock_get.assert_not_called()
         mock_req.assert_called_once()
         self.assertEqual(err, _DUP_ERR)
 
@@ -134,7 +134,7 @@ class TestAddNsIdempotent(unittest.TestCase):
         """If the error-path probe itself raises, the original rejection is
         returned rather than the probe's exception."""
         c = _client()
-        with patch.object(c, "subsystem_list", side_effect=RuntimeError("rpc down")), \
+        with patch.object(c, "subsystem_get", side_effect=RuntimeError("rpc down")), \
              patch.object(c, "_request2", return_value=(None, _DUP_ERR)) as mock_req:
             ret, err = c.nvmf_subsystem_add_ns2("nqn.test", "bdev0")
         mock_req.assert_called_once()
@@ -148,10 +148,10 @@ class TestAddNsIdempotent(unittest.TestCase):
         nqn = "nqn.test:lvol:abc"
         bdev = "LVS_345/LVOL_8403"
 
-        with patch.object(c, "subsystem_list", return_value=[{
+        with patch.object(c, "subsystem_get", return_value={
                 "nqn": nqn,
                 "namespaces": [{"nsid": 2, "bdev_name": bdev, "uuid": "u1"}],
-            }]), \
+            }), \
              patch.object(c, "_request2", return_value=(None, _DUP_ERR)) as mock_req:
             ret = c.nvmf_subsystem_add_ns(nqn, bdev, uuid="u1")  # no nsid pinned
 


### PR DESCRIPTION
The SPDK already allows to retrieve subsystems by NQN, so use that instead of enumerating all and filtering in the client.