### PR TITLE
Avoid node-info computation at module load

### DIFF
--- a/simplyblock_web/api/internal/storage_node/_node_info.py
+++ b/simplyblock_web/api/internal/storage_node/_node_info.py
@@ -1,6 +1,61 @@
-from typing import Callable, List, Optional
+# encoding: utf-8
+"""Static, process-lifetime-constant identity info for a storage node.
 
+Gathering this is not free: ``cpuinfo.get_cpu_info()`` parses ``/proc/cpuinfo``,
+``hostname``/``dmidecode`` shell out, and cloud-metadata detection
+(:func:`get_cloud_info`) makes network requests to well-known metadata
+IPs/hostnames that block for their client timeout whenever the node isn't
+actually on that cloud.
+
+None of it changes for the life of the process, so it is gathered lazily on
+first use and memoized with ``lru_cache`` rather than at import time.
+``docker.py`` and ``kubernetes.py`` are imported transitively by almost
+anything that touches ``simplyblock_web`` (test collection, the CLI,
+OpenAPI-schema generation, ...), so computing this at module scope paid the
+network-probe cost there regardless of whether a ``/info`` request was ever
+served -- that's what made test collection slow.
+"""
+import functools
+import os
+from typing import Any, Callable, Dict, List, Optional, TypedDict
+
+import cpuinfo
 import requests
+
+from simplyblock_core import shell_utils
+
+
+class StaticNodeInfo(TypedDict):
+    cpu_info: Dict[str, Any]
+    hostname: str
+    system_id: str
+    cloud_info: Dict[str, Any]
+
+
+@functools.lru_cache(maxsize=1)
+def get_static_node_info() -> StaticNodeInfo:
+    """Gather and cache this node's static identity info.
+
+    Computed on first call, not at import time. Set ``WITHOUT_CLOUD_INFO`` to
+    skip the cloud-metadata probe entirely (useful in deployments where it's
+    known not to apply, avoiding up to a few seconds of network timeout on
+    the first call after boot).
+    """
+    hostname, _, _ = shell_utils.run_command("hostname -s")
+    system_id, _, _ = shell_utils.run_command("dmidecode -s system-uuid")
+
+    cloud_info: Dict[str, Any] = {}
+    if not os.environ.get("WITHOUT_CLOUD_INFO"):
+        cloud_info = get_cloud_info() or {}
+        if cloud_info:
+            system_id = cloud_info["id"]
+
+    return StaticNodeInfo(
+        cpu_info=cpuinfo.get_cpu_info(),
+        hostname=hostname,
+        system_id=system_id,
+        cloud_info=cloud_info,
+    )
 
 
 def get_cloud_info() -> Optional[dict]:

--- a/simplyblock_web/api/internal/storage_node/docker.py
+++ b/simplyblock_web/api/internal/storage_node/docker.py
@@ -7,7 +7,6 @@ import time
 from pathlib import Path
 from typing import List, Optional, Union
 
-import cpuinfo
 import docker
 import psutil
 import socket
@@ -20,7 +19,7 @@ import simplyblock_core.utils.pci as pci_utils
 import simplyblock_core.utils as init_utils
 from simplyblock_web import utils, node_utils
 
-from ._cloud_info import get_cloud_info
+from ._node_info import get_static_node_info
 
 logger = core_utils.get_logger(__name__)
 
@@ -510,14 +509,15 @@ def get_nodes_config():
 })
 def get_info():
     logger.debug("function:get_info start")
