### PR TITLE
Fix the Kubernetes Node Add Cycling

### DIFF
--- a/simplyblock_core/storage_node_ops.py
+++ b/simplyblock_core/storage_node_ops.py
@@ -2325,11 +2325,9 @@ def add_node(cluster_id, node_addr, iface_name, data_nics_list,
         ssd_pcie = node_config.get("ssd_pcis")
 
         if ssd_pcie:
-            while True:
-                action, existing = _classify_existing_endpoint_record(
-                    db_controller, cluster_id, node_addr, ssd_pcie)
-                if action != "cleanup":
-                    break
+            action, existing = _classify_existing_endpoint_record(
+                db_controller, cluster_id, node_addr, ssd_pcie)
+            if action == "cleanup":
                 # Repeated partial attempts can leave several stale records
                 # for the same endpoint, hence the loop.
                 logger.warning(
@@ -2342,7 +2340,8 @@ def add_node(cluster_id, node_addr, iface_name, data_nics_list,
                     logger.warning("Failed to kill SPDK process for stale in_creation node", exc_info=True)
                 storage_events.snode_delete(existing)
                 existing.remove(db_controller.kv_store)
-            if action == "already_added":
+                return False
+            elif action == "already_added":
                 logger.info(
                     f"Node {existing.get_id()} with endpoint {node_addr} is already "
                     f"added and online (owns the same SSDs); add-node is an "

--- a/simplyblock_core/storage_node_ops.py
+++ b/simplyblock_core/storage_node_ops.py
@@ -2329,7 +2329,7 @@ def add_node(cluster_id, node_addr, iface_name, data_nics_list,
                 db_controller, cluster_id, node_addr, ssd_pcie)
             if action == "cleanup":
                 # Repeated partial attempts can leave several stale records
-                # for the same endpoint, hence the loop.
+                # for the same endpoint; we clean one per task retry.
                 logger.warning(
                     f"Node {existing.get_id()} is in_creation status with endpoint "
                     f"{node_addr}, removing and deleting it")

--- a/simplyblock_core/utils/__init__.py
+++ b/simplyblock_core/utils/__init__.py
@@ -2636,9 +2636,9 @@ def patch_cr_node_status(
                 # Node already absent from status — nothing to do.
                 return
             # Node not yet in status.nodes[] — operator syncs this asynchronously.
-            # Silently return so callers during node_add (in_creation phase) don't abort.
+            # Log and return so callers during node_add (in_creation phase) don't abort.
             logger.warning(
-                f"patch_cr_node_status: node not yet in status.nodes "
+                f"patch_cr_node_status: node not yet in status.nodes for {namespace}/{name} "
                 f"(uuid={node_uuid}, mgmtIp={node_mgmt_ip}), skipping"
             )
             return

--- a/simplyblock_core/utils/__init__.py
+++ b/simplyblock_core/utils/__init__.py
@@ -2634,10 +2634,14 @@ def patch_cr_node_status(
         if not found:
             if remove:
                 # Node already absent from status — nothing to do.
-                return            
-            raise RuntimeError(
-                f"Node not found (uuid={node_uuid}, mgmtIp={node_mgmt_ip})"
+                return
+            # Node not yet in status.nodes[] — operator syncs this asynchronously.
+            # Silently return so callers during node_add (in_creation phase) don't abort.
+            logger.warning(
+                f"patch_cr_node_status: node not yet in status.nodes "
+                f"(uuid={node_uuid}, mgmtIp={node_mgmt_ip}), skipping"
             )
+            return
 
         api.patch_namespaced_custom_object_status(
             group=group,


### PR DESCRIPTION
Made the node add not fail on Kubernetes StorageNodeSet reconcile errors. Those will be fixed in the next iteration.

It also fixes an infinite loop.