### PR TITLE
add disable_monitoring field to DeployConfig

### DIFF
--- a/simplyblock_core/cluster_ops.py
+++ b/simplyblock_core/cluster_ops.py
@@ -407,6 +407,7 @@ def create_cluster(blk_size, page_size_in_blocks, cli_pass,
     cfg.grafana_endpoint = grafana_endpoint or default_grafana
     cfg.grafana_secret = monitoring_secret if mode == "kubernetes" else cluster.secret
     cfg.db_connection = db_connection if db_connection else SecretStr("")
+    cfg.disable_monitoring = disable_monitoring
     cfg.write_to_db()
 
     # Monitoring stack configuration (OpenSearch max_result_window, Graylog
@@ -516,6 +517,7 @@ def add_cluster(blk_size, page_size_in_blocks, cap_warn, cap_crit, prov_cap_warn
         cluster.db_connection = cfg.db_connection
         cluster.grafana_secret = cfg.grafana_secret
         cluster.grafana_endpoint = cfg.grafana_endpoint
+        cluster.disable_monitoring = cfg.disable_monitoring
     else:
         # Bootstrapping the very first cluster of a fresh deployment: no
         # DeployConfig exists yet (only the docker-swarm create_cluster()
@@ -527,6 +529,7 @@ def add_cluster(blk_size, page_size_in_blocks, cap_warn, cap_crit, prov_cap_warn
         monitoring_secret = SecretStr(os.environ.get("MONITORING_SECRET", ""))
 
         cluster.mode = "kubernetes"
+        cluster.disable_monitoring = enable_monitoring != "true"
         logger.info("Retrieving foundationdb connection string...")
         cluster.db_connection = utils.get_fdb_cluster_string(constants.FDB_CONFIG_NAME, constants.K8S_NAMESPACE)
         if monitoring_secret:
@@ -539,7 +542,7 @@ def add_cluster(blk_size, page_size_in_blocks, cap_warn, cap_crit, prov_cap_warn
 
         mgmt_node_ops.add_mgmt_node("0.0.0.0", "kubernetes", cluster.uuid)
 
-        if enable_monitoring == "true":
+        if not cluster.disable_monitoring:
             _set_max_result_window(constants.OS_K8S_ENDPOINT)
             _add_graylog_input(constants.GRAYLOG_K8S_ENDPOINT, cluster.grafana_secret)
 
@@ -548,9 +551,11 @@ def add_cluster(blk_size, page_size_in_blocks, cap_warn, cap_crit, prov_cap_warn
         cfg.grafana_endpoint = cluster.grafana_endpoint
         cfg.grafana_secret = cluster.grafana_secret
         cfg.db_connection = cluster.db_connection
+        cfg.disable_monitoring = cluster.disable_monitoring
         cfg.write_to_db()
 
-    _create_update_user(cluster.uuid, cluster.grafana_endpoint, cluster.grafana_secret, cluster.secret)
+    if not cluster.disable_monitoring:
+        _create_update_user(cluster.uuid, cluster.grafana_endpoint, cluster.grafana_secret, cluster.secret)
 
     if cluster.mode == "kubernetes":
         utils.patch_prometheus_configmap(cluster.uuid, cluster.secret.get_secret_value())

--- a/simplyblock_core/models/cluster.py
+++ b/simplyblock_core/models/cluster.py
@@ -247,6 +247,7 @@ class DeployConfig(BaseModel):
     db_connection: SecretStr = SecretStr("")
     grafana_secret: SecretStr = SecretStr("")
     mode: str = "docker"
+    disable_monitoring: bool = False
 
     def get_id(self):
         return "uuid"


### PR DESCRIPTION
at the moment, cluster create with Simplyblock-operator results in this error

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.12/site-packages/requests/adapters.py", line 696, in send
    resp = conn.urlopen(
           ^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/urllib3/connectionpool.py", line 842, in urlopen
    retries = retries.increment(
              ^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/urllib3/util/retry.py", line 543, in increment
    raise MaxRetryError(_pool, url, reason) from reason  # type: ignore[arg-type]
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
urllib3.exceptions.MaxRetryError: HTTPConnectionPool(host='simplyblock-grafana', port=3000): Max retries exceeded with url: /api/admin/users (Caused by NameResolutionError("HTTPConnection(host='simplyblock-grafana', port=3000): Failed to resolve 'simplyblock-grafana' ([Errno -2] Name or service not known)"))`
```

PR #1182 refactored add_cluster() to read cluster-wide settings from a DeployConfig record instead of deriving them inline. 

Fixing this by taking into consideration of this field for API based creation.


### testing

Tested this by creating a cluster with operator based cluster from this branch. 
```
                                                                                                                                      in 0.692s
NAME                  STATUS   UUID                                   CONFIGURED   AGE
simplyblock-cluster   active   13eb9a30-3805-4f9a-a486-7623c5a1b213   true         5m26s
```

all the storage nodes got added and cluster is also active. 