### PR TITLE
fix(port_block): add support for FirewallClient based on SPDK version

### DIFF
--- a/simplyblock_core/models/storage_node.py
+++ b/simplyblock_core/models/storage_node.py
@@ -163,6 +163,8 @@ class StorageNode(BaseNodeObject):
     lvol_poller_mask: str = ""
     spdk_proxy_image: str = ""
     transfer_hublvol: HubLVol = None  # type: ignore[assignment]
+    # spdk image tag
+    spdk_version: str = "main"
 
     def get_lvol_subsys_port(self, lvs_name=None):
         """Get the client-facing NVMeoF port for a specific lvstore.

--- a/simplyblock_core/storage_node_ops.py
+++ b/simplyblock_core/storage_node_ops.py
@@ -2880,6 +2880,7 @@ def add_node(cluster_id, node_addr, iface_name, data_nics_list,
         snode.active_tcp = active_tcp
         snode.active_rdma = active_rdma
         snode.spdk_proxy_image = spdk_proxy_image
+        snode.spdk_version = spdk_proxy_image.split(":")[1]
 
         if 'cpu_count' in node_info:
             snode.cpu = node_info['cpu_count']
@@ -4412,6 +4413,8 @@ def _restart_storage_node_impl(
 
     if spdk_proxy_image:
         snode.spdk_proxy_image = spdk_proxy_image
+        snode.spdk_version = spdk_proxy_image.split(":")[1]
+
     if not snode.spdk_proxy_image:
         snode.spdk_proxy_image = cluster.container_image_prefix + constants.SIMPLY_BLOCK_DOCKER_IMAGE
 

--- a/simplyblock_core/utils/port_block.py
+++ b/simplyblock_core/utils/port_block.py
@@ -18,11 +18,18 @@ logger = logging.getLogger(__name__)
 
 def set_port(node, port, block, is_reject=False, timeout=5, retry=2):
     """Block or unblock ``port`` on ``node``.
+    If spdk_version is R26.2-PRE-latest or empty (came from upgrade) then
+     use FirewallClient(iptables). Default is to use SPDK RPC.
 
     Tries SPDK ``nvmf_port_block`` / ``nvmf_port_unblock`` first; on
     method-not-found falls back to ``FirewallClient.firewall_set_port``
     (iptables). Any other error from the RPC propagates as-is.
     """
+    if node.spdk_version == "" or node.spdk_version == "R26.2-PRE-latest":
+        fw = FirewallClient(node, timeout=timeout, retry=retry)
+        action = "block" if block else "allow"
+        return fw.firewall_set_port(port, "tcp", action, node.rpc_port, is_reject=is_reject)
+
     rpc = node.rpc_client(timeout=timeout, retry=retry)
     try:
         if block:


### PR DESCRIPTION
Adds a `spdk_version` field to `StorageNode`, derived from the tag of `spdk_proxy_image` and set on node add/restart.

`port_block.set_port()` now checks this version up front: nodes running `R26.2-PRE-latest`, or nodes with no version recorded yet (e.g. nodes that came from an upgrade), go straight to `FirewallClient.firewall_set_port (iptables)` rather than attempting the SPDK `nvmf_port_block/nvmf_port_unblock` RPC first and falling back on a `method-not-found` error.
