### PR TITLE
Harden error handling

### DIFF
--- a/simplyblock_core/cluster_ops.py
+++ b/simplyblock_core/cluster_ops.py
@@ -1843,16 +1843,8 @@ def set_shared_placement(cl_id, enable=True, force=False) -> bool:
 
     # Step 3: persist the flag in every stored distrib stack entry on
     # every node, so restarts re-create with the new mode without needing
-    # to consult the cluster row.
-    #
-    # NB: only `lvstore_stack` is a List[dict] of bdev stack entries.
-    # Despite the model's type annotation, `lvstore_stack_secondary` and
-    # `_tertiary` hold a single UUID string — the id of the upstream
-    # primary whose LVS this node serves as a peer for. The peer's bdev
-    # params come from that primary's lvstore_stack at recreate time
-    # (see storage_node_ops._create_bdev_stack callers in step-2 /
-    # step-3 of full_node_recreate_lvstore), so updating the primary's
-    # stack here covers the peers automatically.
+    # to consult the cluster row. Peers recreate their bdevs from the
+    # primary's lvstore_stack, so updating primaries covers them too.
     for node in nodes:
         # Atomic compare-and-set: mutate only lvstore_stack on the freshly-read
         # node so the long per-node loop above can't clobber a concurrent

--- a/simplyblock_core/models/storage_node.py
+++ b/simplyblock_core/models/storage_node.py
@@ -79,8 +79,10 @@ class StorageNode(BaseNodeObject):
     lvols: int = 0
     lvstore: str = ""
     lvstore_stack: List[dict] = []
-    lvstore_stack_secondary: List[dict] = []
-    lvstore_stack_tertiary: List[dict] = []
+    # Despite the names, these hold the UUID of the primary whose LVS this node
+    # serves as a peer for — not a bdev stack.
+    lvstore_stack_secondary: str = ""
+    lvstore_stack_tertiary: str = ""
     lvol_subsys_port: int = 9090
     lvstore_ports: dict = {}  # {lvs_name: {"lvol_subsys_port": N, "hublvol_port": M}}
     max_lvol: int = 0

--- a/simplyblock_core/models/storage_node.py
+++ b/simplyblock_core/models/storage_node.py
@@ -197,7 +197,7 @@ class StorageNode(BaseNodeObject):
             host = f"{self._k8s_node_label()}.simplyblock-storage-node-api.{self.cr_namespace}.svc.cluster.local:{port}"
         return SNodeClient(host, **kwargs)
 
-    def rpc_client(self, **kwargs):
+    def rpc_client(self, **kwargs) -> RPCClient:
         """Return rpc client to this node
         """
         host = self.mgmt_ip

--- a/simplyblock_core/models/storage_node.py
+++ b/simplyblock_core/models/storage_node.py
@@ -603,7 +603,7 @@ class StorageNode(BaseNodeObject):
                 self.create_hublvol()
                 return True
             except RPCException as e:
-                logger.error("Error establishing hublvol: %s", e.message)
+                logger.error("Error establishing hublvol: %s", e)
                 return False
 
     def connect_to_hublvol(self, primary_node, failover_node=None, *, role,

--- a/simplyblock_core/rpc_client.py
+++ b/simplyblock_core/rpc_client.py
@@ -9,7 +9,7 @@ import requests
 from jsonschema.exceptions import ValidationError
 from pydantic import SecretStr
 from requests.adapters import HTTPAdapter
-from requests.exceptions import RequestException
+from requests.exceptions import ConnectionError, HTTPError, ReadTimeout
 from urllib3 import Retry
 
 from simplyblock_core import utils, constants
@@ -86,10 +86,29 @@ class RPCErrorCode(IntEnum):
 
 
 class RPCException(Exception):
-    def __init__(self, message: str, code: Optional[int] = None, data: Any = None):
-        super().__init__(message, code, data)
+    """Base class for all client-raised operational errors."""
+
+
+class RPCConnectionError(RPCException):
+    """Network/connection-level failure (couldn't reach the server)."""
+
+
+class RPCHTTPError(RPCException):
+    """Non-2xx HTTP status (raise_for_status failure)."""
+    def __init__(self, message, status_code, response_text=None):
+        super().__init__(message)
+        self.status_code = status_code
+        self.response_text = response_text
+
+
+class RPCProtocolError(RPCException):
+    """Response wasn't valid/well-formed JSON-RPC."""
+
+
+class RPCRemoteError(RPCException):
+    def __init__(self, message: str, code: int, data: Any = None):
+        super().__init__(message)
         self.code = code
-        self.message = message
         self.data = data
 
 
@@ -189,27 +208,33 @@ class RPCClient:
 
     def _request3(self, method: str, **kwargs):
         logger.debug("Requesting method: %s, params: %s", method, kwargs)
+        wire_payload = unwrap_secrets_for_send({
+            'id': 1,
+            'method': method,
+            'params': kwargs,
+        })
         try:
-            wire_payload = unwrap_secrets_for_send({
-                'id': 1,
-                'method': method,
-                'params': kwargs,
-            })
             response = self.session.post(
                 self.url, data=json.dumps(wire_payload), timeout=self.timeout,
                 headers={"X-RPC-Timeout": str(self.timeout)})
             response.raise_for_status()
             data = response.json()
             _response_validator.validate(data)
-        except (
-                RequestException,  # requests
-                JSONDecodeError,  # json
-                ValidationError,  # jsonschema
-        ) as e:
-            raise RPCException('Request failed') from e
+        except ConnectionError as e:
+            raise RPCConnectionError("Could not reach remote") from e
+        except ReadTimeout as e:
+            raise RPCConnectionError("Did not get a response from remote within timeout") from e
+        except HTTPError as e:
+            raise RPCHTTPError(
+                f"HTTP {response.status_code} from remote",
+                status_code=response.status_code,
+                response_text=response.text,
+            ) from e
+        except (JSONDecodeError, ValidationError) as e:
+            raise RPCProtocolError("Invalid result payload") from e
 
         if (error := data.get('error')) is not None:
-            raise RPCException(**error)
+            raise RPCRemoteError(**error)
 
         return data['result']
 
@@ -223,7 +248,7 @@ class RPCClient:
     def subsystem_get(self, nqn: str) -> Optional[dict]:
         try:
             return single_or_none(self._request3("nvmf_get_subsystems", nqn=nqn))
-        except RPCException as e:
+        except RPCRemoteError as e:
             if e.code == -errno.ENODEV:
                 return None
             raise
@@ -254,7 +279,7 @@ class RPCClient:
         """
         try:
             return self._request3("keyring_file_add_key", name=name, path=path)
-        except RPCException as e:
+        except RPCRemoteError as e:
             if allow_existing and e.code == -17:
                 logger.debug("Key %s already in SPDK keyring, reusing", name)
                 return None
@@ -1848,7 +1873,7 @@ class RPCClient:
                 name=name,
                 bucket_name=bucket_name,
             )
-        except RPCException as e:
+        except RPCRemoteError as e:
             if allow_existing and e.code == -17:
                 logger.debug("Bucket %s already registered with %s", name, bucket_name)
                 return None

--- a/simplyblock_core/services/tasks_runner_backup.py
+++ b/simplyblock_core/services/tasks_runner_backup.py
@@ -86,7 +86,7 @@ def _run_backup(task):
                 _fail_backup(backup, task, "bdev_lvol_s3_backup RPC failed")
                 return
         except RPCException as e:
-            _fail_backup(backup, task, f"RPC error: {e.message}")
+            _fail_backup(backup, task, f"RPC error: {e}")
             return
 
         backup.status = Backup.STATUS_IN_PROGRESS
@@ -229,7 +229,7 @@ def _run_restore(task):
                 task.write_to_db(db.kv_store)
                 return
         except RPCException as e:
-            task.function_result = f"RPC error: {e.message}"
+            task.function_result = f"RPC error: {e}"
             task.retry += 1
             task.status = JobSchedule.STATUS_SUSPENDED
             task.write_to_db(db.kv_store)
@@ -339,7 +339,7 @@ def _run_merge(task):
                 task.write_to_db(db.kv_store)
                 return
         except RPCException as e:
-            task.function_result = f"RPC error: {e.message}"
+            task.function_result = f"RPC error: {e}"
             task.retry += 1
             task.status = JobSchedule.STATUS_SUSPENDED
             task.write_to_db(db.kv_store)

--- a/simplyblock_core/services/tasks_runner_batch_migration.py
+++ b/simplyblock_core/services/tasks_runner_batch_migration.py
@@ -45,7 +45,7 @@ from simplyblock_core.models.cluster import Cluster
 from simplyblock_core.models.job_schedule import JobSchedule
 from simplyblock_core.models.lvol_migration_group import LVolMigrationGroup
 from simplyblock_core.models.storage_node import StorageNode
-from simplyblock_core.rpc_client import RPCException
+from simplyblock_core.rpc_client import RPCErrorCode, RPCRemoteError, RPCException
 from simplyblock_core.services.hub_controller_manager import HubControllerManager
 from simplyblock_core.services.tasks_runner_lvol_migration import (
     _make_rpc,
@@ -545,13 +545,11 @@ def _handle_intermediate_barrier(group, member_migrations, src_node, tgt_node, s
             lvol_names, lvol_ids, snapshot_names, 2, hub_bdev, "migrate")
         logger.info(f"Group {group.uuid[:8]}: bdev_lvol_batch_transfer_final_step returned {ret!r}")
         batch_ok = True
-    except RPCException as e:
+    except RPCRemoteError as e:
         logger.error(f"Group {group.uuid[:8]}: bdev_lvol_batch_transfer_final_step RPC error code={e.code}: {e}")
         batch_err = str(e)
-        # -32601 = Method not found: SPDK binary is missing this RPC handler.
-        # Retrying will never help; surface as fatal so the group fails immediately.
-        if e.code == -32601:
-            return False, batch_err
+        if e.code == RPCErrorCode.method_not_found:
+            return False, batch_err  # Retrying will never help; surface as fatal so the group fails immediately.
     except Exception as e:
         logger.error(f"Group {group.uuid[:8]}: bdev_lvol_batch_transfer_final_step failed: {e}")
         batch_err = str(e)

--- a/simplyblock_core/services/tasks_runner_lvol_migration.py
+++ b/simplyblock_core/services/tasks_runner_lvol_migration.py
@@ -102,7 +102,7 @@ from simplyblock_core.models.lvol_migration import LVolMigration
 from simplyblock_core.models.lvol_migration_group import LVolMigrationGroup
 from simplyblock_core.models.storage_node import StorageNode
 from simplyblock_core.models.snapshot import SnapShot
-from simplyblock_core.rpc_client import RPCErrorCode, RPCException, RPCClient
+from simplyblock_core.rpc_client import RPCErrorCode, RPCRemoteError, RPCException, RPCClient
 from simplyblock_core.services.hub_controller_manager import HubControllerManager
 from simplyblock_core.storage_node_ops import execute_on_leader_with_failover
 
@@ -2284,7 +2284,7 @@ def _rename_migrated_bdevs(migration, tgt_node, tgt_rpc, tgt_sec_rpc=None, tgt_t
         try:
             ret = tgt_rpc.bdev_lvol_rename(old_composite, new_short)
             prim_exists = False
-        except RPCException as exc:
+        except RPCRemoteError as exc:
             if exc.code == RPCErrorCode.invalid_params:
                 logger.warning(
                     f"_do_rename prim: {old_composite!r} -> {new_short!r}: "
@@ -2300,11 +2300,11 @@ def _rename_migrated_bdevs(migration, tgt_node, tgt_rpc, tgt_sec_rpc=None, tgt_t
                 try:
                     rpc.bdev_lvol_rename(old_composite, new_short)
                     logger.debug(f"_do_rename {role}: {old_composite!r} -> {new_short!r}: ok")
-                except RPCException as exc:
+                except RPCRemoteError as exc:
                     logger.warning(
                         f"_rename_migrated_bdevs: {role} rename {label} "
                         f"{old_composite!r} -> {new_short!r}: non-fatal "
-                        f"(code={exc.code}: {exc.message})")
+                        f"(code={exc.code}: {exc})")
                 except Exception as exc:
                     logger.warning(
                         f"_rename_migrated_bdevs: {role} rename {label} (non-fatal): {exc}")

--- a/simplyblock_core/services/tasks_runner_port_allow.py
+++ b/simplyblock_core/services/tasks_runner_port_allow.py
@@ -3,7 +3,7 @@ import time
 
 
 from simplyblock_core import db_controller, utils, storage_node_ops, distr_controller
-from simplyblock_core.rpc_client import RPCException
+from simplyblock_core.rpc_client import RPCErrorCode, RPCException, RPCRemoteError
 from simplyblock_core.utils import port_block
 from simplyblock_core.controllers import (
     tcp_ports_events, health_controller, tasks_controller, storage_events, device_controller,
@@ -363,8 +363,8 @@ def _failback_leadership_to_primary(node, current_leader, other_peers):
                 if current_leader.rpc_client().jc_disable_replication(lvs_jm_vuid):
                     repl_suspended = True
                     break
-            except RPCException as e:
-                if e.code == -32601: # method not found
+            except RPCRemoteError as e:
+                if e.code == RPCErrorCode.method_not_found:
                     try:
                         logger.warning("Failed to disable replication on leader, trying other method")
                         ret = current_leader.rpc_client().jc_get_jm_status(lvs_jm_vuid)
@@ -389,6 +389,12 @@ def _failback_leadership_to_primary(node, current_leader, other_peers):
                         "leader %s (attempt %d/%d); re-quiescing",
                     current_leader.get_id()[:8], _attempt + 1,
                     _REPL_SUSPEND_MAX_ATTEMPTS)
+            except RPCException:
+                logger.warning(
+                    "jc_disable_replication reports active replication on acting "
+                    "leader %s (attempt %d/%d); re-quiescing",
+                current_leader.get_id()[:8], _attempt + 1,
+                _REPL_SUSPEND_MAX_ATTEMPTS)
         except Exception as e:
             return False, f"jc_disable_replication on acting leader failed: {e}"
 

--- a/simplyblock_core/storage_node_ops.py
+++ b/simplyblock_core/storage_node_ops.py
@@ -38,7 +38,7 @@ from simplyblock_core.models.snapshot import SnapShot
 from simplyblock_core.models.storage_node import StorageNode
 from simplyblock_core.models.cluster import Cluster
 from simplyblock_core.prom_client import PromClient
-from simplyblock_core.rpc_client import RPCClient, RPCException  # noqa: F401  (RPCClient kept as a patch target for tests)
+from simplyblock_core.rpc_client import RPCClient, RPCErrorCode, RPCRemoteError, RPCException  # noqa: F401  (RPCClient kept as a patch target for tests)
 from simplyblock_core.snode_client import SNodeClient, SNodeClientException
 from simplyblock_web import node_utils
 from simplyblock_core.utils import addNvmeDevices
@@ -8927,8 +8927,8 @@ def _recreate_lvstore_impl(snode, force=False, lvs_primary=None, activation_mode
                     # c. suspend journal replication while the port is blocked
                     try:
                         repl_disabled = current_leader.rpc_client().jc_disable_replication(lvs_jm_vuid)
-                    except RPCException as e:
-                        if e.code == -32601:  # method not found
+                    except RPCRemoteError as e:
+                        if e.code == RPCErrorCode.method_not_found:
                             try:
                                 logger.warning("Failed to disable replication on leader, trying other method")
                                 ret = current_leader.rpc_client().jc_get_jm_status(lvs_jm_vuid)
@@ -8943,6 +8943,9 @@ def _recreate_lvstore_impl(snode, force=False, lvs_primary=None, activation_mode
                         else:
                             _abort_restart_and_unblock(
                                 f"jc_disable_replication on leader {current_leader.get_id()} failed: {e}")
+                    except RPCException as e:
+                        _abort_restart_and_unblock(
+                            f"jc_disable_replication on leader {current_leader.get_id()} failed: {e}")
 
                     if repl_disabled:
                         replication_suspended = True
@@ -9224,8 +9227,8 @@ def _recreate_lvstore_impl(snode, force=False, lvs_primary=None, activation_mode
                             _abort_restart_and_unblock(
                                 f"recreate_hublvol returned False on {snode.get_id()}")
                     except RPCException as e:
-                        logger.error("Error creating hublvol: %s", e.message)
-                        _abort_restart_and_unblock(f"recreate_hublvol raised: {e.message}")
+                        logger.error("Error creating hublvol: %s", e)
+                        _abort_restart_and_unblock(f"recreate_hublvol raised: {e}")
                     try:
                         # defer_db_write: the full-object node write (~150ms FDB
                         # round-trip caught in-window by the [NODE-WRITE]
@@ -9233,7 +9236,7 @@ def _recreate_lvstore_impl(snode, force=False, lvs_primary=None, activation_mode
                         snode.create_transfer_hublvol(defer_db_write=True)
                         _deferred_node_persist["needed"] = True
                     except RPCException as e:
-                        logger.error("Error creating transfer hublvol: %s", e.message)
+                        logger.error("Error creating transfer hublvol: %s", e)
 
             ### 8b- connect peers to hublvol WITHIN port-blocked window
             # The old leader must be set to secondary role (via set_lvs_opts + connect_hublvol)
@@ -10057,13 +10060,13 @@ def create_lvstore(snode, ndcs, npcs, distr_bs, distr_chunk_bs, page_size_in_blo
     try:
         snode.create_hublvol(cluster_nqn=cluster.nqn)
     except RPCException as e:
-        logger.error("Error establishing hublvol: %s", e.message)
+        logger.error("Error establishing hublvol: %s", e)
         # return False
 
     try:
         snode.create_transfer_hublvol()
     except RPCException as e:
-        logger.error("Error creating transfer hublvol: %s", e.message)
+        logger.error("Error creating transfer hublvol: %s", e)
 
     if secondary_ids:
         # Create secondary hublvol on sec_1 so tertiary can multipath.

--- a/simplyblock_core/storage_node_ops.py
+++ b/simplyblock_core/storage_node_ops.py
@@ -3713,17 +3713,17 @@ def _delete_replica_on_peer(peer, primary, cluster):
         nqn = peer.hublvol_nqn_for_lvstore(cluster.nqn, lvstore)
         if rpc_client.subsystem_get(nqn):
             rpc_client.subsystem_delete(nqn)
-    except Exception as e:
+    except RPCException as e:
         logger.warning(f"hublvol subsystem teardown for {lvstore} on {peer.get_id()} failed: {e}")
     try:
         rpc_client.bdev_lvol_delete_hublvol(lvstore)
-    except Exception as e:
+    except RPCException as e:
         logger.warning(f"hublvol bdev teardown for {lvstore} on {peer.get_id()} failed: {e}")
     try:
         # deepcopy: _remove_bdev_stack stamps bdev['status']; don't mutate the
         # primary's stored stack definition.
         _remove_bdev_stack(copy.deepcopy(primary.lvstore_stack), rpc_client)
-    except Exception as e:
+    except RPCException as e:
         logger.warning(f"replica bdev-stack teardown for {lvstore} on {peer.get_id()} failed: {e}")
 
 

--- a/simplyblock_core/storage_node_ops.py
+++ b/simplyblock_core/storage_node_ops.py
@@ -120,7 +120,7 @@ def _rpc_lvstore_exists(rpc_client, lvs_name):
         return False
 
 
-def _kill_spdk_until_dead(snode, max_attempts=3, poll_per_attempt_sec=5,
+def _kill_spdk_until_dead(snode: StorageNode, max_attempts=3, poll_per_attempt_sec=5,
                            poll_interval=0.25):
     """Kill SPDK on `snode` and return only after it is verifiably gone.
 
@@ -191,7 +191,7 @@ def _kill_spdk_until_dead(snode, max_attempts=3, poll_per_attempt_sec=5,
 
 
 
-def _set_lvol_ana_on_node(lvol, node, ana_state):
+def _set_lvol_ana_on_node(lvol: LVol, node: StorageNode, ana_state):
     """Set ANA state for a single lvol's listeners on a given node."""
     rpc_client = node.rpc_client(timeout=10, retry=2)
     listener_port = node.get_lvol_subsys_port(lvol.lvs_name)
@@ -206,7 +206,7 @@ def _set_lvol_ana_on_node(lvol, node, ana_state):
                 logger.info("ANA: %s on %s (%s) → %s", lvol.nqn, node.get_id(), iface.ip4_address, ana_state)
 
 
-def _failover_primary_ana(primary_node):
+def _failover_primary_ana(primary_node: StorageNode):
     """Primary failed: promote first_sec→optimized.
 
     The second_sec stays at non_optimized (its permanent state).
@@ -232,7 +232,7 @@ def _failover_primary_ana(primary_node):
             _set_lvol_ana_on_node(lvol, first_sec, "optimized")
 
 
-def _failback_primary_ana(primary_node):
+def _failback_primary_ana(primary_node: StorageNode):
     """Primary restarting: demote first_sec→non_optimized.
 
     The second_sec is already non_optimized and never changes.
@@ -255,7 +255,7 @@ def _failback_primary_ana(primary_node):
             _set_lvol_ana_on_node(lvol, first_sec, "non_optimized")
 
 
-def trigger_ana_failover_for_node(offline_node):
+def trigger_ana_failover_for_node(offline_node: StorageNode):
     """Trigger ANA failover when a node goes offline.
 
     Only action needed: if the offline node is a primary, promote its
@@ -272,7 +272,7 @@ def trigger_ana_failover_for_node(offline_node):
             logger.error("ANA failover for primary role of %s failed: %s", node_id, e)
 
 
-def trigger_ana_failback_for_node(restarting_node):
+def trigger_ana_failback_for_node(restarting_node: StorageNode):
     """Trigger ANA failback when a primary comes back online.
 
     Demote first_sec from optimized back to non_optimized.
@@ -568,7 +568,7 @@ def connect_device(name: str, device: NVMeDevice, node: StorageNode, attach_time
             expected_ips, is_multipath)
 
 
-def _connect_device_attach(name, device, node, rpc_client, attach_rpc_client,
+def _connect_device_attach(name, device, node: StorageNode, rpc_client, attach_rpc_client,
                            expected_ips, is_multipath):
     """Controller inspect + attach path of connect_device.
 
@@ -839,7 +839,7 @@ def _search_for_partitions(rpc_client, nvme_device):
     return partitioned_devices
 
 
-def _create_jm_stack_on_raid(rpc_client, jm_nvme_bdevs, snode, after_restart):
+def _create_jm_stack_on_raid(rpc_client, jm_nvme_bdevs, snode: StorageNode, after_restart):
     # RAID 0+1 journal layout (see simplyblock_core/jm_raid.py):
     #   1 device   -> no raid (bare device)
     #   2 devices  -> raid1 over two single-device legs  (a 2-way mirror)
@@ -953,7 +953,7 @@ def _create_jm_stack_on_raid(rpc_client, jm_nvme_bdevs, snode, after_restart):
     })
 
 
-def _create_jm_stack_on_device(rpc_client, nvme, snode, after_restart):
+def _create_jm_stack_on_device(rpc_client, nvme, snode: StorageNode, after_restart):
     alceml_id = nvme.get_id()
     alceml_name = device_controller.get_alceml_name(alceml_id)
     db_controller = DBController()
@@ -1044,7 +1044,7 @@ def _create_jm_stack_on_device(rpc_client, nvme, snode, after_restart):
     })
 
 
-def _create_storage_device_stack(rpc_client, nvme, snode, after_restart):
+def _create_storage_device_stack(rpc_client, nvme, snode: StorageNode, after_restart):
     db_controller = DBController()
     nvme_bdev = nvme.nvme_bdev
     if snode.enable_test_device:
@@ -1117,7 +1117,7 @@ def _create_storage_device_stack(rpc_client, nvme, snode, after_restart):
     return nvme
 
 
-def _create_device_partitions(rpc_client, nvme, snode, num_partitions_per_dev, jm_percent, partition_size, nbd_index):
+def _create_device_partitions(rpc_client, nvme, snode: StorageNode, num_partitions_per_dev, jm_percent, partition_size, nbd_index):
     nbd_device = rpc_client.nbd_start_disk(nvme.nvme_bdev, f"/dev/nbd{nbd_index}")
     time.sleep(3)
     if not nbd_device:
@@ -1155,7 +1155,7 @@ def _create_device_partitions(rpc_client, nvme, snode, num_partitions_per_dev, j
     return True
 
 
-def _prepare_cluster_devices_partitions(snode, devices):
+def _prepare_cluster_devices_partitions(snode: StorageNode, devices):
     db_controller = DBController()
     new_devices = []
     devices_to_partition = []
@@ -1245,7 +1245,7 @@ def _prepare_cluster_devices_partitions(snode, devices):
     return True
 
 
-def _prepare_cluster_devices_jm_on_dev(snode, devices):
+def _prepare_cluster_devices_jm_on_dev(snode: StorageNode, devices):
     db_controller = DBController()
     if not devices:
         return True
@@ -1284,7 +1284,7 @@ def _prepare_cluster_devices_jm_on_dev(snode, devices):
     return True
 
 
-def _prepare_cluster_devices_on_restart(snode, clear_data=False):
+def _prepare_cluster_devices_on_restart(snode: StorageNode, clear_data=False):
     db_controller = DBController()
 
     new_devices = []
@@ -1965,7 +1965,7 @@ def reconnect_dropped_remote_devs(this_node: StorageNode):
     return changed, all_ok
 
 
-def _peer_reachable_via_jm_quorum(target_node_id, this_node, peer_probe_timeout=1):
+def _peer_reachable_via_jm_quorum(target_node_id, this_node: StorageNode, peer_probe_timeout=1):
     """Check whether ``target_node`` is reachable on the data plane by asking
     other online peers about their JM quorum state.
 
@@ -2000,7 +2000,7 @@ def _peer_reachable_via_jm_quorum(target_node_id, this_node, peer_probe_timeout=
     return not probed
 
 
-def _connect_to_remote_jm_devs(this_node, jm_ids=None, only_node_id=None):
+def _connect_to_remote_jm_devs(this_node: StorageNode, jm_ids=None, only_node_id=None):
     """Connect ``this_node`` to remote JM devices and return the refreshed
     remote-JM records.
 
@@ -3506,7 +3506,7 @@ def remove_storage_node(node_id, force_remove=False, force_migrate=False):
     return task_id
 
 
-def _check_replica_relocation_feasible(removed_node, db_controller):
+def _check_replica_relocation_feasible(removed_node: StorageNode, db_controller):
     """Pre-flight Case-B check: a secondary/tertiary replica hosted on
     ``removed_node`` for some OTHER primary must have a valid relocation target.
     Returns (feasible: bool, reason: str)."""
@@ -3528,7 +3528,7 @@ def _check_replica_relocation_feasible(removed_node, db_controller):
     return True, ""
 
 
-def _pick_replica_relocation_node(primary, removed_node, role, db_controller):
+def _pick_replica_relocation_node(primary, removed_node: StorageNode, role, db_controller):
     """Choose a node to re-host ``primary``'s ``role`` (secondary|tertiary)
     replica, currently on ``removed_node``. Returns a node id or None.
     Reuses the existing anti-affinity-aware placement helpers.
@@ -3662,7 +3662,7 @@ def node_removal_orchestrate(node_id, force_remove=False):
         cluster_ops.set_cluster_status(cluster.get_id(), prev_cluster_status)
 
 
-def _teardown_replicas_of_primary(removed_node):
+def _teardown_replicas_of_primary(removed_node: StorageNode):
     """Case A: the primary LVS lives on ``removed_node`` (now shut down).
     Delete its secondary/tertiary replicas from the peers that host them and
     clear the cross-reference bookkeeping. The node has no LVols (enforced at
@@ -3727,7 +3727,7 @@ def _delete_replica_on_peer(peer, primary, cluster):
         logger.warning(f"replica bdev-stack teardown for {lvstore} on {peer.get_id()} failed: {e}")
 
 
-def _relocate_replicas_hosted_on(removed_node):
+def _relocate_replicas_hosted_on(removed_node: StorageNode):
     """Case B: ``removed_node`` holds a secondary and/or tertiary replica for
     other primaries. Re-host each on a fresh, anti-affinity-valid node so the
     owning primary keeps its fault tolerance after this node leaves."""
@@ -3746,7 +3746,7 @@ def _relocate_replicas_hosted_on(removed_node):
     return True
 
 
-def _relocate_one_replica(removed_node, primary_id, role):
+def _relocate_one_replica(removed_node: StorageNode, primary_id, role):
     """Re-host ``primary_id``'s ``role`` replica off ``removed_node``.
 
     Idempotent: the back-reference on ``removed_node`` is cleared only AFTER the
@@ -3796,7 +3796,7 @@ def _relocate_one_replica(removed_node, primary_id, role):
     return True
 
 
-def _clear_replica_backref(removed_node, backref):
+def _clear_replica_backref(removed_node: StorageNode, backref):
     db_controller = DBController()
     removed_node = db_controller.get_storage_node_by_id(removed_node.get_id())
     if getattr(removed_node, backref):
@@ -3804,7 +3804,7 @@ def _clear_replica_backref(removed_node, backref):
         removed_node.write_to_db()
 
 
-def _decommission_node_devices(removed_node):
+def _decommission_node_devices(removed_node: StorageNode):
     """Remove, fail and migrate every data device on ``removed_node``.
 
     Drives each device ONLINE/UNAVAILABLE -> REMOVED -> FAILED (which queues the
@@ -3866,7 +3866,7 @@ def _decommission_node_devices(removed_node):
     return True
 
 
-def _finalize_node_removal(removed_node):
+def _finalize_node_removal(removed_node: StorageNode):
     """Best-effort host cleanup before the node is flipped to REMOVED: leave the
     docker swarm and wipe GPT partitions. Mirrors the tail of the legacy
     offline-removal path."""
@@ -4157,7 +4157,7 @@ def restart_storage_node(
     return result
 
 
-def fd_dead_recovery_allowed(db_controller, snode) -> bool:
+def fd_dead_recovery_allowed(db_controller, snode: StorageNode) -> bool:
     """Same-failure-domain parallel restart carve-out, reinstated with a hard gate.
 
     Concurrent node restarts outside a drained SUSPENDED cluster are sanctioned
@@ -5028,7 +5028,7 @@ def _restart_storage_node_impl(
         return True
 
 
-def _format_lvstore_ports(node):
+def _format_lvstore_ports(node: StorageNode):
     """Format per-lvstore ports for display."""
     if not node.lvstore_ports:
         return "-"
@@ -5334,7 +5334,7 @@ def _check_ftt_allows_node_removal(node_id, db_controller):
     return True, ""
 
 
-def _allow_shutdown_with_migration_tasks(snode, db_controller):
+def _allow_shutdown_with_migration_tasks(snode: StorageNode, db_controller):
     cluster = db_controller.get_cluster_by_id(snode.cluster_id)
     return (
         cluster.ha_type == "ha"
@@ -5354,7 +5354,7 @@ _PEER_RECONNECT_ELIGIBLE_STATUSES = (
 )
 
 
-def _target_is_reconnect_eligible(target_node):
+def _target_is_reconnect_eligible(target_node: StorageNode):
     """True iff a remote ctrlr attach toward ``target_node`` should proceed.
 
     Any service that calls bdev_nvme_attach_controller toward a peer must
@@ -5368,7 +5368,7 @@ def _target_is_reconnect_eligible(target_node):
     return target_node.status in _PEER_RECONNECT_ELIGIBLE_STATUSES
 
 
-def _detach_remote_controllers_from_peers(snode, db_controller):
+def _detach_remote_controllers_from_peers(snode: StorageNode, db_controller):
     """Loop 2 of graceful shutdown.
 
     For every peer in {online, down, in_restart}, detach the remote
@@ -6426,7 +6426,7 @@ def set_node_status(node_id, status, caused_by="monitor"):
     return True
 
 
-def _set_restart_phase(snode, lvs_name, phase, db_controller):
+def _set_restart_phase(snode: StorageNode, lvs_name, phase, db_controller):
     """Persist the restart phase for a given LVS to FDB.
 
     Other services check this to gate sync deletes and create/clone/
@@ -6660,7 +6660,7 @@ def drain_restart_queue(node_id, lvs_name):
             logger.error("Queued operation failed (%s): %s", description, e)
 
 
-def _is_node_rpc_responsive(node, lvs_name, timeout=5, retry=2):
+def _is_node_rpc_responsive(node: StorageNode, lvs_name, timeout=5, retry=2):
     """Check if a node's RPC interface is responsive.
 
     Returns True if RPC succeeds, False if it fails/times out.
@@ -6675,7 +6675,7 @@ def _is_node_rpc_responsive(node, lvs_name, timeout=5, retry=2):
         return False
 
 
-def _is_fabric_connected(node, lvs_peer_ids=None):
+def _is_fabric_connected(node: StorageNode, lvs_peer_ids=None):
     """Check if a node's fabric is connected (JM quorum says NOT disconnected)."""
     return not _check_peer_disconnected(node, lvs_peer_ids=lvs_peer_ids)
 
@@ -7237,7 +7237,7 @@ def execute_on_leader_with_failover(all_nodes, lvs_name, operation_fn,
         return False, new_leader, f"Operation failed on new leader: {e}"
 
 
-def _check_peer_disconnected(peer_node, lvs_peer_ids=None):
+def _check_peer_disconnected(peer_node: StorageNode, lvs_peer_ids=None):
     """Check if a peer node should be treated as disconnected for the purpose
     of routing (takeover vs. non-leader path) and peer-port-block decisions.
 
@@ -7310,7 +7310,7 @@ def _check_peer_disconnected(peer_node, lvs_peer_ids=None):
     return False
 
 
-def _check_hublvol_connected(snode, peer_node):
+def _check_hublvol_connected(snode: StorageNode, peer_node):
     """Method 2: Check if the hublvol to peer_node is still connected from snode.
 
     Per design: used as fallback when RPCs fail/timeout after the quorum check
@@ -7337,7 +7337,7 @@ def _check_hublvol_connected(snode, peer_node):
         return False
 
 
-def _handle_rpc_failure_on_peer(snode, peer_node, lvs_jm_vuid, lvs_name=None):
+def _handle_rpc_failure_on_peer(snode: StorageNode, peer_node, lvs_jm_vuid, lvs_name=None):
     """Handle RPC failure to a peer during restart, per design decision tree.
 
     Called when RPCs to a previously-connected peer fail/timeout.
@@ -7398,7 +7398,7 @@ def recreate_lvstore_on_non_leader(snode, leader_node, primary_node, activation_
             snode, leader_node, primary_node, activation_mode=False, force=force)
 
 
-def _recreate_lvstore_on_non_leader_impl(snode, leader_node, primary_node, activation_mode=False, force=False):
+def _recreate_lvstore_on_non_leader_impl(snode: StorageNode, leader_node, primary_node, activation_mode=False, force=False):
     """Recreate a non-leader LVS on snode.
 
     Per design: runs for secondary when primary is online, or for tertiary always.
@@ -8265,7 +8265,7 @@ def _restore_peer_lvstore_status_ready(node_id, db_controller):
             fresh, lambda n: setattr(n, "lvstore_status", "ready"))
 
 
-def recreate_all_lvstores(snode, force=False):
+def recreate_all_lvstores(snode: StorageNode, force=False):
     """Recreate all LVS stacks on a restarting node: primary, secondary, tertiary.
 
     This is the dispatch logic extracted from restart_storage_node() so it can
@@ -8285,7 +8285,7 @@ def recreate_all_lvstores(snode, force=False):
     return _recreate_all_lvstores_serial(snode, force=force)
 
 
-def _recreate_all_lvstores_serial(snode, force=False):
+def _recreate_all_lvstores_serial(snode: StorageNode, force=False):
     db_controller = DBController()
 
     # --- Step 1: Primary LVS ---
@@ -8403,7 +8403,7 @@ def _recreate_all_lvstores_serial(snode, force=False):
     return non_leader_ok
 
 
-def recreate_lvstore(snode, force=False, lvs_primary=None, activation_mode=False):
+def recreate_lvstore(snode: StorageNode, force=False, lvs_primary=None, activation_mode=False):
     """Per-LVS-locked wrapper: serialize recreate of this LVS only against a
     concurrent recreate of the SAME LVS. The LVS is ``lvs_primary.lvstore``
     (secondary taking leadership) or ``snode.lvstore`` (own primary).
@@ -8417,7 +8417,7 @@ def recreate_lvstore(snode, force=False, lvs_primary=None, activation_mode=False
             snode, force=force, lvs_primary=lvs_primary, activation_mode=False)
 
 
-def _recreate_lvstore_impl(snode, force=False, lvs_primary=None, activation_mode=False):
+def _recreate_lvstore_impl(snode: StorageNode, force=False, lvs_primary=None, activation_mode=False):
     """Recreate LVStore as leader.
 
     Per design: runs for snode's own primary LVS, and also when snode
@@ -9436,7 +9436,7 @@ def _recreate_lvstore_impl(snode, force=False, lvs_primary=None, activation_mode
         _release_block_gate()
 
 
-def add_lvol_thread(lvol, snode, lvol_ana_state="optimized"):
+def add_lvol_thread(lvol, snode: StorageNode, lvol_ana_state="optimized"):
     db_controller = DBController()
 
     # Refuse to (re)register an lvol that is being torn down: the delete
@@ -9529,7 +9529,7 @@ def add_lvol_thread(lvol, snode, lvol_ana_state="optimized"):
     return True, None
 
 
-def repair_lvol_registration_on_non_leader(lvol, sec_node, secondary_index):
+def repair_lvol_registration_on_non_leader(lvol, sec_node: StorageNode, secondary_index):
     """(Re)apply an lvol's fabric registration on an ONLINE non-leader
     (secondary/tertiary): create the missing nvmf subsystem if absent
     (cntlid range mirrors the restart flow: sec1 1000, sec2/tert 2000,
@@ -9581,7 +9581,7 @@ def repair_lvol_registration_on_non_leader(lvol, sec_node, secondary_index):
     return add_lvol_thread(lvol, sec_node, lvol_ana_state="non_optimized")
 
 
-def get_sorted_ha_jms(current_node):
+def get_sorted_ha_jms(current_node: StorageNode):
     """Select the remote HA journal members for ``current_node``.
 
     The full HA journal set is ``ha_jm_count`` members: the node's own local JM
@@ -9699,7 +9699,7 @@ def get_sorted_ha_jms(current_node):
     return selected[:target]
 
 
-def get_node_jm_names(current_node, remote_node=None):
+def get_node_jm_names(current_node: StorageNode, remote_node=None):
     jm_list = []
     if current_node.jm_device:
         if remote_node:
@@ -9728,7 +9728,7 @@ def get_node_jm_names(current_node, remote_node=None):
     return jm_list[:current_node.ha_jm_count]
 
 
-def get_secondary_nodes(current_node, exclude_ids=None, removed_node=None):
+def get_secondary_nodes(current_node: StorageNode, exclude_ids=None, removed_node=None):
     if exclude_ids is None:
         exclude_ids = []
     db_controller = DBController()
@@ -9790,7 +9790,7 @@ def get_secondary_nodes(current_node, exclude_ids=None, removed_node=None):
     return []
 
 
-def get_secondary_nodes_2(current_node, exclude_ids=None, exclude_mgmt_ips=None,
+def get_secondary_nodes_2(current_node: StorageNode, exclude_ids=None, exclude_mgmt_ips=None,
                           exclude_failure_domains=None, exclude_physical_labels=None):
     """Get candidate nodes for second secondary assignment (dual fault tolerance).
     Unlike get_secondary_nodes, this checks lvstore_stack_tertiary instead of
@@ -9880,7 +9880,7 @@ def get_secondary_nodes_2(current_node, exclude_ids=None, exclude_mgmt_ips=None,
     return []
 
 
-def create_lvstore(snode, ndcs, npcs, distr_bs, distr_chunk_bs, page_size_in_blocks, max_size):
+def create_lvstore(snode: StorageNode, ndcs, npcs, distr_bs, distr_chunk_bs, page_size_in_blocks, max_size):
     db_controller = DBController()
     cluster = db_controller.get_cluster_by_id(snode.cluster_id)
     lvstore_stack: List[dict] = []
@@ -10117,12 +10117,12 @@ def create_lvstore(snode, ndcs, npcs, distr_bs, distr_chunk_bs, page_size_in_blo
 _DISTR_RECREATE_RETRY_DELAY_SEC = 5
 
 
-def _create_bdev_stack(snode, lvstore_stack=None, primary_node=None):
+def _create_bdev_stack(snode: StorageNode, lvstore_stack=None, primary_node=None):
     # Per-distrib creation outcome, keyed by bdev name. Threads write their own
     # key (distinct keys -> GIL-safe), the main loop reads after join.
     distr_results: dict = {}
 
-    def _create_distr(snode, name, params):
+    def _create_distr(snode: StorageNode, name, params):
         # If a peer node goes offline at the exact moment a distrib is
         # (re)created, the cluster map can be briefly stale -- it still flags
         # that peer's devices as online -- and bdev_distrib_create (or the
@@ -10280,7 +10280,7 @@ def _remove_bdev_stack(bdev_stack, rpc_client, remove_distr_only=False):
         # time.sleep(1)
 
 
-def recreate_lvstore_on_sec(snode):
+def recreate_lvstore_on_sec(snode: StorageNode):
     """Build (or rebuild) the non-leader LVS stack on ``snode`` for every
     primary that currently points at it as secondary or tertiary.
 
@@ -10344,7 +10344,7 @@ def recreate_lvstore_on_sec(snode):
     return overall_ok
 
 
-def teardown_non_leader_lvstore(donor_node, primary_node, slot=None):
+def teardown_non_leader_lvstore(donor_node: StorageNode, primary_node: StorageNode, slot=None):
     """Tear down a non-leader (secondary or tertiary) LVStore stack on
     ``donor_node`` for the LVS owned by ``primary_node``, in-place.
 
@@ -10479,7 +10479,7 @@ def teardown_non_leader_lvstore(donor_node, primary_node, slot=None):
     return True
 
 
-def reattach_sibling_failover(sibling_node, primary_node,
+def reattach_sibling_failover(sibling_node: StorageNode, primary_node: StorageNode,
                               old_failover_node, new_failover_node):
     """Surgically reconfigure a sibling secondary's NVMe-oF multipath group
     so its failover path points at the new sec_1 holder instead of the old

--- a/simplyblock_core/utils/__init__.py
+++ b/simplyblock_core/utils/__init__.py
@@ -677,7 +677,21 @@ def make_async_handler(target_handler):
     log_queue: "_queue.Queue" = _queue.Queue(-1)  # unbounded; enqueue never blocks a worker
     listener = _lh.QueueListener(log_queue, target_handler, respect_handler_level=False)
     listener.start()
-    atexit.register(listener.stop)
+
+    def _stop_if_running() -> None:
+        # TODO(drop-py3.9): delete this wrapper and register listener.stop
+        # directly once Python 3.9 support is dropped. On 3.9,
+        # QueueListener.stop() is not idempotent (`self._thread.join();
+        # self._thread = None` with no guard), so a second call raises
+        # AttributeError. Callers that need the listener drained
+        # deterministically (e.g. tests) may already have called `stop()`
+        # themselves before interpreter exit; only stop here if that hasn't
+        # happened yet. Fixed upstream in https://github.com/python/cpython/issues/114706
+        # (backported to 3.10+), where stop() guards on `if self._thread`.
+        if listener._thread is not None:
+            listener.stop()
+
+    atexit.register(_stop_if_running)
     qh = _lh.QueueHandler(log_queue)
     qh._listener = listener  # type: ignore[attr-defined]  # strong ref, not GC'd
     return qh

--- a/simplyblock_core/utils/port_block.py
+++ b/simplyblock_core/utils/port_block.py
@@ -10,7 +10,7 @@ import logging
 
 import jc
 
-from simplyblock_core.rpc_client import RPCErrorCode, RPCException
+from simplyblock_core.rpc_client import RPCErrorCode, RPCRemoteError
 from simplyblock_core.fw_api_client import FirewallClient
 
 logger = logging.getLogger(__name__)
@@ -35,7 +35,7 @@ def set_port(node, port, block, is_reject=False, timeout=5, retry=2):
         if block:
             return rpc.nvmf_port_block(port, is_reject=is_reject)
         return rpc.nvmf_port_unblock(port)
-    except RPCException as exc:
+    except RPCRemoteError as exc:
         if exc.code != RPCErrorCode.method_not_found:
             raise
         logger.info(
@@ -61,7 +61,7 @@ def get_blocked_ports_set(node, timeout=5, retry=5):
     rpc = node.rpc_client(timeout=timeout, retry=retry)
     try:
         blocked = rpc.nvmf_get_blocked_ports()
-    except RPCException as exc:
+    except RPCRemoteError as exc:
         if exc.code != RPCErrorCode.method_not_found:
             raise
         return None
@@ -79,7 +79,7 @@ def is_port_blocked(node, port_id, timeout=5, retry=5):
     """
     try:
         return port_id in node.rpc_client(timeout=timeout, retry=retry).nvmf_get_blocked_ports()
-    except RPCException as exc:
+    except RPCRemoteError as exc:
         if exc.code != RPCErrorCode.method_not_found:
             raise
         return  _is_port_blocked_iptables(node, port_id, timeout, retry)

--- a/simplyblock_web/api/v1/static/swagger.yaml
+++ b/simplyblock_web/api/v1/static/swagger.yaml
@@ -2725,8 +2725,8 @@ paths:
                           num_md_pages_per_cluster_ratio: 1
                         status: created
                         type: bdev_lvstore
-                    lvstore_stack_secondary: []
-                    lvstore_stack_tertiary: []
+                    lvstore_stack_secondary: ""
+                    lvstore_stack_tertiary: ""
                     max_lvol: 10
                     max_prov: 1000000000000
                     max_snap: 500
@@ -3503,8 +3503,8 @@ paths:
                           num_md_pages_per_cluster_ratio: 1
                         status: created
                         type: bdev_lvstore
-                    lvstore_stack_secondary: []
-                    lvstore_stack_tertiary: []
+                    lvstore_stack_secondary: ""
+                    lvstore_stack_tertiary: ""
                     max_lvol: 10
                     max_prov: 1000000000000
                     max_snap: 500
@@ -4281,8 +4281,8 @@ paths:
                           num_md_pages_per_cluster_ratio: 1
                         status: created
                         type: bdev_lvstore
-                    lvstore_stack_secondary: []
-                    lvstore_stack_tertiary: []
+                    lvstore_stack_secondary: ""
+                    lvstore_stack_tertiary: ""
                     max_lvol: 10
                     max_prov: 1000000000000
                     max_snap: 500
@@ -5059,8 +5059,8 @@ paths:
                           num_md_pages_per_cluster_ratio: 1
                         status: created
                         type: bdev_lvstore
-                    lvstore_stack_secondary: []
-                    lvstore_stack_tertiary: []
+                    lvstore_stack_secondary: ""
+                    lvstore_stack_tertiary: ""
                     max_lvol: 10
                     max_prov: 1000000000000
                     max_snap: 500
@@ -5733,8 +5733,8 @@ paths:
                     lvols: 0
                     lvstore: ''
                     lvstore_stack: []
-                    lvstore_stack_secondary: []
-                    lvstore_stack_tertiary: []
+                    lvstore_stack_secondary: ""
+                    lvstore_stack_tertiary: ""
                     max_lvol: 10
                     max_prov: 10000000000000
                     max_snap: 500
@@ -6729,8 +6729,8 @@ paths:
                           num_md_pages_per_cluster_ratio: 1
                         status: created
                         type: bdev_lvstore
-                    lvstore_stack_secondary: []
-                    lvstore_stack_tertiary: []
+                    lvstore_stack_secondary: ""
+                    lvstore_stack_tertiary: ""
                     max_lvol: 10
                     max_prov: 1000000000000
                     max_snap: 500
@@ -8827,8 +8827,8 @@ paths:
                           num_md_pages_per_cluster_ratio: 1
                         status: created
                         type: bdev_lvstore
-                    lvstore_stack_secondary: []
-                    lvstore_stack_tertiary: []
+                    lvstore_stack_secondary: ""
+                    lvstore_stack_tertiary: ""
                     max_lvol: 10
                     max_prov: 1000000000000
                     max_snap: 500
@@ -10250,8 +10250,8 @@ paths:
                           num_md_pages_per_cluster_ratio: 1
                         status: created
                         type: bdev_lvstore
-                    lvstore_stack_secondary: []
-                    lvstore_stack_tertiary: []
+                    lvstore_stack_secondary: ""
+                    lvstore_stack_tertiary: ""
                     max_lvol: 10
                     max_prov: 1000000000000
                     max_snap: 500

--- a/tests/integration/test_backup.py
+++ b/tests/integration/test_backup.py
@@ -328,10 +328,10 @@ class TestCreateS3Bdev(unittest.TestCase):
     @patch("simplyblock_core.controllers.backup_controller.boto3.client")
     @patch("simplyblock_core.models.storage_node.RPCClient")
     def test_bucket_name_fails(self, MockRPC, mock_boto3_client):
-        from simplyblock_core.rpc_client import RPCException
+        from simplyblock_core.rpc_client import RPCRemoteError
         mock_rpc = MockRPC.return_value
         mock_rpc.bdev_s3_create.return_value = True
-        mock_rpc.bdev_s3_add_bucket_name.side_effect = RPCException("error", code=-1)
+        mock_rpc.bdev_s3_add_bucket_name.side_effect = RPCRemoteError("error", code=-1)
         mock_s3 = mock_boto3_client.return_value
         mock_s3.head_bucket.return_value = {}
 
@@ -344,11 +344,11 @@ class TestCreateS3Bdev(unittest.TestCase):
     @patch("simplyblock_core.controllers.backup_controller.boto3.client")
     @patch("simplyblock_core.models.storage_node.RPCClient")
     def test_attach_fails(self, MockRPC, mock_boto3_client):
-        from simplyblock_core.rpc_client import RPCException
+        from simplyblock_core.rpc_client import RPCRemoteError
         mock_rpc = MockRPC.return_value
         mock_rpc.bdev_s3_create.return_value = True
         mock_rpc.bdev_s3_add_bucket_name.return_value = (True, None)
-        mock_rpc.bdev_lvol_s3_bdev.side_effect = RPCException("attach failed")
+        mock_rpc.bdev_lvol_s3_bdev.side_effect = RPCRemoteError("attach failed", code=-1)
         mock_s3 = mock_boto3_client.return_value
         mock_s3.head_bucket.return_value = {}
 

--- a/tests/integration/test_shared_placement.py
+++ b/tests/integration/test_shared_placement.py
@@ -59,8 +59,8 @@ def _make_node(node_id, status=StorageNode.STATUS_ONLINE,
                     "write_protection": False}}
         for i, name in enumerate(distrib_names)
     ]
-    n.lvstore_stack_secondary = []
-    n.lvstore_stack_tertiary = []
+    n.lvstore_stack_secondary = ""
+    n.lvstore_stack_tertiary = ""
 
     rpc = MagicMock()
     rpc.distr_shared_placement = MagicMock(return_value=True)

--- a/tests/unit/rpc/test_client.py
+++ b/tests/unit/rpc/test_client.py
@@ -8,7 +8,7 @@ from unittest.mock import patch
 
 from pydantic import SecretStr
 
-from simplyblock_core.rpc_client import RPCClient, RPCException
+from simplyblock_core.rpc_client import RPCClient, RPCException, RPCRemoteError
 
 
 def _make_client(**kwargs):
@@ -76,14 +76,14 @@ class TestSubsystem(unittest.TestCase):
     def test_subsystem_get_no_such_device_returns_none(self, mock_req):
         # SPDK returns ENODEV (-19) "No such device" when the subsystem is gone;
         # treat it as absent rather than propagating the error.
-        mock_req.side_effect = RPCException("No such device", code=-errno.ENODEV)
+        mock_req.side_effect = RPCRemoteError("No such device", code=-errno.ENODEV)
         client = _make_client()
         self.assertIsNone(client.subsystem_get("nqn.gone"))
 
     @patch.object(RPCClient, "_request3")
     def test_subsystem_get_other_rpc_error_propagates(self, mock_req):
         # Generic RPC failures must still surface.
-        mock_req.side_effect = RPCException("Something broke", code=-errno.EINVAL)
+        mock_req.side_effect = RPCRemoteError("Something broke", code=-errno.EINVAL)
         client = _make_client()
         with self.assertRaises(RPCException):
             client.subsystem_get("nqn.b")

--- a/tests/unit/test_node_removal.py
+++ b/tests/unit/test_node_removal.py
@@ -23,6 +23,7 @@ from simplyblock_core import storage_node_ops
 from simplyblock_core.models.storage_node import StorageNode
 from simplyblock_core.models.nvme_device import NVMeDevice, JMDevice
 from simplyblock_core.models.cluster import Cluster
+from simplyblock_core.rpc_client import RPCConnectionError
 
 
 # ---------------------------------------------------------------------------
@@ -324,7 +325,7 @@ class TestDeleteReplicaOnPeer(unittest.TestCase):
         primary = _node("p1", lvstore="LVS_1")
         peer = _node("peer1", lvstore="LVS_1")  # hublvol_nqn_for_lvstore's mocked return value bakes in this lvstore
         rpc = peer.rpc_client()
-        rpc.subsystem_get.side_effect = Exception("connection error")
+        rpc.subsystem_get.side_effect = RPCConnectionError("connection error")
         storage_node_ops._delete_replica_on_peer(peer, primary, cl)  # must not raise
         rpc.subsystem_delete.assert_not_called()
         # Teardown of the other artifacts still proceeds despite this failure.


### PR DESCRIPTION
d0247d70898e46e30fcb9cc04a7cbc34bf56c49e fixed an issue `RPCClient.subsystem_list` was used with an NQN parameter, a mode of operation that was removed in 2646d16216bcbc8490ee7831ea9ddbd123503234. This replaced that mode with a dedicated function. Two things contribute to this failure being difficult to catch:
- catching blanket exceptions hid the `TypeError` that was raised
- missing type annotations prevented the type checker from flagging this

This PR:
- introduces annotations for storage node parameters and the `StorageNode.rpc_client()` helper, which together would have flagged the original error statically
- fixes type annotations of the `StorageNode.lvstore_stack_{secondary,tertiary}` attributes to correctly indicate `str`, which was caught because of the prior change
- adds subtypes for RPC errors, removing motivation for the original code that hid the fault
- removes the blanket except statements and replaces it with `RPCException` instead
- avoid traceback being printed due to a bug in Python 3.9.