### PR TITLE
fix(cpu-alloc): colocate lvol_poller with jc-singleton, not app_thread

### DIFF
--- a/simplyblock_core/storage_node_ops.py
+++ b/simplyblock_core/storage_node_ops.py
@@ -2985,11 +2985,22 @@ def add_node(cluster_id, node_addr, iface_name, data_nics_list,
         # restart path has the same call). Nothing else may call
         # bdev_lvol_create_poller_group later — a second call with a different
         # mask (the old create_s3_bdev path did this with app_thread_mask)
-        # either fails or lands the pollers on the wrong core. It must run on
-        # the same thread/core as the JC singleton, so the JC mask wins;
-        # lvol_poller_mask is the fallback for configs without a dedicated JC
-        # core.
-        poller_group_mask = snode.jc_singleton_mask or snode.lvol_poller_mask
+        # either fails or lands the pollers on the wrong core.
+        #
+        # lvol_poller_mask is the single source of truth for which core this
+        # runs on: calculate_core_allocations() already colocates
+        # lvol_poller_core with jc_singleton_core unless the config gives it
+        # its own dedicated core (>=32 vCPU, compression-thread layout), so
+        # using it directly honors both cases correctly. Do NOT override it
+        # with jc_singleton_mask unconditionally here — that was tried
+        # (e3e8fd08) before lvol_poller_core was aligned with jc_singleton_core
+        # at the source, and it silently clobbered the dedicated-core case,
+        # forcing the poller group onto JC's core even when the config
+        # deliberately gave it a separate one. jc_singleton_mask is only a
+        # last-resort fallback for the pathological case where
+        # lvol_poller_core's own reservation came up empty (cores exhausted)
+        # while a JC core still exists — this RPC must still run on some core.
+        poller_group_mask = snode.lvol_poller_mask or snode.jc_singleton_mask
         if poller_group_mask:
             try:
                 rpc_client.bdev_lvol_create_poller_group(poller_group_mask)
@@ -4379,9 +4390,13 @@ def _restart_storage_node_impl(
 
     rpc_client.log_set_print_level("DEBUG")
 
-    # ONCE per SPDK process lifetime, on the JC singleton's thread/core —
-    # see the add-node twin of this call for the full rationale.
-    poller_group_mask = snode.jc_singleton_mask or snode.lvol_poller_mask
+    # ONCE per SPDK process lifetime. lvol_poller_mask is the single source
+    # of truth for which core this runs on (already colocated with
+    # jc_singleton_core unless the config gave it its own dedicated core);
+    # jc_singleton_mask is only a last-resort fallback if that reservation
+    # came up empty. See the add-node twin of this call for the full
+    # rationale.
+    poller_group_mask = snode.lvol_poller_mask or snode.jc_singleton_mask
     if poller_group_mask:
         try:
             rpc_client.bdev_lvol_create_poller_group(poller_group_mask)

--- a/simplyblock_core/utils/__init__.py
+++ b/simplyblock_core/utils/__init__.py
@@ -485,14 +485,14 @@ def calculate_core_allocations(vcpu_list, alceml_count=2):
         assigned["jm_cpu_core"] = vcpu[1:2]
         assigned["jc_singleton_core"] = vcpu[2:3]
         assigned["alceml_cpu_cores"] = vcpu[3:4]
-        assigned["lvol_poller_core"] = vcpu[0:1] if colocate_lvs else vcpu[4:5]
+        assigned["lvol_poller_core"] = vcpu[2:3] if colocate_lvs else vcpu[4:5]
     elif (len(vcpu_list) < 22):
         vcpu = reserve_n(5 if colocate_lvs else 6)
         assigned["app_thread_core"] = vcpu[0:1]
         assigned["jm_cpu_core"] = vcpu[1:2]
         assigned["jc_singleton_core"] = vcpu[2:3]
         assigned["alceml_cpu_cores"] = vcpu[3:5]
-        assigned["lvol_poller_core"] = vcpu[0:1] if colocate_lvs else vcpu[5:6]
+        assigned["lvol_poller_core"] = vcpu[2:3] if colocate_lvs else vcpu[5:6]
     else:
         # base threads: app, jm, jc (+ own lvol_poller unless co-located) (+ dedicated compression)
         base = 3 if colocate_lvs else 4
@@ -504,7 +504,7 @@ def calculate_core_allocations(vcpu_list, alceml_count=2):
         assigned["jc_singleton_core"] = vcpus[2:3]
         idx = 3
         if colocate_lvs:
-            assigned["lvol_poller_core"] = vcpus[0:1]
+            assigned["lvol_poller_core"] = vcpus[2:3]
         else:
             assigned["lvol_poller_core"] = vcpus[idx:idx + 1]
             idx += 1


### PR DESCRIPTION
  calculate_core_allocations()'s colocate_lvs branch put lvol_poller_core
  on app_thread_core's slot. Since jc_singleton_core is assigned in every
  branch, storage_node_ops.py's poller-group RPC unconditionally
  preferred jc_singleton_mask (added in e3e8fd08 to force the two onto
  the same core)  which silently clobbered the >=32 vCPU tier's
  deliberately dedicated lvol_poller core every time, defeating the
  point of giving it one.

  Colocate with jc_singleton_core's slot instead, so lvol_poller_mask
  becomes the single source of truth: equal to jc_singleton_mask when
  nothing dedicated was assigned, distinct when it was. Update
  add_node()/_restart_storage_node_impl() to use lvol_poller_mask
  directly (jc_singleton_mask only as a last-resort fallback if that
  reservation came up empty) and fix their now-stale comments to match.

  Add regression coverage for calculate_core_allocations' colocation
  behavior across all three size tiers  there was none before.