### PR TITLE
Fix regression in type check fix

### DIFF
--- a/simplyblock_cli/clibase.py
+++ b/simplyblock_cli/clibase.py
@@ -582,7 +582,7 @@ class CLIWrapperBase:
         return cluster_ops.get_ssh_pass(cluster_id)
 
     def cluster__set(self, sub_command, args):
-        cluster_ops.set(args.cluster_id, args.attr_name, args.attr_value)
+        cluster_ops.set_(args.cluster_id, args.attr_name, args.attr_value)
         return True
 
     def cluster__set_shared_placement(self, sub_command, args):

--- a/simplyblock_core/cluster_ops.py
+++ b/simplyblock_core/cluster_ops.py
@@ -1004,7 +1004,7 @@ def _cluster_activate(cl_id, force=False, force_lvstore_create=False) -> None:
             if len(fd_host_counts) < 2:
                 _fd_fail("failure domains are enabled but all hosts are in a "
                          "single domain; at least two domains are required")
-            if len(fd_host_counts) != 1:
+            if len(set(fd_host_counts.values())) != 1:
                 _fd_fail(
                     f"failure domains must hold an EQUAL number of hosts at "
                     f"activation; current split: "

--- a/simplyblock_core/cluster_ops.py
+++ b/simplyblock_core/cluster_ops.py
@@ -2530,7 +2530,7 @@ def delete_cluster(cl_id) -> None:
     cluster.remove(db_controller.kv_store)
     logger.info("Done")
 
-def set(cl_id, attr, value) -> bool:
+def set_(cl_id, attr, value) -> bool:
     cluster = db_controller.get_cluster_by_id(cl_id)
     key_splits = attr.split(".")
     key = key_splits[0]


### PR DESCRIPTION
15aecbbabb5e3f828379f4e032146fd91541a9a6 introduced a regression that this reverts. The intended use of the `set`-builtin in that code was shadowed by `cluster_ops.set`. The type checker flagged that and I confused misread the error. The additional fix to the original type failure is to avoid shadowing the builtin by renaming `cluster_ops.set` to `set_`.