### PR TITLE
Make test execution reproducible

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ build-backend = 'setuptools.build_meta'
 extend-exclude = ['simplyblock_cli/cli.py']
 
 [tool.ruff.lint]
+extend-select = ["TID251"]
 ignore = [
     "B006",
     "B008",
@@ -93,6 +94,14 @@ ignore = [
     "UP045",
 ]
 
+[tool.ruff.lint.per-file-ignores]
+# TID251 is flake8-tidy-imports.banned-api, configured below. Test code only —
+# production code may seed the global RNG.
+"!tests/**" = ["TID251"]
+
+[tool.ruff.lint.flake8-tidy-imports.banned-api]
+"random.seed".msg = "Seeding the global RNG breaks seed replay for every later test — pytest-randomly seeds it per test. See tests/AGENTS.md § Randomness and seeds."
+
 [tool.mypy]
 check_untyped_defs = true
 follow_untyped_imports = true
@@ -102,6 +111,10 @@ enable_error_code = ["deprecated"]
 pythonpath = "."
 testpaths = ['simplyblock_core/test', 'tests']
 norecursedirs = ['tests/perf']
+# Order randomization stays off for now: tests/conftest.py documents inter-test
+# coupling (TTL caches, the DBController singleton, the port-block gate) that
+# shuffling would surface all at once. Enabling it is its own change.
+addopts = "-p randomly --randomly-dont-reorganize"
 markers = [
     "slow: long-running integration tests (e.g. live migration); excluded from the default integration run, opt in with -m slow",
 ]

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,6 @@
 httpx  # fastapi.testclient
 pytest
+pytest-randomly  # per-run seed + per-test reseed; see tests/AGENTS.md
 pytest-timeout
 requests
 testcontainers>=4.0

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -94,6 +94,49 @@ adding one, check you are not looking at a stall instead:
 Both integration envs run with `--durations=10`, so the slowest tests are printed on
 every run and drift is visible before it trips a timeout.
 
+### Randomness and seeds
+
+`pytest-randomly` picks a **fresh seed on every run** and prints it in the report
+header (`Using --randomly-seed=1234567`), so runs explore different stochastic paths
+and any run can be replayed exactly:
+
+```bash
+PYTEST_ADDOPTS="--randomly-seed=1234567" tox run -e unit    # replay a specific run
+PYTEST_ADDOPTS="--randomly-seed=last" tox run -e unit       # replay the previous local run
+```
+
+`last` reads pytest's cache directory, which CI does not persist — **re-running a CI
+job picks a new seed and will not reproduce the failure.** Copy the seed out of the
+failed run's header instead.
+
+The global RNG is reseeded before each test to `seed + crc32(nodeid)`, so a test's
+draws don't depend on what ran before it or on xdist sharding. Ordinary tests should
+just use the `random` module; there is no fixture to request and nothing to wire up.
+
+**`random.seed()` is banned in `tests/`** (ruff TID251) — it overrides the session
+seed and breaks replay for every test that follows.
+
+**Threads must be handed their own RNG.** A shared stream consumed from several
+threads has a nondeterministic draw *order*, so seeding alone won't replay. Draw the
+child seed in the spawning thread, at a fixed point:
+
+```python
+worker_rng = random.Random(random.getrandbits(64))   # in start(), not in the worker
+t = threading.Thread(target=self._worker, args=(i, worker_rng))
+```
+
+`StressRunner.start` in `integration/ftt2/test_restart_concurrent_ops.py` is the
+canonical example, and `MockRpcServer` (`integration/migration/mock_rpc_server.py`)
+gives each node its own stream, reseeded per test in `reset_state()`, so the src/tgt
+servers can't perturb each other's failure patterns.
+
+A seed replays the *values* each thread draws, not the *interleaving* between them.
+Concurrency tests must therefore assert invariants, not exact outcomes.
+
+Don't patch stdlib `random` attributes (`patch("...utils.random.random", ...)`) —
+that mutates the module process-wide, for every thread. Rebind the name in the module
+under test instead (see `unit/test_soak_outage_gap.py`).
+
 ### Slow tests (the `slow` marker)
 
 The migration suite (`tests/integration/migration/`, ~138 tests, ~20min) is tagged

--- a/tests/device_namespace_mock_rpc.py
+++ b/tests/device_namespace_mock_rpc.py
@@ -34,7 +34,7 @@ class NamespaceNodeState:
         self.failures = {}
         self.random_failures = {}
         self.random_failure_probability = 0.0
-        self.random = random.Random(0)
+        self.random = random.Random(random.getrandbits(64))
         self.thread_stats = {"threads": [{"name": "app_thread", "id": 1}]}
 
     def next_nsid(self, nqn, requested_nsid=None):
@@ -47,10 +47,11 @@ class NamespaceNodeState:
         self.next_namespace[nqn] += 1
         return nsid
 
-    def configure_random_failures(self, mapping, probability=1.0, seed=0):
+    def configure_random_failures(self, mapping, probability=1.0, seed=None):
         self.random_failures = mapping
         self.random_failure_probability = probability
-        self.random = random.Random(seed)
+        self.random = random.Random(
+            seed if seed is not None else random.getrandbits(64))
 
     def configure_failures(self, mapping):
         self.failures = {method: list(codes) for method, codes in mapping.items()}
@@ -410,6 +411,6 @@ class NamespaceMockRpcServer:
         with self.state.lock:
             self.state.configure_failures(mapping)
 
-    def configure_random_failures(self, mapping, probability=1.0, seed=0):
+    def configure_random_failures(self, mapping, probability=1.0, seed=None):
         with self.state.lock:
             self.state.configure_random_failures(mapping, probability=probability, seed=seed)

--- a/tests/integration/ftt2/test_restart_concurrent_ops.py
+++ b/tests/integration/ftt2/test_restart_concurrent_ops.py
@@ -131,7 +131,7 @@ class StressRunner:
                 "thread": threading.current_thread().name,
             })
 
