### PR TITLE
Lvol migration test fixes

### DIFF
--- a/simplyblock_core/controllers/migration_controller.py
+++ b/simplyblock_core/controllers/migration_controller.py
@@ -996,7 +996,7 @@ def create_migration(lvol_id, target_node_id,
     # ── 1d. Register migration bdev on TGT-sec and TGT-ter ───────────────────
     # All HA peers need bdev_lvol_register so they can mirror writes during migration.
     _pre_sec_node = None
-    if lvol.ha_type in ("ha", "ha3") and tgt_node.secondary_node_id:
+    if lvol.ha_type != "single" and tgt_node.secondary_node_id:
         try:
             _pre_sec_node = db.get_storage_node_by_id(tgt_node.secondary_node_id)
             _sec_rpc_reg  = _pre_sec_node.rpc_client()
@@ -1066,7 +1066,7 @@ def create_migration(lvol_id, target_node_id,
         src_node_ids.add(src_node.tertiary_node_id)
 
     tgt_sec_node = None
-    if lvol.ha_type in ("ha", "ha3") and tgt_node.secondary_node_id:
+    if lvol.ha_type != "single" and tgt_node.secondary_node_id:
         tgt_sec_node = (_pre_sec_node if _pre_sec_node is not None else None)
         if tgt_sec_node is None:
             try:

--- a/simplyblock_core/controllers/migration_controller.py
+++ b/simplyblock_core/controllers/migration_controller.py
@@ -149,7 +149,12 @@ def start_migration(migration_id,
     migration.started_at = int(time.time())
     migration.deadline = int(time.time()) + deadline_seconds if deadline_seconds else 0
     migration.max_retries = max_retries
-    migration.status = LVolMigration.STATUS_NEW
+    # RUNNING, not NEW: _cancel_stale_new_migrations treats STATUS_NEW as
+    # "operator never called migrate-continue" and auto-cancels it after 5
+    # minutes. Once continued, the migration is actively in progress even if
+    # the task runner's own NEW→RUNNING flip is delayed behind a node/cluster
+    # gate (e.g. cluster rebalancing) — it must not look abandoned.
+    migration.status = LVolMigration.STATUS_RUNNING
     migration.write_to_db(db.kv_store)
     logger.info(
         f"Promoting pre-created migration {migration.uuid} → PHASE_SNAP_COPY "
@@ -1288,7 +1293,12 @@ def create_batch_migration(lvol_id, target_node_id,
             f"Use create_migration instead."
         )
 
-    # Check for an existing active group for this NQN on this target.
+    # Check for an existing active group for this NQN on this target. If it's
+    # still PHASE_PRE_CREATED, treat this as an idempotent retry (e.g. a
+    # client-side timeout on a call that actually succeeded) and reuse it
+    # below instead of hard-failing every retry -- mirrors create_migration's
+    # existing_migration handling.
+    existing_group = None
     existing_groups = db_inst.get_migration_groups(tgt_node.cluster_id)
     for g in existing_groups:
         if g.target_node_id == target_node_id and g.status not in (
@@ -1298,10 +1308,12 @@ def create_batch_migration(lvol_id, target_node_id,
         ):
             # Check NQN overlap via target_nqn
             if g.target_nqn == lvol.nqn:
-                raise ValueError(
-                    f"An active batch migration group ({g.uuid}) already exists "
-                    f"for NQN {lvol.nqn} targeting {target_node_id}."
-                )
+                if g.phase != LVolMigrationGroup.PHASE_PRE_CREATED:
+                    raise PreconditionError(
+                        f"Batch migration group {g.uuid} for NQN {lvol.nqn} is already "
+                        f"past pre-create (phase={g.phase}). Use /continue or cancel it."
+                    )
+                existing_group = g
 
     source_node_id = lvol.node_id
 
@@ -1331,6 +1343,13 @@ def create_batch_migration(lvol_id, target_node_id,
         for snap_uuid, lvol_uuid in snap_owner_lvol.items()
         if lvol_uuid in lvol_uuid_to_migration_id
     }
+
+    if existing_group is not None:
+        logger.info(
+            f"create_batch_migration: idempotent re-call for NQN={lvol.nqn} "
+            f"target={target_node_id} reusing group_id={existing_group.uuid} "
+            f"connect_strings={len(master_connect_strings)}")
+        return existing_group.uuid, master_connect_strings
 
     # Stamp migration_group_id on each worker record.
     group = LVolMigrationGroup()
@@ -1381,6 +1400,19 @@ def start_batch_migration(group_id,
             f"Group {group_id} is not in PHASE_PRE_CREATED (phase={group.phase})"
         )
 
+    # Same preconditions as start_migration's single-lvol path — these are
+    # only checked at create_batch_migration (precreate) time today, so a
+    # cluster rebalance / conflicting node migration starting in the gap
+    # before migrate-continue --batch would otherwise go unnoticed here.
+    cluster = db.get_cluster_by_id(group.cluster_id)
+    if cluster.status != Cluster.STATUS_ACTIVE:
+        raise PreconditionError(f"Cluster {cluster.get_id()} is not active (status={cluster.status})")
+    if not _can_add_lvol_migration(cluster.get_id()):
+        raise PreconditionError(f"Cluster {cluster.get_id()} is rebalancing; wait for it to finish before migrating")
+    for node_id in (group.source_node_id, group.target_node_id):
+        if tasks_controller.get_active_node_mig_task(group.cluster_id, node_id):
+            raise PreconditionError(f"Node {node_id} has a data migration in progress; wait for it to finish")
+
     now = int(time.time())
     deadline = now + deadline_seconds if deadline_seconds else 0
 
@@ -1397,6 +1429,9 @@ def start_batch_migration(group_id,
             lvol = db.get_lvol_by_id(lvol_id)
         except KeyError:
             raise ValueError(f"LVol {lvol_id} not found for worker {migration_id}")
+
+        if lvol.status != LVol.STATUS_ONLINE:
+            raise ValueError(f"Volume {lvol_id} is not online (status={lvol.status})")
 
         snap_plan = get_snapshot_chain(lvol_id, migration.source_node_id)
         snaps_on_target = [s for s in snap_plan if _is_snap_on_node(s, migration.target_node_id)]
@@ -1418,7 +1453,11 @@ def start_batch_migration(group_id,
         migration.started_at = now
         migration.deadline = deadline
         migration.max_retries = max_retries
-        migration.status = LVolMigration.STATUS_NEW
+        # RUNNING, not NEW — see the matching comment in start_migration:
+        # _cancel_stale_new_migrations doesn't know about batch workers and
+        # would cancel just this one member (stranding the group) if it sat
+        # in STATUS_NEW for 5+ minutes behind a delayed task-runner pickup.
+        migration.status = LVolMigration.STATUS_RUNNING
         migration.write_to_db(db.kv_store)
 
         task_uuid = tasks_controller.add_lvol_mig_task(migration)
@@ -1485,6 +1524,22 @@ def cancel_batch_migration(group_id):
         except Exception as e:
             logger.warning(f"cancel_batch_migration: could not mark worker "
                            f"{rec['migration_id']} cancelled: {e}")
+
+    # A cancelled worker abandons its current phase for its own CLEANUP_TARGET
+    # instead of signalling snap_copy_done/intermediates_done -- so the
+    # orchestrator's barrier for that phase would otherwise wait forever and
+    # the group would stay STATUS_RUNNING permanently, even after every worker
+    # reaches a terminal state on its own. Advance the group directly, same as
+    # _group_worker_budget_suspend does on retry exhaustion.
+    if group.phase not in (
+        LVolMigrationGroup.PHASE_CLEANUP_TARGET,
+        LVolMigrationGroup.PHASE_CLEANUP_SOURCE,
+        LVolMigrationGroup.PHASE_COMPLETED,
+    ):
+        group.phase = LVolMigrationGroup.PHASE_CLEANUP_TARGET
+        group.error_message = "cancelled by operator"
+        group.write_to_db(db.kv_store)
+
     logger.info(f"cancel_batch_migration: marked all workers cancelled: {group_id}")
 
 

--- a/simplyblock_core/services/tasks_runner_batch_migration.py
+++ b/simplyblock_core/services/tasks_runner_batch_migration.py
@@ -191,10 +191,30 @@ def _reconstruct_snap_tree(group, member_migrations, tgt_node, tgt_rpc) -> Optio
                 if not ter_rpc.bdev_lvol_convert(tgt_composite):
                     return f"bdev_lvol_convert on tertiary failed for {snap_uuid}"
 
+            # Early partial DB update: route health-check/delete to the target
+            # node right away rather than waiting for apply_migration_to_db()
+            # at this worker's CLEANUP_SOURCE -- which, on the batch path, is
+            # still several phases (INTERMEDIATE, final-step transfer, ANA
+            # flip) and potentially a long wall-clock gap away. Mirrors the
+            # single-lvol path's _post_process_snap.
+            try:
+                snap_rec = db.get_snapshot_by_id(snap_uuid)
+                if snap_rec.lvol.uuid == m.lvol_id:
+                    snap_rec.lvol.node_id = tgt_node.get_id()
+                    snap_rec.write_to_db(db.kv_store)
+            except KeyError:
+                logger.warning(f"Snapshot {snap_uuid} not found in DB for early node update")
+
             committed.add(snap_uuid)
             # Update migration record so snaps_migrated reflects committed state.
             if snap_uuid not in m.snaps_migrated:
                 m.snaps_migrated.append(snap_uuid)
+            # Track this snap's target bdev so cleanup_migration_target() knows
+            # to delete it on rollback -- mirrors _post_process_snap; without
+            # this the batch path never recorded it, so cleanup silently left
+            # every migrated snapshot bdev orphaned on the target.
+            if snap_uuid not in m.snaps_preexisting_on_target and tgt_composite not in m.target_snap_bdevs:
+                m.target_snap_bdevs.append(tgt_composite)
 
         m.write_to_db(db.kv_store)
 
@@ -858,18 +878,14 @@ def task_runner(task):
     try:
         src_node = db.get_storage_node_by_id(group.source_node_id)
     except KeyError:
-        task.function_result = f"source node {group.source_node_id} not found"
-        task.status = JobSchedule.STATUS_SUSPENDED
-        task.write_to_db(db.kv_store)
-        return False
+        return _batch_budget_suspend(
+            task, group, group_id, f"source node {group.source_node_id} not found")
 
     try:
         tgt_node = db.get_storage_node_by_id(group.target_node_id)
     except KeyError:
-        task.function_result = f"target node {group.target_node_id} not found"
-        task.status = JobSchedule.STATUS_SUSPENDED
-        task.write_to_db(db.kv_store)
-        return False
+        return _batch_budget_suspend(
+            task, group, group_id, f"target node {group.target_node_id} not found")
 
     phase = group.phase
     _is_cleanup_phase = phase in (
@@ -1076,7 +1092,14 @@ def main():
         else:
             for cl in clusters:
                 for task in db.get_active_batch_migration_tasks(cl.get_id()):
-                    task_runner(task)
+                    # Lease gate: skip a task another live runner host owns, so
+                    # two replicas can't both drive the same batch migration's
+                    # multi-phase data-plane state-machine concurrently.
+                    if not tasks_controller.claim_task(task):
+                        logger.info(f"Batch-migration task {task.uuid} owned by another runner host; skipping")
+                        continue
+                    with tasks_controller.task_lease_heartbeat(task):
+                        task_runner(task)
 
         time.sleep(3)
 

--- a/simplyblock_core/services/tasks_runner_batch_migration.py
+++ b/simplyblock_core/services/tasks_runner_batch_migration.py
@@ -558,6 +558,48 @@ def _handle_intermediate_barrier(group, member_migrations, src_node, tgt_node, s
                 f"failure (non-fatal): {detach_exc}")
         return None, str(e)
 
+    # Pre-freeze: take SRC secondary/tertiary out of the read path before the
+    # synchronous final-step transfer below. bdev_lvol_batch_transfer_final_step
+    # freezes the SRC primary internally for the duration of the transfer, but
+    # a client sitting on a SRC replica path is not covered by that freeze —
+    # without this, a write accepted by a SRC replica during the transfer (or
+    # in the gap before cutover flips SRC paths inaccessible) never reaches
+    # the copy that already ran, and is silently lost. Mirrors the single-lvol
+    # path's identical pre-freeze (tasks_runner_lvol_migration.py).
+    nqn = group.target_nqn
+    src_paths, _, _ = _build_paths(src_node, tgt_node, src_rpc, tgt_rpc)
+    src_replica_paths = src_paths[1:]  # secondary/tertiary only; primary is frozen internally by the RPC below
+
+    def _flip(rpc, ip, port, trtype, state, label):
+        try:
+            rpc.nvmf_subsystem_listener_set_ana_state(nqn, ip, port, trtype=trtype, ana=state)
+            logger.info(f"Group {group.uuid[:8]}: ANA {label} {ip}:{port} → {state}")
+            return True
+        except Exception as e:
+            logger.warning(f"Group {group.uuid[:8]}: ANA {label} {ip}:{port} (non-fatal): {e}")
+            return False
+
+    def _flip_all(rpc, ips, port, trtype, state, label):
+        for _ip in ips:
+            _flip(rpc, _ip, port, trtype, state, label)
+
+    def _revert_src_replicas(reason):
+        # Final step didn't complete — put SRC secondary/tertiary back into
+        # the read path (their pre-freeze state) so clients keep multipath
+        # access to the still-live source instead of being stuck on primary only.
+        if not src_replica_paths:
+            return
+        logger.warning(f"Group {group.uuid[:8]}: {reason}; reverting SRC secondary/tertiary to non_optimized")
+        for p in src_replica_paths:
+            _flip_all(p['rpc'], p['ips'], p['port'], p['trtype'],
+                      "non_optimized", f"SRC-{p['node_id'][:8]}(revert)")
+
+    if src_replica_paths:
+        logger.info(f"Group {group.uuid[:8]}: setting SRC secondary/tertiary inaccessible pre-final-step")
+        for p in src_replica_paths:
+            _flip_all(p['rpc'], p['ips'], p['port'], p['trtype'],
+                      "inaccessible", f"SRC-{p['node_id'][:8]}(pre-freeze)")
+
     logger.info(
         f"Group {group.uuid[:8]}: batch_final_step "
         f"lvols={len(lvol_names)} hub={hub_bdev}")
@@ -572,10 +614,16 @@ def _handle_intermediate_barrier(group, member_migrations, src_node, tgt_node, s
         logger.error(f"Group {group.uuid[:8]}: bdev_lvol_batch_transfer_final_step RPC error code={e.code}: {e}")
         batch_err = str(e)
         if e.code == RPCErrorCode.method_not_found:
+            _revert_src_replicas("batch_final_step failed (method_not_found)")
             return False, batch_err  # Retrying will never help; surface as fatal so the group fails immediately.
     except Exception as e:
         logger.error(f"Group {group.uuid[:8]}: bdev_lvol_batch_transfer_final_step failed: {e}")
         batch_err = str(e)
+
+    if not batch_ok:
+        _revert_src_replicas("batch_final_step failed")
+    # else: left as-is — the Done handler's ANA sequence (_flip_ana_to_optimized)
+    # already drives every SRC path (including primary) to inaccessible on success.
 
     if batch_ok:
         # bdev_lvol_batch_final_step handles add_clone on the primary internally.

--- a/simplyblock_core/services/tasks_runner_batch_migration.py
+++ b/simplyblock_core/services/tasks_runner_batch_migration.py
@@ -55,7 +55,7 @@ from simplyblock_core.services.tasks_runner_lvol_migration import (
     _get_source_tertiary_node,
     _lvol_tgt_bdev_name,
     _build_paths,
-    _ensure_target_nvmf_state,
+    _ensure_and_prune_target_paths,
 )
 
 logger = utils.get_logger(__name__)
@@ -330,6 +330,29 @@ def _flip_ana_to_optimized(group, member_migrations, src_node, src_rpc, tgt_node
     nqn = group.target_nqn
     src_paths, tgt_paths, overlap_ids = _build_paths(src_node, tgt_node, src_rpc, tgt_rpc)
     src_port_by_id = {p['node_id']: p['port'] for p in src_paths}
+
+    # Detect and repair a target-side node restart that wiped the migration's
+    # NVMe-oF subsystem/listener/namespace, right before this ANA-flip
+    # sequence -- that state is only ever consumed here, at cutover, so there
+    # is no need to poll for it during PHASE_SNAP_COPY/PHASE_INTERMEDIATE.
+    # All workers share the same NQN/subsystem, so the first member is a
+    # representative stand-in. bdev_lvol_batch_final_step has already run and
+    # cannot be undone, so unlike solo migration this is always best-effort:
+    # secondary/tertiary get pruned from tgt_paths on failure (same as solo),
+    # and even a primary failure is only logged -- there is no "abort" option
+    # left at this point, matching this function's existing tolerance for any
+    # ANA-flip step failing (see docstring above).
+    if member_migrations:
+        try:
+            first_lvol = db.get_lvol_by_id(member_migrations[0].lvol_id)
+            tgt_paths, _ensure_err = _ensure_and_prune_target_paths(
+                member_migrations[0], first_lvol, tgt_node, tgt_paths)
+            if _ensure_err:
+                logger.error(
+                    f"Group {group.uuid[:8]}: target primary NVMe-oF state check "
+                    f"failed (non-fatal, batch_final_step already committed): {_ensure_err}")
+        except Exception as e:
+            logger.warning(f"Group {group.uuid[:8]}: target NVMe-oF state check error (non-fatal): {e}")
 
     def _flip(rpc, ip, port, trtype, state, label):
         try:
@@ -877,22 +900,6 @@ def task_runner(task):
             task.status = JobSchedule.STATUS_SUSPENDED
             task.write_to_db(db.kv_store)
             return False
-
-    # --- Target NVMe-oF state reconciliation (GAP D) ---
-    # Mirror the solo runner's per-tick subsystem/listener/namespace repair.
-    # Use the first member migration (all workers share the same NQN and subsystem).
-    if phase in (LVolMigrationGroup.PHASE_SNAP_COPY, LVolMigrationGroup.PHASE_INTERMEDIATE):
-        if member_migrations:
-            first_mig = member_migrations[0]
-            try:
-                first_lvol = db.get_lvol_by_id(first_mig.lvol_id)
-                nvmf_err = _ensure_target_nvmf_state(
-                    first_mig, first_lvol, src_node, tgt_node, src_rpc, tgt_rpc)
-                if nvmf_err:
-                    logger.warning(f"Group {group_id[:8]}: target NVMe-oF state check failed: {nvmf_err}")
-                    return _batch_budget_suspend(task, group, group_id, nvmf_err)
-            except Exception as e:
-                logger.warning(f"Group {group_id[:8]}: _ensure_target_nvmf_state error (non-fatal): {e}")
 
     try:
         # ── PHASE_SNAP_COPY: wait for all workers, then reconstruct tree ─────────

--- a/simplyblock_core/services/tasks_runner_lvol_migration.py
+++ b/simplyblock_core/services/tasks_runner_lvol_migration.py
@@ -1321,7 +1321,7 @@ def _handle_snap_copy(migration, src_node, tgt_node, src_rpc, tgt_rpc):
                     snap = db.get_snapshot_by_id(snap_uuid)
                 except KeyError:
                     return False, True, f"Snapshot {snap_uuid} not found in DB"
-                if snap.lvol.ha_type == "ha":
+                if snap.lvol.ha_type != "single":
                     tgt_sec, sec_err = _get_target_secondary_node(tgt_node, src_node.get_id())
                     if sec_err:
                         migration.error_message = sec_err
@@ -1331,16 +1331,13 @@ def _handle_snap_copy(migration, src_node, tgt_node, src_rpc, tgt_rpc):
                         return False, True, None
                     if tgt_sec:
                         sec_rpc = _make_rpc(tgt_sec)
-                elif snap.lvol.ha_type == "ha3":
-                    tgt_sec, sec_err = _get_target_secondary_node(tgt_node, src_node.get_id())
-                    if sec_err:
-                        migration.error_message = sec_err
-                        migration.write_to_db(db.kv_store)
-                        # transient replica state: suspend (via error_message),
-                        # don't charge the retry budget toward cleanup_target
-                        return False, True, None
-                    if tgt_sec:
-                        sec_rpc = _make_rpc(tgt_sec)
+
+                    # Tertiary eligibility is a property of the target node's own
+                    # LVS topology (tgt_node.tertiary_node_id), not of this lvol's
+                    # ha_type -- match every other subsystem's detection
+                    # (snapshot_controller.delete, lvol_controller, health_controller,
+                    # snapshot_monitor, storage_node_monitor, cluster_expansion,
+                    # replication_final_step all check tertiary_node_id directly).
                     tgt_ter, ter_err = _get_target_tertiary_node(tgt_node, src_node.get_id())
                     if ter_err:
                         migration.error_message = ter_err
@@ -1558,7 +1555,7 @@ def _handle_snap_copy(migration, src_node, tgt_node, src_rpc, tgt_rpc):
         sec_rpc = None
         tgt_ter = None
         ter_rpc = None
-        if snap.lvol.ha_type in ("ha", "ha3"):
+        if snap.lvol.ha_type != "single":
             tgt_sec, sec_err = _get_target_secondary_node(tgt_node, src_node.get_id())
             if sec_err:
                 migration.error_message = sec_err
@@ -1568,7 +1565,11 @@ def _handle_snap_copy(migration, src_node, tgt_node, src_rpc, tgt_rpc):
                 return False, True, None
             if tgt_sec:
                 sec_rpc = _make_rpc(tgt_sec)
-        if snap.lvol.ha_type == "ha3":
+
+            # Tertiary eligibility is a property of the target node's own LVS
+            # topology (tgt_node.tertiary_node_id), not of this lvol's ha_type
+            # -- match every other subsystem's detection (see the identical
+            # comment at the snap-copy call site above).
             tgt_ter, ter_err = _get_target_tertiary_node(tgt_node, src_node.get_id())
             if ter_err:
                 migration.error_message = ter_err
@@ -1865,15 +1866,23 @@ def _handle_lvol_migrate(migration, src_node, tgt_node, src_rpc, tgt_rpc):
         }
 
     else:
-        # --- Gate: check target secondary state before creating on target primary ---
-        if lvol.ha_type == "ha":
-            _, sec_err = _get_target_secondary_node(tgt_node, src_node.get_id())
-            if sec_err:
-                migration.error_message = sec_err
-                migration.write_to_db(db.kv_store)
-                # transient replica state: suspend (via error_message),
-                # don't charge the retry budget toward cleanup_target
-                return False, True, None
+        # --- Gate: check target secondary/tertiary state before creating on
+        # target primary. tgt_sec/tgt_ter were already resolved unconditionally
+        # above (node topology, not lvol.ha_type) -- match that here instead of
+        # re-deriving readiness from ha_type. ---
+        _, sec_err = _get_target_secondary_node(tgt_node, src_node.get_id())
+        if sec_err:
+            migration.error_message = sec_err
+            migration.write_to_db(db.kv_store)
+            # transient replica state: suspend (via error_message),
+            # don't charge the retry budget toward cleanup_target
+            return False, True, None
+        _, ter_err = _get_target_tertiary_node(tgt_node, src_node.get_id())
+        if ter_err:
+            migration.error_message = ter_err
+            migration.write_to_db(db.kv_store)
+            # transient replica state: suspend, don't charge retries
+            return False, True, None
 
         # --- Start the final migration ---
 

--- a/simplyblock_core/services/tasks_runner_lvol_migration.py
+++ b/simplyblock_core/services/tasks_runner_lvol_migration.py
@@ -3393,6 +3393,55 @@ def _handle_group_intermediate(migration, src_node, tgt_node, src_rpc, tgt_rpc):
     return True, False, None
 
 
+def _group_worker_budget_suspend(task, migration, group_id, error_msg):
+    """Charge retry budget for a group worker; fail the WHOLE GROUP when this
+    worker's own budget is exhausted.
+
+    The top-level task_runner's retry-ceiling check (see the `if error:` block
+    after phase dispatch) never runs for group workers -- they're routed to
+    _group_worker_phase_dispatch before that point. Without this, a worker
+    hitting a persistent error just suspended forever via plain _suspend_task,
+    never reaching a terminal state; the barrier it was blocking
+    (snap_copy_done / intermediates_done / cleanup_source_done) never noticed
+    it was stuck, so the whole group hung instead of failing.
+    """
+    migration.retry_count += 1
+    migration.error_message = error_msg
+    task.function_result = error_msg
+    if migration.retry_count >= migration.max_retries:
+        logger.error(
+            f"Group worker {migration.uuid[:8]}: exceeded max retries "
+            f"({migration.max_retries}); entering cleanup_target: {error_msg}")
+        task.retry += 1
+        task.status = JobSchedule.STATUS_SUSPENDED
+        migration.phase = LVolMigration.PHASE_CLEANUP_TARGET
+        migration.current_job_id = ""
+        task.write_to_db(db.kv_store)
+        migration.write_to_db(db.kv_store)
+        migration_events.migration_phase_changed(migration)
+
+        # This worker will never signal done to its barrier now -- fail the
+        # whole group rather than let siblings (and the orchestrator) wait
+        # on it forever.
+        try:
+            group = db.get_migration_group_by_id(group_id)
+            if group.phase not in (LVolMigrationGroup.PHASE_CLEANUP_TARGET,
+                                   LVolMigrationGroup.PHASE_CLEANUP_SOURCE,
+                                   LVolMigrationGroup.PHASE_COMPLETED):
+                group.phase = LVolMigrationGroup.PHASE_CLEANUP_TARGET
+                group.error_message = (
+                    f"worker {migration.uuid[:8]} (lvol={migration.lvol_id}) "
+                    f"exceeded max retries: {error_msg}")
+                group.write_to_db(db.kv_store)
+                logger.error(
+                    f"Group {group_id[:8]}: failing whole group — worker "
+                    f"{migration.uuid[:8]} exhausted its retry budget")
+        except KeyError:
+            pass
+        return False
+    return _suspend_task(task, migration, error_msg)
+
+
 def _group_worker_phase_dispatch(task, migration, phase, src_node, tgt_node, src_rpc, tgt_rpc):
     """
     Complete phase dispatcher for FN_LVOL_MIG tasks that belong to a batch
@@ -3424,7 +3473,7 @@ def _group_worker_phase_dispatch(task, migration, phase, src_node, tgt_node, src
             done, suspend, error = _handle_group_snap_copy(
                 migration, src_node, tgt_node, src_rpc, tgt_rpc)
             if error:
-                return _suspend_task(task, migration, error)
+                return _group_worker_budget_suspend(task, migration, group_id, error)
             if suspend:
                 return _suspend_task(task, migration, migration.error_message or "waiting")
             if done:
@@ -3467,7 +3516,7 @@ def _group_worker_phase_dispatch(task, migration, phase, src_node, tgt_node, src
             done, suspend, error = _handle_group_intermediate(
                 migration, src_node, tgt_node, src_rpc, tgt_rpc)
             if error:
-                return _suspend_task(task, migration, error)
+                return _group_worker_budget_suspend(task, migration, group_id, error)
             if suspend:
                 return _suspend_task(task, migration, migration.error_message or "waiting")
             if done:
@@ -3516,7 +3565,7 @@ def _group_worker_phase_dispatch(task, migration, phase, src_node, tgt_node, src
             return _suspend_task(task, migration, str(exc))
 
         if error:
-            return _suspend_task(task, migration, error)
+            return _group_worker_budget_suspend(task, migration, group_id, error)
         if suspend:
             return _suspend_task(task, migration, migration.error_message or "waiting")
         if done:

--- a/simplyblock_core/services/tasks_runner_lvol_migration.py
+++ b/simplyblock_core/services/tasks_runner_lvol_migration.py
@@ -720,151 +720,138 @@ def _target_role_label(node_id, tgt_node):
     return 'unknown'
 
 
-def _ensure_target_nvmf_state(migration, lvol, src_node, tgt_node, src_rpc, tgt_rpc):
+def _ensure_nvmf_state_on_node(migration, lvol, nqn, path, label, owns_subsystem, ns_composite):
+    """Detect and repair a target-side node restart that wiped the migration's
+    NVMe-oF subsystem / listener / namespace on a single path. Raises on any
+    failure to reach or repair the node; the caller decides what that means
+    (mandatory for the primary, best-effort for secondary/tertiary)."""
+    node_id = path['node_id']
+    rpc = path['rpc']
+
+    sub = rpc.subsystem_get(nqn)
+
+    if not sub:
+        if not owns_subsystem:
+            raise RuntimeError(
+                f"target {label} node {node_id[:8]} is missing subsystem {nqn} "
+                f"that this migration does not own; waiting for node recovery")
+
+        logger.warning(
+            f"_ensure_nvmf_state_on_node: subsystem {nqn} missing on "
+            f"{label} target node {node_id[:8]} (likely node restart) — recreating")
+        lo, hi = _CNTLID_RANGES.get(label, (3, 500))
+        rpc.subsystem_create(
+            nqn, lvol.ha_type, lvol.uuid, min_cntlid=random.randint(lo, hi),
+            max_namespaces=lvol.max_namespace_per_subsys)
+        if lvol.allowed_hosts:
+            _reapply_allowed_hosts(lvol, path['node'], rpc)
+        for _ip in path['ips']:
+            rpc.listeners_create(nqn, path['trtype'], _ip, path['port'],
+                                 ana_state="inaccessible")
+        ns = rpc.nvmf_subsystem_add_ns(nqn, ns_composite, lvol.uuid, lvol.guid)
+        if not ns:
+            logger.warning(
+                f"_ensure_nvmf_state_on_node: namespace add failed on "
+                f"{label} {node_id[:8]} after subsystem recreate")
+        if node_id not in migration.target_subsystem_node_ids:
+            migration.target_subsystem_node_ids.append(node_id)
+        logger.info(
+            f"_ensure_nvmf_state_on_node: recreated subsystem+listener+ns "
+            f"for migration {migration.uuid} on {label} {node_id[:8]}")
+        return
+
+    # Subsystem present — verify our listener survived.
+    listeners = rpc.listeners_list(nqn) or []
+    listener_addrs = {
+        (ls.get('address', {}).get('traddr'), str(ls.get('address', {}).get('trsvcid')))
+        for ls in listeners
+    }
+    for _ip in path['ips']:
+        if (_ip, str(path['port'])) not in listener_addrs:
+            logger.warning(
+                f"_ensure_nvmf_state_on_node: listener {_ip}:{path['port']} "
+                f"missing on {label} target node {node_id[:8]} (likely node "
+                f"restart) — recreating as inaccessible")
+            rpc.listeners_create(nqn, path['trtype'], _ip, path['port'],
+                                 ana_state="inaccessible")
+
+    # Namespace check — only on nodes whose namespace lifecycle we own;
+    # overlap nodes legitimately still point at the SRC bdev pre-cutover
+    # (the namespace swap is _handle_lvol_migrate's job, not ours).
+    if owns_subsystem:
+        ns_list = sub.get('namespaces', []) if isinstance(sub, dict) else []
+        has_ns = any(ns.get('uuid') == lvol.uuid for ns in ns_list)
+        if not has_ns:
+            logger.warning(
+                f"_ensure_nvmf_state_on_node: namespace for {lvol.uuid} "
+                f"missing on {label} target node {node_id[:8]} — re-adding")
+            ns = rpc.nvmf_subsystem_add_ns(nqn, ns_composite, lvol.uuid, lvol.guid)
+            if not ns:
+                logger.warning(
+                    f"_ensure_nvmf_state_on_node: namespace re-add failed "
+                    f"on {label} {node_id[:8]}")
+
+
+def _ensure_and_prune_target_paths(migration, lvol, tgt_node, tgt_paths):
     """
     Detect and repair a target-side node restart that wiped the migration's
-    NVMe-oF subsystem / listener / namespace before cutover.
+    NVMe-oF subsystem / listener / namespace. Called ONCE, right before
+    cutover (from _handle_lvol_migrate, before the freeze/transfer/ANA-flip
+    sequence) — subsystem/listener/namespace state on the target only matters
+    at cutover, so there is no need to poll for it during PHASE_SNAP_COPY.
 
-    A restart is inferred rather than tracked explicitly: every call re-checks
-    that the subsystem, our TGT-port listener, and (on nodes whose subsystem
-    lifecycle we own) the namespace are still present on the target primary
-    and its online secondary/tertiary, recreating whatever SPDK lost.
+    Every path is attempted regardless of an earlier failure (the caller may
+    be running this after an already-irreversible step — e.g. batch
+    migration's cutover, which runs this after bdev_lvol_batch_final_step —
+    so bailing out early is not always safe). The target primary is always
+    kept in the returned list, whether or not its own check succeeded, so
+    callers can rely on tgt_paths[0] still being the primary; its failure is
+    reported separately via the returned error string, and it is up to the
+    caller whether that means suspend-without-charging-retry-budget (solo
+    migration, before its irreversible step) or just a logged, non-fatal
+    warning (batch migration, after it).
 
-    A recreated listener is always set to ana_state="inaccessible" — pre-cutover
-    that already is the desired state, and post-final-migration
-    _handle_lvol_migrate's Done handler unconditionally re-runs its ANA-flip
-    sequence on every call, correcting it within the same tick.
+    Secondary/tertiary are always best-effort: a failure there is logged and
+    that path is dropped from the returned list instead of failing anything
+    — the rest of the ANA-flip sequence only operates on whatever's in the
+    returned list, so a dropped replica's cutover state is simply skipped for
+    this attempt. If that node is still down when it eventually restarts, the
+    ordinary per-lvol restart reconciliation in storage_node_ops.py (keyed
+    off lvol.node_id, which points at the new primary once cutover
+    completes) recreates its subsystem the normal way — no special handling
+    needed here.
 
-    Overlap nodes (subsystem shared with the SRC role) never had their
-    subsystem created by this migration — if that subsystem is entirely gone,
-    something outside migration's control needs to fix it, so this only waits.
-
-    Returns None if everything is fine (or was successfully repaired), or an
-    error string describing the transient failure.
+    Returns (pruned_tgt_paths, primary_error). primary_error is None unless
+    the target primary itself could not be verified/repaired.
     """
     nqn = lvol.nqn
-    try:
-        _, tgt_paths, _overlap_ids = _build_paths(src_node, tgt_node, src_rpc, tgt_rpc)
-    except Exception as e:
-        logger.warning(f"_ensure_target_nvmf_state: could not build target paths: {e}")
-        migration.error_message = f"target topology unavailable: {e}"
-        return migration.error_message
-
     owned_node_ids = set(migration.target_subsystem_node_ids or [])
     short_bdev = _lvol_tgt_bdev_name(lvol.lvol_bdev)
     ns_bdev_short = f"crypto_{short_bdev}" if lvol.crypto_bdev else short_bdev
     ns_composite = f"{tgt_node.lvstore}/{ns_bdev_short}"
 
+    pruned_paths = []
+    primary_error = None
     for path in tgt_paths:
         node_id = path['node_id']
-        rpc = path['rpc']
         label = _target_role_label(node_id, tgt_node)
+        is_primary = (node_id == tgt_node.get_id())
         owns_subsystem = node_id in owned_node_ids
 
         try:
-            sub = rpc.subsystem_get(nqn)
+            _ensure_nvmf_state_on_node(migration, lvol, nqn, path, label,
+                                       owns_subsystem, ns_composite)
+            pruned_paths.append(path)
         except Exception as e:
-            logger.warning(
-                f"_ensure_target_nvmf_state: subsystem_get failed on "
-                f"{label} {node_id[:8]}: {e}")
-            migration.error_message = f"could not query subsystem on {label} target node: {e}"
-            return migration.error_message
-
-        if not sub:
-            if not owns_subsystem:
-                msg = (f"target {label} node {node_id[:8]} is missing subsystem "
-                       f"{nqn} that this migration does not own; waiting for "
-                       f"node recovery")
-                logger.warning(f"_ensure_target_nvmf_state: {msg}")
-                migration.error_message = msg
-                return migration.error_message
-
-            logger.warning(
-                f"_ensure_target_nvmf_state: subsystem {nqn} missing on "
-                f"{label} target node {node_id[:8]} (likely node restart) "
-                f"— recreating")
-            try:
-                lo, hi = _CNTLID_RANGES.get(label, (3, 500))
-                rpc.subsystem_create(
-                    nqn, lvol.ha_type, lvol.uuid, min_cntlid=random.randint(lo, hi),
-                    max_namespaces=lvol.max_namespace_per_subsys)
-                if lvol.allowed_hosts:
-                    _reapply_allowed_hosts(lvol, path['node'], rpc)
-                for _ip in path['ips']:
-                    rpc.listeners_create(nqn, path['trtype'], _ip, path['port'],
-                                         ana_state="inaccessible")
-                ns = rpc.nvmf_subsystem_add_ns(nqn, ns_composite, lvol.uuid, lvol.guid)
-                if not ns:
-                    logger.warning(
-                        f"_ensure_target_nvmf_state: namespace add failed on "
-                        f"{label} {node_id[:8]} after subsystem recreate")
-                if node_id not in migration.target_subsystem_node_ids:
-                    migration.target_subsystem_node_ids.append(node_id)
-                logger.info(
-                    f"_ensure_target_nvmf_state: recreated subsystem+listener+ns "
-                    f"for migration {migration.uuid} on {label} {node_id[:8]}")
-            except Exception as e:
+            if is_primary:
+                primary_error = str(e)
+                pruned_paths.append(path)  # keep it -- caller decides what a primary failure means
+            else:
                 logger.warning(
-                    f"_ensure_target_nvmf_state: recreate failed on {label} "
-                    f"{node_id[:8]}: {e}")
-                migration.error_message = f"failed to recreate target subsystem on {label} node: {e}"
-                return migration.error_message
-            continue
-
-        # Subsystem present — verify our listener survived.
-        try:
-            listeners = rpc.listeners_list(nqn) or []
-        except Exception as e:
-            logger.warning(
-                f"_ensure_target_nvmf_state: listeners_list failed on "
-                f"{label} {node_id[:8]}: {e}")
-            migration.error_message = f"could not query listeners on {label} target node: {e}"
-            return migration.error_message
-
-        listener_addrs = {
-            (ls.get('address', {}).get('traddr'), str(ls.get('address', {}).get('trsvcid')))
-            for ls in listeners
-        }
-        for _ip in path['ips']:
-            if (_ip, str(path['port'])) not in listener_addrs:
-                logger.warning(
-                    f"_ensure_target_nvmf_state: listener {_ip}:{path['port']} "
-                    f"missing on {label} target node {node_id[:8]} (likely node "
-                    f"restart) — recreating as inaccessible")
-                try:
-                    rpc.listeners_create(nqn, path['trtype'], _ip, path['port'],
-                                         ana_state="inaccessible")
-                except Exception as e:
-                    logger.warning(
-                        f"_ensure_target_nvmf_state: listener recreate failed on "
-                        f"{label} {node_id[:8]}: {e}")
-                    migration.error_message = f"failed to recreate target listener on {label} node: {e}"
-                    return migration.error_message
-
-        # Namespace check — only on nodes whose namespace lifecycle we own;
-        # overlap nodes legitimately still point at the SRC bdev pre-cutover
-        # (the namespace swap is _handle_lvol_migrate's job, not ours).
-        if owns_subsystem:
-            ns_list = sub.get('namespaces', []) if isinstance(sub, dict) else []
-            has_ns = any(ns.get('uuid') == lvol.uuid for ns in ns_list)
-            if not has_ns:
-                logger.warning(
-                    f"_ensure_target_nvmf_state: namespace for {lvol.uuid} "
-                    f"missing on {label} target node {node_id[:8]} — re-adding")
-                try:
-                    ns = rpc.nvmf_subsystem_add_ns(nqn, ns_composite, lvol.uuid, lvol.guid)
-                    if not ns:
-                        logger.warning(
-                            f"_ensure_target_nvmf_state: namespace re-add failed "
-                            f"on {label} {node_id[:8]}")
-                except Exception as e:
-                    logger.warning(
-                        f"_ensure_target_nvmf_state: namespace re-add errored on "
-                        f"{label} {node_id[:8]}: {e}")
-                    migration.error_message = f"failed to re-add namespace on {label} node: {e}"
-                    return migration.error_message
-
-    return None
+                    f"_ensure_and_prune_target_paths: {label} {node_id[:8]} "
+                    f"unreachable/repair failed — skipping its cutover state "
+                    f"for this attempt: {e}")
+    return pruned_paths, primary_error
 
 
 # ---------------------------------------------------------------------------
@@ -1769,6 +1756,21 @@ def _handle_lvol_migrate(migration, src_node, tgt_node, src_rpc, tgt_rpc):
     src_paths, tgt_paths, overlap_ids = _build_paths(src_node, tgt_node, src_rpc, tgt_rpc)
     src_replica_paths = src_paths[1:]  # secondary/tertiary only; primary stays live until cutover
 
+    # Detect and repair a target-side node restart that wiped the migration's
+    # NVMe-oF subsystem/listener/namespace before cutover -- run once here,
+    # right before the freeze/transfer/ANA-flip sequence below, since that
+    # state is only ever consumed at cutover (not during PHASE_SNAP_COPY).
+    # Target primary failures suspend without charging the retry budget
+    # (mirroring PHASE_CLEANUP_TARGET/SOURCE's identical transient-connectivity
+    # carve-out); secondary/tertiary failures just drop that path so the rest
+    # of this function's best-effort ANA-flip steps skip it for this attempt.
+    tgt_paths, _ensure_err = _ensure_and_prune_target_paths(migration, lvol, tgt_node, tgt_paths)
+    if _ensure_err:
+        migration.error_message = _ensure_err
+        migration.write_to_db(db.kv_store)
+        # transient replica state: suspend, don't charge the retry budget
+        return False, True, None
+
     def _flip(rpc, ip, port, trtype, state, label):
         try:
             rpc.nvmf_subsystem_listener_set_ana_state(
@@ -2641,7 +2643,7 @@ def _handle_cleanup_target(migration, tgt_node, tgt_rpc, src_rpc=None):
 
         # Per-node ownership: migration.target_subsystem_node_ids is the
         # authoritative record of which nodes had their subsystem *created*
-        # by this migration (see _ensure_target_nvmf_state). An overlap node
+        # by this migration (see _ensure_and_prune_target_paths). An overlap node
         # reuses a preexisting subsystem it doesn't own, so it's never added
         # to this list — cleanup must not delete a subsystem this migration
         # never created just because the transfer failed/was cancelled.
@@ -2957,26 +2959,6 @@ def task_runner(task):
     done = suspend = False
     error = None
     next_phase = ""
-
-    # --- Target-restart reconciliation ---
-    # Before cutover, nothing else re-verifies that the target subsystem/
-    # listener/namespace created by create_migration are still there; a
-    # target (or its secondary/tertiary) restarting mid-migration silently
-    # drops them, which would otherwise only surface as a hard ANA-flip
-    # failure once PHASE_LVOL_MIGRATE's Done handler runs.  Not applicable to
-    # group workers (batch migration's shared subsystem is reconciled by its
-    # own orchestrator).
-    if not migration.migration_group_id and phase in (
-            LVolMigration.PHASE_SNAP_COPY, LVolMigration.PHASE_LVOL_MIGRATE):
-        try:
-            lvol = db.get_lvol_by_id(migration.lvol_id)
-        except KeyError:
-            return _budget_suspend(task, migration, migration.get_id(), f"LVol {migration.lvol_id} not found")
-
-        nvmf_err = _ensure_target_nvmf_state(migration, lvol, src_node, tgt_node, src_rpc, tgt_rpc)
-        if nvmf_err:
-            return _budget_suspend(task, migration, migration.get_id(),
-                                   migration.error_message or nvmf_err)
 
     try:
         if migration.migration_group_id:

--- a/simplyblock_core/services/tasks_runner_lvol_migration.py
+++ b/simplyblock_core/services/tasks_runner_lvol_migration.py
@@ -3437,7 +3437,11 @@ def _group_worker_budget_suspend(task, migration, group_id, error_msg):
                     f"Group {group_id[:8]}: failing whole group — worker "
                     f"{migration.uuid[:8]} exhausted its retry budget")
         except KeyError:
-            pass
+            # Group may already be removed/cleaned up by another workflow.
+            # We keep worker cleanup flow idempotent by not re-raising.
+            logger.warning(
+                f"Group {group_id[:8]} not found while propagating worker "
+                f"{migration.uuid[:8]} retry-budget exhaustion; continuing.")
         return False
     return _suspend_task(task, migration, error_msg)
 

--- a/tests/unit/tasks/test_retry_ceiling.py
+++ b/tests/unit/tasks/test_retry_ceiling.py
@@ -400,6 +400,12 @@ def _spec_batch_migration(runner, monkeypatch):
     # Stub collaborators that hit real infrastructure (DB, events, network).
     monkeypatch.setattr(runner.tasks_controller, "get_active_cluster_expand_task",
                         lambda *a, **k: False)
+    # main() lease-gates each task via claim_task before running it (so two
+    # runner replicas can't both drive the same group); without this the real
+    # claim_task hits the module's own uninitialized DBController, "loses" the
+    # claim every time, and main() skips task_runner forever.
+    monkeypatch.setattr(runner.tasks_controller, "claim_task",
+                        lambda *a, **k: True)
     monkeypatch.setattr(runner, "_delete_target_subsystem", MagicMock())
     monkeypatch.setattr(runner, "migration_events", MagicMock())
     monkeypatch.setattr(runner, "tasks_events", MagicMock())


### PR DESCRIPTION
this PR aims to fix issues the tests has surfaced 

- "no such device" sometimes the tertiary node registration is skipped and isn't handled properly
- "can't get target subsystem" a rework is needed for the logic of restoring subsystems and namespaces that the migration has created since waiting for the node to come back online isn't really an option due to recent changes on the migration flow