+    node_info = get_static_node_info()
     resp = utils.get_response({
         "cluster_id": get_cluster_id(),
 
-        "hostname": HOSTNAME,
-        "system_id": SYSTEM_ID,
+        "hostname": node_info["hostname"],
+        "system_id": node_info["system_id"],
 
-        "cpu_count": CPU_INFO['count'],
-        "cpu_hz": CPU_INFO['hz_advertised'][0] if 'hz_advertised' in CPU_INFO else 1,
+        "cpu_count": node_info["cpu_info"]['count'],
+        "cpu_hz": node_info["cpu_info"]['hz_advertised'][0] if 'hz_advertised' in node_info["cpu_info"] else 1,
 
         "memory": node_utils.get_memory(),
         "hugepages": node_utils.get_huge_memory(),
@@ -531,7 +531,7 @@ def get_info():
 
         "network_interface": core_utils.get_nics_data(),
 
-        "cloud_instance": CLOUD_INFO,
+        "cloud_instance": node_info["cloud_info"],
 
         "lsblk": get_node_lsblk(),
         "nodes_config": get_nodes_config(),
@@ -659,16 +659,6 @@ def delete_gpt_partitions_for_dev(body: utils.DeviceParams):
     out, err, ret_code = shell_utils.run_command(cmd)
     logger.info(f"out: {out}, err: {err}, ret_code: {ret_code}")
     return utils.get_response(ret_code == 0, error=err)
-
-
-CPU_INFO = cpuinfo.get_cpu_info()
-HOSTNAME, _, _ = shell_utils.run_command("hostname -s")
-SYSTEM_ID, _, _ = shell_utils.run_command("dmidecode -s system-uuid")
-CLOUD_INFO = {}
-if not os.environ.get("WITHOUT_CLOUD_INFO"):
-    CLOUD_INFO = get_cloud_info() or {}
-    if CLOUD_INFO:
-        SYSTEM_ID = CLOUD_INFO["id"]
 
 
 @api.post('/format_device_with_4k')

--- a/simplyblock_web/api/internal/storage_node/kubernetes.py
+++ b/simplyblock_web/api/internal/storage_node/kubernetes.py
@@ -6,7 +6,6 @@ import time
 import traceback
 from typing import List, Optional, Union
 
-import cpuinfo
 from flask_openapi3 import APIBlueprint
 from kubernetes.client import ApiException, V1DeleteOptions
 from jinja2 import Environment, PackageLoader
@@ -19,7 +18,7 @@ from simplyblock_web import utils, node_utils, node_utils_k8s
 from simplyblock_web.node_utils_k8s import namespace_id_file
 
 from . import docker as snode_ops
-from ._cloud_info import get_cloud_info
+from ._node_info import get_static_node_info
 
 
 logger = logging.getLogger(__name__)
@@ -112,14 +111,15 @@ def get_nodes_config():
     })}}},
 })
 def get_info():
+    node_info = get_static_node_info()
     return utils.get_response({
         "cluster_id": get_cluster_id(),
 
-        "hostname": HOSTNAME,
-        "system_id": SYSTEM_ID,
+        "hostname": node_info["hostname"],
+        "system_id": node_info["system_id"],
 
-        "cpu_count": CPU_INFO['count'],
-        "cpu_hz": CPU_INFO['hz_advertised'][0] if 'hz_advertised' in CPU_INFO else 1,
+        "cpu_count": node_info["cpu_info"]['count'],
+        "cpu_hz": node_info["cpu_info"]['hz_advertised'][0] if 'hz_advertised' in node_info["cpu_info"] else 1,
 
         "memory": node_utils.get_memory(),
         "hugepages": node_utils.get_huge_memory(),
@@ -133,7 +133,7 @@ def get_info():
 
         "network_interface": core_utils.get_nics_data(),
 
-        "cloud_instance": CLOUD_INFO,
+        "cloud_instance": node_info["cloud_info"],
         "nodes_config": get_nodes_config(),
     })
 
@@ -196,16 +196,6 @@ def make_gpt_partitions_for_nbd(body: _GPTPartitionsParams):
 
 
 api.post('/delete_dev_gpt_partitions')(snode_ops.delete_gpt_partitions_for_dev)
-
-
-CPU_INFO = cpuinfo.get_cpu_info()
-HOSTNAME, _, _ = shell_utils.run_command("hostname -s")
-SYSTEM_ID = ""
-CLOUD_INFO = get_cloud_info() or {}
-if CLOUD_INFO:
-    SYSTEM_ID = CLOUD_INFO["id"]
-else:
-    SYSTEM_ID, _, _ = shell_utils.run_command("dmidecode -s system-uuid")
 
 
 class SPDKParams(BaseModel):


### PR DESCRIPTION
This slows down test collection as the network addresses that are probed do not respond. It can be delegated to the first call.