-    def _worker(self, worker_id):
+    def _worker(self, worker_id, rng):
         """Worker thread that fires random operations.
         NOTE: patches must be started by the caller BEFORE spawning threads."""
         from simplyblock_core.db_controller import DBController
@@ -140,7 +140,7 @@ class StressRunner:
         created_lvols = []
 
         while not self._stop.is_set():
-            op = random.choice(["create", "delete", "resize", "create", "delete"])
+            op = rng.choice(["create", "delete", "resize", "create", "delete"])
             t0 = time.time()
 
             try:
@@ -152,13 +152,13 @@ class StressRunner:
 
                 elif op == "delete" and created_lvols:
                     from simplyblock_core.controllers import lvol_controller
-                    lvol = created_lvols.pop(random.randrange(len(created_lvols)))
+                    lvol = created_lvols.pop(rng.randrange(len(created_lvols)))
                     lvol_controller.delete_lvol(lvol, force_delete=True)
                     self._record("delete", True, t0, time.time(), lvol.uuid)
 
                 elif op == "resize" and created_lvols:
                     from simplyblock_core.controllers import lvol_controller
-                    lvol = random.choice(created_lvols)
+                    lvol = rng.choice(created_lvols)
                     new_size = lvol.size + 1_073_741_824
                     lvol_controller.resize_lvol(lvol.uuid, new_size)
                     self._record("resize", True, t0, time.time(), lvol.uuid)
@@ -166,12 +166,18 @@ class StressRunner:
             except Exception as e:
                 self._record(op, False, t0, time.time(), str(e))
 
-            time.sleep(self.interval + random.uniform(0, self.interval))
+            time.sleep(self.interval + rng.uniform(0, self.interval))
 
     def start(self):
         self._stop.clear()
         for i in range(self.num_threads):
