### PR TITLE
fix(security-scan): stop shipping dev caches; ignore pip-vendored CVEs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,6 +10,14 @@ sbcli*
 .env
 .env.*
 
+# Ignore test/tooling caches and virtualenvs (not needed at runtime;
+# these can carry outdated, vulnerable copies of pip/setuptools/wheel
+# that trip up the Trivy image scan)
+.tox
+.mypy_cache
+.ruff_cache
+.pytest_cache
+
 # Ignore Docker-related files
 Dockerfile
 docker-compose.yml

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -54,6 +54,7 @@ jobs:
           ignore-unfixed: true
           exit-code: '1'
           scanners: vuln,secret
+          trivyignores: .trivyignore.yaml
 
       - name: Generate SBOM (CycloneDX)
         uses: aquasecurity/trivy-action@v0.35.0

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -1,0 +1,16 @@
+# Findings ignored here are not fixable from our side: they live inside
+# pip's own vendored dependency bundle (pip/_vendor), shipped by pip itself
+# for its internal use (dependency resolution, HTTP caching) during
+# `pip install`. They are not imported or reachable by the running
+# simplyblock control-plane application. As of pip 26.2 (the latest
+# release), pip still vendors these versions — see
+# https://github.com/pypa/pip/blob/main/src/pip/_vendor/vendor.txt
+# Re-check on the next pip release; drop the entry once pip bumps the
+# vendored version past the fix.
+vulnerabilities:
+  # msgpack 1.1.2 vendored by pip; fixed upstream in 1.2.1
+  - id: GHSA-6v7p-g79w-8964
+  # setuptools 70.3.0 pinned in pip's vendor.txt; fixed upstream in 78.1.1
+  - id: CVE-2025-47273
+  # setuptools 70.3.0 pinned in pip's vendor.txt; fixed upstream in 83.0.0
+  - id: CVE-2026-59890


### PR DESCRIPTION
## Summary
The daily `Security Scan` workflow (https://github.com/simplyblock/sbcli/actions/runs/30521368594) was failing on the Trivy step. Two independent root causes, both confirmed by locally reproducing the exact build + scan:

1. **`docker/Dockerfile`'s `COPY . /app` was shipping local dev caches into the image.** `.dockerignore` didn't exclude `.tox`, `.mypy_cache`, `.ruff_cache`, or `.pytest_cache`. `.tox` alone carried ~900MB across several stale `python3.9`/`3.12`/`3.13` tox virtualenvs, each bundling its own old (genuinely vulnerable) `pip`/`wheel`. This is why the failing run showed vulnerabilities tied to package versions that don't otherwise exist anywhere in `requirements.txt` or the Dockerfiles — they were pip copies inside a leftover local `.tox` directory. Fixed by adding those dirs to `.dockerignore`. As a side effect the scanned image shrank from 1.96GB to 1.09GB.
2. **The remaining 3 findings are inherent to pip 26.2 itself**, not to anything we install: `msgpack==1.1.2` and `setuptools==70.3.0` are pinned in pip's own vendored bundle (`pip/_vendor/vendor.txt`) for pip's internal use (dependency resolution / HTTP caching), and are still the current pinned versions in the latest pip release (26.2) as of this PR — so there's no available fix on our side, and rebuilding won't change it. Added `.trivyignore.yaml` (wired via the `trivyignores` input) to suppress just these 3 specific finding IDs, with a comment explaining why and a note to re-check when pip bumps its vendor bundle.

## Test plan
- [x] Rebuilt `docker/Dockerfile` locally against `simplyblock/simplyblock:base_image` before and after the `.dockerignore` change — confirmed `.tox`'s stray pip/wheel copies disappear and image size drops 1.96GB → 1.09GB.
- [x] Ran `aquasec/trivy:latest image` against the built image with the same flags as the workflow (`--severity CRITICAL,HIGH,MEDIUM --ignore-unfixed --scanners vuln,secret --ignorefile .trivyignore.yaml --exit-code 1`) — exits `0` with zero findings.
- [x] Verified `trivy-action@v0.35.0`'s `trivyignores` input correctly routes a `.yaml` ignorefile to `TRIVY_IGNOREFILE` (checked `entrypoint.sh` for that release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)