-            t = threading.Thread(target=self._worker, args=(i,),
+            # Seed drawn here, in the spawning thread: this loop runs in a fixed
+            # order, so each worker replays the same op sequence for a given
+            # session seed. Drawing inside _worker would race and defeat replay.
+            # Thread interleaving stays nondeterministic either way, so the
+            # assertions below are invariants, not exact outcomes.
+            worker_rng = random.Random(random.getrandbits(64))
+            t = threading.Thread(target=self._worker, args=(i, worker_rng),
                                  name=f"stress-{i}", daemon=True)
             t.start()
             self._threads.append(t)

--- a/tests/integration/migration/mock_rpc_server.py
+++ b/tests/integration/migration/mock_rpc_server.py
@@ -36,13 +36,13 @@ logger = logging.getLogger(__name__)
 # Async-delay helper
 # ---------------------------------------------------------------------------
 
-def _async_delay() -> float:
+def _async_delay(rng: random.Random) -> float:
     """
     Return a completion delay (seconds) from an exponential distribution with
     mean 0.2 s (λ = 5), clipped to [0.1, 100].  Values pile up near 0.2 s but
     occasionally reach tens of seconds, matching real-world transfer variance.
     """
-    raw = random.expovariate(5.0)
+    raw = rng.expovariate(5.0)
     return max(0.1, min(100.0, raw))
 
 
@@ -82,6 +82,11 @@ class NodeState:
         self._map_id_counter = 1
         self._nsid_counter: Dict[str, int] = {}  # nqn → next nsid
         self.lock = threading.Lock()
+
+        # Per node rather than one shared stream: otherwise adding a single RPC
+        # to the source would shift every later failure draw on the target, so
+        # an unrelated edit would silently change which calls fail.
+        self.rng = random.Random()
 
     # ---- helpers ----
 
@@ -153,8 +158,9 @@ class _RpcHandler(BaseHTTPRequestHandler):
 
         # --- failure injection ---
         if server.failure_rate > 0:
-            if random.random() < server.failure_rate:
-                failure_type = random.choice(['timeout', 'error'])
+            rng = server.node_state.rng
+            if rng.random() < server.failure_rate:
+                failure_type = rng.choice(['timeout', 'error'])
                 if failure_type == 'timeout':
                     # Sleep beyond typical client timeout to simulate a hang
                     time.sleep(server.timeout_seconds + 1)
@@ -163,7 +169,7 @@ class _RpcHandler(BaseHTTPRequestHandler):
                 else:
                     # Pick a random error code from method-specific list or generic
                     codes = _METHOD_ERROR_CODES.get(method, [-1, -22, -2])
-                    code = random.choice(codes)
+                    code = rng.choice(codes)
                     self._send_error(code, f"Simulated failure for {method}", req_id)
                     return
 
@@ -332,7 +338,7 @@ def _bdev_lvol_delete(s: NodeState, p: dict):
         if composite not in bdevs:
             # Not found – return ok (idempotent start)
             return True
-        s.delete_ops[composite] = time.time() + _async_delay()
+        s.delete_ops[composite] = time.time() + _async_delay(s.rng)
         logger.debug("mock delete_lvol async start %s", composite)
         return True
     else:
@@ -567,7 +573,7 @@ def _bdev_lvol_transfer(s: NodeState, p: dict):
     if composite not in s.lvols and composite not in s.snapshots:
         raise _RpcError(-2, f"source bdev {composite} not found")
     s.transfer_ops[composite] = {
-        'complete_at': time.time() + _async_delay(),
+        'complete_at': time.time() + _async_delay(s.rng),
         'state': 'In progress',
     }
     logger.debug("mock bdev_lvol_transfer started for %s", composite)
@@ -598,7 +604,7 @@ def _bdev_lvol_transfer_final_step(s: NodeState, p: dict):
     if composite not in s.lvols:
         raise _RpcError(-2, f"source lvol {composite} not found")
     s.transfer_ops[composite] = {
-        'complete_at': time.time() + _async_delay(),
+        'complete_at': time.time() + _async_delay(s.rng),
         'state': 'In progress',
     }
     logger.debug("mock bdev_lvol_transfer_final_step started for %s", composite)
@@ -909,8 +915,15 @@ class MockRpcServer:
             self._server.timeout_seconds = timeout_seconds
 
     def reset_state(self):
-        """Wipe all in-memory state (useful between subtests)."""
+        """Wipe all in-memory state (useful between subtests).
+
+        Also reseeds the node's RNG — servers are session-scoped, so without
+        this the stream would carry over between tests. The draw happens here,
+        on the main thread while the server is idle, rather than in the handler
+        thread, so it lands at a fixed point in the test's stream.
+        """
         with self.state.lock:
+            self.state.rng.seed(random.getrandbits(64))
             self.state.lvols.clear()
             self.state.snapshots.clear()
             self.state.subsystems.clear()

--- a/tests/integration/migration/test_scalability.py
+++ b/tests/integration/migration/test_scalability.py
@@ -57,7 +57,7 @@ MAX_SNAPS = 10
 AVG_VOLS_PER_SUBSYS = 5
 
 
-def _generate_scalability_spec(rng: random.Random) -> dict:
+def _generate_scalability_spec() -> dict:
     """
     Build a topology spec dict with NUM_VOLUMES volumes, random snapshot
     chains, and shared namespace groups.
@@ -72,8 +72,8 @@ def _generate_scalability_spec(rng: random.Random) -> dict:
     for vi in range(NUM_VOLUMES):
         vol_id = f"v{vi}"
         vol_name = f"vol_{vi}"
-        grp = rng.choice(groups)
-        num_snaps = rng.randint(MIN_SNAPS, MAX_SNAPS)
+        grp = random.choice(groups)
+        num_snaps = random.randint(MIN_SNAPS, MAX_SNAPS)
 
         volumes.append({
             "id": vol_id,
@@ -209,8 +209,7 @@ class TestScalability:
         mock_tgt_server.reset_state()
         mock_tgt_server.set_failure_rate(0.0)
 
-        rng = random.Random(42)  # deterministic for reproducibility
-        spec = _generate_scalability_spec(rng)
+        spec = _generate_scalability_spec()
 
         # Patch RPC ports to match session-scoped mock servers
         import os
@@ -229,13 +228,13 @@ class TestScalability:
         ctx = load_topology(spec)
         _seed_all(mock_src_server, ctx, "src")
 
-        yield ctx, rng
+        yield ctx
 
         ctx.teardown()
 
     def test_topology_creation(self, scale_topology):
         """Verify the topology was created with expected counts."""
-        ctx, rng = scale_topology
+        ctx = scale_topology
 
         assert len(ctx._lvols) == NUM_VOLUMES
         assert len(ctx._snaps) > NUM_VOLUMES  # at least 1 snap per vol
@@ -254,11 +253,11 @@ class TestScalability:
     @pytest.mark.timeout(300)  # 10 sequential migrations over the scale topology (~128s)
     def test_migrate_sample_volumes(self, scale_topology, mock_tgt_server):
         """Migrate 10 random volumes sequentially and verify each completes."""
-        ctx, rng = scale_topology
+        ctx = scale_topology
         tgt = ctx.node("tgt")
 
         # Pick 10 random volumes to migrate
-        vol_syms = [f"v{i}" for i in rng.sample(range(NUM_VOLUMES), 10)]
+        vol_syms = [f"v{i}" for i in random.sample(range(NUM_VOLUMES), 10)]
 
         for vol_sym in vol_syms:
             lvol_uuid = ctx.lvol_uuid(vol_sym)
@@ -281,7 +280,7 @@ class TestScalability:
         Find a namespace group with multiple volumes and migrate all of them.
         The target should reuse the subsystem for subsequent volumes.
         """
-        ctx, rng = scale_topology
+        ctx = scale_topology
         tgt = ctx.node("tgt")
 
         # Find a group with at least 3 volumes
@@ -323,7 +322,7 @@ class TestScalability:
         Migrate two volumes from the same snapshot chain.
         The second migration should detect pre-existing snapshots.
         """
-        ctx, rng = scale_topology
+        ctx = scale_topology
         tgt = ctx.node("tgt")
 
         # Find a volume with multiple snapshots (>= 3)
@@ -374,7 +373,7 @@ class TestScalability:
         Migrate 20 volumes sequentially and measure throughput.
         This is not a pass/fail test — it prints timing stats for CI monitoring.
         """
-        ctx, rng = scale_topology
+        ctx = scale_topology
         tgt = ctx.node("tgt")
 
         vol_syms = [f"v{i}" for i in range(20)]

--- a/tests/integration/test_nvmeof_security_e2e.py
+++ b/tests/integration/test_nvmeof_security_e2e.py
@@ -13,7 +13,6 @@ Tests cover:
 """
 
 import json
-import random
 import unittest
 import uuid as _uuid_mod
 
@@ -368,7 +367,6 @@ class TestErrorInjection(unittest.TestCase):
         })
         _server.set_failure_rate(0.5, timeout_seconds=0.5)
 
-        random.seed(42)
         successes = 0
         errors = 0
         for i in range(20):

--- a/tests/integration/test_snapshot_delete_race.py
+++ b/tests/integration/test_snapshot_delete_race.py
@@ -1,14 +1,10 @@
 # coding=utf-8
 """Unit tests for the snapshot/clone delete-race fixes.
 
-Three fixes covered:
-
-1. ``get_random_vuid`` and ``get_random_snapshot_vuid`` dedupe against
-   existing ``CLN_``/``LVOL_``/``SNAP_`` bdev-name numeric suffixes
-   so SPDK won't reject a new clone/snapshot with
-   ``lvol with name X already exists``. The legacy 10k random space
-   on ``get_random_vuid`` had ~50% birthday-collision probability with
-   ~10k lvols/snaps in a soak; bumped to 1M plus the explicit dedupe.
+Fixes covered, numbered to match the section banners below. Fix 1 was the
+``get_random_vuid`` bdev-name dedupe; it no longer exists — vuids are now
+allocated monotonically via ``DBController.next_vuid``, which cannot collide,
+so the tests for it were removed.
 
 2. ``snapshot_controller.add`` rejects creating a snapshot from an lvol
    in ``STATUS_IN_DELETION``, and ``snapshot_controller.clone`` rejects
@@ -119,81 +115,6 @@ def _snapshot(uuid, lvol, snap_bdev=None,
     s.cluster_id = "cluster-1"
     s.vuid = 100
     return s
-
-
-# ---------------------------------------------------------------------------
-# Fix 1: random vuid dedupe against existing bdev-name numeric suffixes
-# ---------------------------------------------------------------------------
-
-class TestRandomVuidDedupesAgainstBdevNames(unittest.TestCase):
-
-    @patch("simplyblock_core.db_controller.DBController")
-    def test_get_random_vuid_skips_existing_lvol_bdev_number(self, mock_db_cls):
-        """``get_random_vuid`` must not return a number already used as
-        the numeric suffix of an existing ``CLN_``/``LVOL_`` bdev name —
-        SPDK would reject the resulting create with "lvol with name
-        already exists" and trigger the snapshot-delete-in-flight bug.
-        """
-        from simplyblock_core import utils
-
-        existing_lvol = _lvol("ex", lvol_bdev="CLN_42")
-        existing_lvol.top_bdev = "LVS_100/CLN_42"
-
-        db = MagicMock()
-        db.get_storage_nodes.return_value = []
-        db.get_lvols.return_value = [existing_lvol]
-        db.get_snapshots.return_value = []
-        mock_db_cls.return_value = db
-
-        # Force random to first return 42 (which IS in use), then 99.
-        # The dedupe loop must skip 42 and return a different number.
-        with patch("simplyblock_core.utils.random.random",
-                   side_effect=[42 / 1000000.0, 99 / 1000000.0]):
-            result = utils.get_random_vuid()
-        # The crucial property: the result is NOT 42, even though
-        # random.random() handed us 42 on the first try.
-        self.assertNotEqual(result, 42)
-
-    @patch("simplyblock_core.db_controller.DBController")
-    def test_get_random_vuid_skips_existing_snap_bdev_number(self, mock_db_cls):
-        """Same dedupe applies to existing ``SNAP_`` bdev names. The
-        clone-create path uses ``CLN_<vuid>``; if a fresh ``CLN_77047``
-        request lands while a ``SNAP_77047`` (different bdev type but
-        same numeric suffix) exists, SPDK still treats them as a name
-        collision because the bdev name space is flat."""
-        from simplyblock_core import utils
-
-        snap_lvol = _lvol("ex", lvol_bdev="LVOL_1")
-        existing_snap = _snapshot("snap-1", snap_lvol, snap_bdev="SNAP_77047")
-
-        db = MagicMock()
-        db.get_storage_nodes.return_value = []
-        db.get_lvols.return_value = [snap_lvol]
-        db.get_snapshots.return_value = [existing_snap]
-        mock_db_cls.return_value = db
-
-        with patch("simplyblock_core.utils.random.random",
-                   side_effect=[77047 / 1000000.0, 250 / 1000000.0]):
-            result = utils.get_random_vuid()
-        self.assertNotEqual(result, 77047)
-
-    @patch("simplyblock_core.db_controller.DBController")
-    def test_get_random_snapshot_vuid_skips_existing_bdev_names(self, mock_db_cls):
-        """``get_random_snapshot_vuid`` must also dedupe against existing
-        ``CLN_``/``LVOL_``/``SNAP_`` bdev numbers."""
-        from simplyblock_core import utils
-
-        clone_lvol = _lvol("c1", lvol_bdev="CLN_867796")
-        db = MagicMock()
-        db.get_storage_nodes.return_value = []
-        db.get_lvols.return_value = [clone_lvol]
-        db.get_snapshots.return_value = []
-        mock_db_cls.return_value = db
-
-        with patch("simplyblock_core.utils.random.random",
-                   side_effect=[867796 / 1000000.0, 555 / 1000000.0]):
-            result = utils.get_random_snapshot_vuid()
-        self.assertNotEqual(result, 867796)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_capacity_churn_soak.py
+++ b/tests/unit/test_capacity_churn_soak.py
@@ -17,7 +17,6 @@ If this logic drifts, the soak silently stops honouring its 2500-volume /
 
 import importlib.util
 import os
-import random
 import threading
 import types
 import unittest
@@ -105,7 +104,6 @@ class TestSizeSteering(unittest.TestCase):
     def test_running_average_converges_to_target(self):
         """Feeding picked sizes back into the live set should steer the
         cumulative average toward --avg-size (5 GiB)."""
-        random.seed(1234)
         runner = _fake_runner()
         seq = 0
         for _ in range(2500):

--- a/tests/unit/test_soak_outage_gap.py
+++ b/tests/unit/test_soak_outage_gap.py
@@ -18,15 +18,17 @@ contracted to exercise. If the cap math drifts, the soak silently stops
 covering the dual-outage path it was built for.
 """
 
+import functools
 import importlib.util
 import os
 import random
 import sys
 import unittest
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 
+@functools.cache
 def _load_soak_module():
     """Load the soak script as a module without invoking its main().
 
@@ -34,6 +36,10 @@ def _load_soak_module():
     `python scripts/aws_dual_node_outage_soak_mixed_churn.py`. It does
     not run anything at import time (only argparse + class defs), so a
     plain importlib load gives us the SoakRunner class.
+
+    Cached so every ``_runner_stub()`` shares one module object: tests that
+    build a second stub mid-test would otherwise get a freshly exec'd module,
+    which a patch installed in setUp does not cover.
     """
     repo_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
     path = os.path.join(repo_root, "scripts",
@@ -114,14 +120,16 @@ class TestPickOutageGap(unittest.TestCase):
 
     def setUp(self):
         self.mod, self.runner = _runner_stub()
-        # Determinism: lock random.randint for repeatable assertions on
-        # bounds. random.uniform is not used by _pick_outage_gap.
-        self._orig_randint = random.randint
         self.calls = []
-        random.randint = lambda a, b: (self.calls.append((a, b)) or a)
-
-    def tearDown(self):
-        random.randint = self._orig_randint
+        # Record the bounds _pick_outage_gap asks for, and return the low one so
+        # the assertions below are about the bounds, not the draw. Rebinding the
+        # name inside the soak module rather than assigning to random.randint:
+        # the latter mutates the stdlib module for the whole process.
+        stub = MagicMock(wraps=random)
+        stub.randint = lambda a, b: (self.calls.append((a, b)) or a)
+        patcher = patch.object(self.mod, "random", stub)
+        patcher.start()
+        self.addCleanup(patcher.stop)
 
     def _last_bounds(self):
         self.assertTrue(self.calls, "random.randint was not called")


### PR DESCRIPTION
Randomization in tests is irreproducible at the moment.  The seeds are only set to a fixed value for a specific test, all other tests don't set it. This makes it hard to track down random test failures (e.g. #1228).

This PR introduces proper seeding for tests, instrumentation to make it play nice with parallel execution, and blacklists overrides of the seeds to avoid falsifying the seed.

Seeds are printed in test summaries and can be used upon failures to rerun the exact same test.