### PR TITLE
Introduce metrics support to API v2

### DIFF
--- a/simplyblock_core/models/stats.py
+++ b/simplyblock_core/models/stats.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 import json
 import uuid
+from typing import List, TypedDict
 
 from simplyblock_core.models.base_model import BaseModel
 
@@ -86,8 +87,33 @@ class DeviceStatObject(StatsObject):
     pass
 
 
+# `total=False` throughout: these records are read back from FoundationDB and
+# may have been written by an older collector, so every key is genuinely
+# optional at read time. Key names and value types are still checked — only
+# presence is not. Readers get `Optional[...]` from `.get()` and have to say
+# what absence means rather than defaulting it away.
+class ThreadStats(TypedDict, total=False):
+    id: int
+    name: str
+    busy: int
+    idle: int
+
+
+class ReactorStats(TypedDict, total=False):
+    lcore: int
+    busy: int
+    idle: int
+    irq: int
+    sys: int
+    threads: List[ThreadStats]
+
+
+class CpuStats(TypedDict, total=False):
+    reactors: List[ReactorStats]
+
+
 class NodeStatObject(StatsObject):
-    pass
+    cpu_dict: CpuStats = {}
 
 
 class ClusterStatObject(StatsObject):

--- a/simplyblock_core/scripts/prometheus.yml.j2
+++ b/simplyblock_core/scripts/prometheus.yml.j2
@@ -6,6 +6,10 @@ global:
 
 scrape_configs:
 
+  # Both exporters are scraped during the migration to the v2 metric names. The
+  # two publish disjoint series (v2 namespaces everything under `simplyblock_`),
+  # so collecting both is safe, and it keeps the dashboards and alert rules
+  # working until they are switched over. Remove this job once they are.
   - job_name: 'cluster_metrics'
     scrape_timeout: 50s
     static_configs:
@@ -15,6 +19,14 @@ scrape_configs:
     basic_auth:
       username: '{{ CLUSTER_ID }}'
       password: '{{ CLUSTER_SECRET }}'
+
+  - job_name: 'simplyblock_metrics'
+    scrape_timeout: 30s
+    static_configs:
+      - targets: ['HAProxy:80']
+    metrics_path: '/api/v2/metrics'
+    authorization:
+      credentials: '{{ CLUSTER_SECRET }}'
 
   - job_name: 'node'
     dns_sd_configs:

--- a/simplyblock_core/services/capacity_and_stats_collector.py
+++ b/simplyblock_core/services/capacity_and_stats_collector.py
@@ -1,12 +1,21 @@
 # coding=utf-8
 import statistics
 import time
+from typing import List, Optional
 
 from simplyblock_core import constants, db_controller, utils
 from simplyblock_core.controllers import device_events
 from simplyblock_core.models.nvme_device import NVMeDevice
 from simplyblock_core.models.storage_node import StorageNode
-from simplyblock_core.models.stats import DeviceStatObject, NodeStatObject, ClusterStatObject
+from simplyblock_core.models.stats import (
+    ClusterStatObject,
+    CpuStats,
+    DeviceStatObject,
+    NodeStatObject,
+    ReactorStats,
+    ThreadStats,
+)
+from simplyblock_core.rpc_client import RPCException
 
 logger = utils.get_logger(__name__)
 
@@ -211,7 +220,46 @@ def add_device_stats(cl, device, capacity_dict, stats_dict):
     return stat_obj
 
 
-def add_node_stats(cluster, node, records, all_lvols):
+def get_cpu_stats(rpc_client) -> CpuStats:
+    """Collect raw SPDK reactor and lightweight-thread tick counters.
+
+    The counters are stored unprocessed rather than as a utilization
+    percentage. SPDK reports busy/idle/irq/sys cumulatively since reactor
+    start, so a ratio computed at collection time is an average over the whole
+    process lifetime, not current load — the longer a node is up, the less it
+    responds to present load. Deriving the rate at query time also makes the
+    result independent of this collector's interval.
+    """
+    reactor_data = rpc_client.framework_get_reactors() or {}
+    thread_data = rpc_client.thread_get_stats() or {}
+    thread_stats = {t['id']: t for t in thread_data.get('threads', [])}
+
+    reactors: List[ReactorStats] = []
+    for reactor in reactor_data['reactors']:
+        threads: List[ThreadStats] = []
+        for thread in reactor['lw_threads']:
+            entry: ThreadStats = {'id': thread['id'], 'name': thread['name']}
+            # Per-thread counters come from the second RPC and are matched by
+            # id. A thread that appeared between the two calls has no entry
+            # there; omit its counters rather than recording them as zero.
+            stats = thread_stats.get(thread['id'])
+            if stats is not None:
+                entry['busy'] = stats['busy']
+                entry['idle'] = stats['idle']
+            threads.append(entry)
+
+        reactors.append({
+            'lcore': reactor['lcore'],
+            'busy': reactor['busy'],
+            'idle': reactor['idle'],
+            'irq': reactor['irq'],
+            'sys': reactor['sys'],
+            'threads': threads,
+        })
+    return {'reactors': reactors}
+
+
+def add_node_stats(cluster, node, records, all_lvols, cpu_dict: Optional[CpuStats] = None):
     size_used = 0
     size_total = 0
     data = {}
@@ -238,7 +286,8 @@ def add_node_stats(cluster, node, records, all_lvols):
         "date": int(time.time()),
         "size_util": size_util,
         "size_prov": size_prov,
-        "size_prov_util": size_prov_util
+        "size_prov_util": size_prov_util,
+        "cpu_dict": cpu_dict or {}
     })
     stat_obj = NodeStatObject(data=data)
     stat_obj.write_to_db(db.kv_store)
@@ -338,7 +387,18 @@ def main():
                             devices_records.append(record)
                             cluster_device_records.append((device, record))
 
-                node_record = add_node_stats(cl, node, devices_records, all_lvols)
+                try:
+                    cpu_dict = get_cpu_stats(rpc_client)
+                except (RPCException, KeyError) as e:
+                    # KeyError means the SPDK reply lacked a field we read
+                    # unconditionally — record no CPU data rather than
+                    # substituting zeros for counters we did not observe.
+                    logger.error("Failed to collect CPU stats for node %s: %s", node.get_id(), e)
+                    # Empty, not {'reactors': []} — we do not know the node has
+                    # zero reactors.
+                    cpu_dict = {}
+
+                node_record = add_node_stats(cl, node, devices_records, all_lvols, cpu_dict)
                 node_records.append(node_record)
 
             add_cluster_stats(cl, node_records)

--- a/simplyblock_core/utils/__init__.py
+++ b/simplyblock_core/utils/__init__.py
@@ -3067,6 +3067,11 @@ def patch_prometheus_configmap(username: str, password: str):
         try:
             prometheus_yml = re.sub(r"username:.*", f"username: '{username}'", prometheus_yml)
             prometheus_yml = re.sub(r"password:.*", f"password: '{password}'", prometheus_yml)
+            # The v2 exporter authenticates with a bearer token rather than
+            # basic auth, so the secret also has to reach `authorization:
+            # credentials:`. A no-op until the chart's ConfigMap declares the
+            # v2 job — without it that job would scrape with an empty token.
+            prometheus_yml = re.sub(r"credentials:.*", f"credentials: '{password}'", prometheus_yml)
         except re.error as e:
             logger.error(f"Regex error while patching Prometheus YAML: {e}")
             return False

--- a/simplyblock_web/AGENTS.md
+++ b/simplyblock_web/AGENTS.md
@@ -18,7 +18,9 @@ Use these patterns when adding new v2 endpoints:
 
 **Dependencies** (`_dependencies.py`): FastAPI `Depends()`-based resource lookup. Typed aliases like `Cluster`, `StorageNode`, `Volume`, `Snapshot` resolve path parameters to core model objects (raising 404 on miss). Dependencies chain — e.g., `Volume` depends on `StoragePool` which depends on `Cluster` — enforcing hierarchical ownership.
 
-**Auth** (`_auth.py`): `verify_api_token` dependency on all routers. Supports k8s service account tokens (via TokenReview) and cluster-secret bearer tokens. Admin service accounts bypass per-cluster checks. Secret comparison uses `hmac.compare_digest(secret.get_secret_value(), token)` for timing safety.
+**Auth** (`_auth.py`): `verify_api_token` dependency on all routers. Supports k8s service account tokens (via TokenReview) and cluster-secret bearer tokens. Admin service accounts (`SB_K8S_ADMIN_SERVICE_ACCOUNTS`) bypass per-cluster checks. Secret comparison uses `hmac.compare_digest(secret.get_secret_value(), token)` for timing safety.
+
+The metrics router instead uses `verify_metrics_token`, which additionally admits service accounts listed in `SB_K8S_METRICS_SERVICE_ACCOUNTS` — a scrape credential that reaches `/api/v2/metrics` and nothing else. Grant a capability by adding a per-capability setting and a matching dependency, not by widening the admin list; the per-capability lists map onto a principal's scope set when authorization moves to scopes.
 
 **Access logging** (`app.py`): The `AccessLogMiddleware` logs only `request.url.path`, never the query string — query parameters can carry credentials (`?secret=…`, `?token=…`) and have no type info to mask by.
 

--- a/simplyblock_web/api/v2/__init__.py
+++ b/simplyblock_web/api/v2/__init__.py
@@ -4,10 +4,10 @@ from . import cluster
 from . import management_node
 from . import meta
 from . import metrics
-from ._auth import verify_api_token
+from ._auth import verify_api_token, verify_metrics_token
 
 api = APIRouter()
 api.include_router(cluster.api, prefix='/clusters', dependencies=[Depends(verify_api_token)])
 api.include_router(management_node.api, prefix='/management-nodes', dependencies=[Depends(verify_api_token)])
 api.include_router(meta.api, prefix='/_meta')
-api.include_router(metrics.api, prefix='/metrics', dependencies=[Depends(verify_api_token)])
+api.include_router(metrics.api, prefix='/metrics', dependencies=[Depends(verify_metrics_token)])

--- a/simplyblock_web/api/v2/__init__.py
+++ b/simplyblock_web/api/v2/__init__.py
@@ -3,9 +3,11 @@ from fastapi import APIRouter, Depends
 from . import cluster
 from . import management_node
 from . import meta
+from . import metrics
 from ._auth import verify_api_token
 
 api = APIRouter()
 api.include_router(cluster.api, prefix='/clusters', dependencies=[Depends(verify_api_token)])
 api.include_router(management_node.api, prefix='/management-nodes', dependencies=[Depends(verify_api_token)])
 api.include_router(meta.api, prefix='/_meta')
+api.include_router(metrics.api, prefix='/metrics', dependencies=[Depends(verify_api_token)])

--- a/simplyblock_web/api/v2/_auth.py
+++ b/simplyblock_web/api/v2/_auth.py
@@ -154,3 +154,24 @@ def verify_api_token(
 
     if cluster_id is not None and authorized_cluster_id != cluster_id:
         raise HTTPException(401, 'Invalid token')
+
+
+def verify_metrics_token(
+    sa_name: Annotated[Optional[str], Depends(authenticated_service_account)],
+    authorized_cluster_id: Annotated[Optional[UUID], Depends(authorized_cluster)],
+) -> None:
+    """FastAPI dependency: enforce read access to the metrics exporter.
+
+    Admits everything `verify_api_token` does, plus service accounts listed in
+    ``SB_K8S_METRICS_SERVICE_ACCOUNTS``. Those are authorized here and nowhere
+    else, so a scrape credential does not carry admin rights.
+
+    Raises 401 otherwise.
+    """
+    if sa_name is not None and sa_name in (
+        _web_settings.k8s_admin_service_accounts + _web_settings.k8s_metrics_service_accounts
+    ):
+        return
+
+    if authorized_cluster_id is None:
+        raise HTTPException(401, 'Invalid token')

--- a/simplyblock_web/api/v2/metrics.py
+++ b/simplyblock_web/api/v2/metrics.py
@@ -1,0 +1,358 @@
+"""Prometheus exporter.
+
+Implemented as a `prometheus_client` custom collector rather than a set of
+long-lived `Gauge` objects. The values here are a snapshot of FoundationDB, not
+state of this process, so the "set it and leave it" lifecycle of direct
+instrumentation is wrong for them: a `Gauge.labels(...)` child is never
+released, so a deleted volume keeps reporting its last value until the process
+restarts. Since HAProxy round-robins scrapes across every API instance, each
+instance accumulates a *different* set of those stale children, and Prometheus
+sees one series written alternately by disagreeing sources.
+
+A collector rebuilds every series inside `collect()`, so absence is meaningful:
+an object that no longer exists stops being exported, and every instance
+returns an identical response because the only input is shared FDB state.
+"""
+
+from typing import Callable, Iterable, Iterator, Optional, Sequence
+
+from fastapi import APIRouter
+from fastapi.responses import Response
+from prometheus_client import CONTENT_TYPE_LATEST, CollectorRegistry, generate_latest
+from prometheus_client.core import CounterMetricFamily, GaugeMetricFamily, Metric
+
+from simplyblock_core.db_controller import DBController
+from simplyblock_core.models.stats import CpuStats, ReactorStats, ThreadStats
+
+
+api = APIRouter()
+db = DBController()
+
+NAMESPACE = 'simplyblock'
+
+_CLUSTER_LABELS = ['cluster', 'cluster_name']
+_NODE_LABELS = _CLUSTER_LABELS + ['snode', 'hostname']
+_DEVICE_LABELS = _CLUSTER_LABELS + ['snode', 'device']
+_POOL_LABELS = _CLUSTER_LABELS + ['pool', 'pool_name']
+# `pool` is the uuid, so volume series join to pool series on it; `pool_name`
+# rides along for human-facing filters and legends. It adds no series, being
+# functionally dependent on the uuid.
+_LVOL_LABELS = _CLUSTER_LABELS + ['pool', 'pool_name', 'lvol', 'lvol_name', 'pvc_name']
+
+# Cumulative SPDK counters. Exported as counters so that PromQL `rate()` handles
+# an SPDK restart natively; the collectors' `_ps` fields, which hand-derived
+# rates from consecutive samples, are deliberately not exported.
+#
+# Latency is exported only as cumulative ticks alongside the operation count,
+# never pre-divided. Mean latency is `rate(latency_ticks) / rate(operations)`,
+# which stays correct when a node or cluster series is the sum over its
+# devices, because summing numerator and denominator separately is the right
+# aggregation. Dividing per-device first and summing the quotients — what the
+# v1 exporter published — is not a latency at any level above the device.
+_IO_COUNTERS: Sequence[tuple[str, str, str]] = (
+    ('read_bytes', 'read_bytes', 'Cumulative bytes read'),
+    ('read_io', 'read_operations', 'Cumulative read operations'),
+    ('read_latency_ticks', 'read_latency_ticks', 'Cumulative read latency in SPDK ticks'),
+    ('write_bytes', 'write_bytes', 'Cumulative bytes written'),
+    ('write_io', 'write_operations', 'Cumulative write operations'),
+    ('write_latency_ticks', 'write_latency_ticks', 'Cumulative write latency in SPDK ticks'),
+    ('unmap_bytes', 'unmap_bytes', 'Cumulative bytes unmapped'),
+    ('unmap_io', 'unmap_operations', 'Cumulative unmap operations'),
+    ('unmap_latency_ticks', 'unmap_latency_ticks', 'Cumulative unmap latency in SPDK ticks'),
+)
+
+# Capacity is exported in bytes only. The collectors also persist integer
+# percentages (`size_util`, `size_prov_util`), but those are truncated with
+# `int(used / total * 100)`, so exporting them would publish a lossy copy of
+# something PromQL can divide exactly.
+_SIZE_GAUGES: Sequence[tuple[str, str, str]] = (
+    ('size_total', 'size_total_bytes', 'Total capacity in bytes'),
+    ('size_used', 'size_used_bytes', 'Used capacity in bytes'),
+    ('size_free', 'size_free_bytes', 'Free capacity in bytes'),
+    ('size_prov', 'size_provisioned_bytes', 'Provisioned capacity in bytes'),
+)
+
+# Only levels whose collector actually populates a key may export it, otherwise
+# the field's zero default would be published as a real measurement. Device,
+# volume and pool records never carry a provisioned size.
+_SIZE_KEYS_BY_LEVEL = {
+    'cluster': ('size_total', 'size_used', 'size_free', 'size_prov'),
+    'snode': ('size_total', 'size_used', 'size_free', 'size_prov'),
+    'device': ('size_total', 'size_used', 'size_free'),
+    'lvol': ('size_total', 'size_used', 'size_free'),
+    'pool': ('size_total', 'size_used', 'size_free'),
+}
+
+_CORE_LABELS = _NODE_LABELS + ['core_id']
+_THREAD_LABELS = _CORE_LABELS + ['thread_name']
+
+# Each entry pairs the metric with a literal-key accessor. A loop over variable
+# keys would defeat the TypedDict: mypy widens `reactor.get(key)` to `object`
+# when the key is not a literal, so the field names would go unchecked.
+#
+# The accessors return None for a key an older collector never wrote. That is
+# not zero — for a counter a fabricated 0 reads as a reset — so the caller skips
+# the sample instead, and mypy enforces that by refusing to pass Optional[int]
+# to add_metric.
+#
+# mypy does not check the key of a TypedDict `.get()` (only of a subscript), so
+# a typo here would read as permanently absent rather than failing to compile.
+# test_every_reactor_and_thread_counter_reports pins all six names instead.
+_REACTOR_COUNTERS: Sequence[tuple[str, str, Callable[[ReactorStats], Optional[int]]]] = (
+    ('reactor_busy_ticks', 'Cumulative reactor busy ticks', lambda r: r.get('busy')),
+    ('reactor_idle_ticks', 'Cumulative reactor idle ticks', lambda r: r.get('idle')),
+    ('reactor_irq_ticks', 'Cumulative reactor IRQ ticks', lambda r: r.get('irq')),
+    ('reactor_sys_ticks', 'Cumulative reactor system ticks', lambda r: r.get('sys')),
+)
+
+_THREAD_COUNTERS: Sequence[tuple[str, str, Callable[[ThreadStats], Optional[int]]]] = (
+    ('thread_busy_ticks', 'Cumulative lightweight-thread busy ticks', lambda t: t.get('busy')),
+    ('thread_idle_ticks', 'Cumulative lightweight-thread idle ticks', lambda t: t.get('idle')),
+)
+
+
+def _stat_families(
+    level: str,
+    labelnames: Sequence[str],
+    entries: Iterable[tuple[list[str], dict]],
+) -> Iterator[Metric]:
+    """Yield one IO/capacity family per stat key, populated from `entries`.
+
+    `entries` pairs a label-value list with the newest stat record for that
+    object, as a plain dict.
+    """
+    counters = {
+        key: CounterMetricFamily(f'{NAMESPACE}_{level}_{name}', help_text, labels=list(labelnames))
+        for key, name, help_text in _IO_COUNTERS
+    }
+    size_keys = _SIZE_KEYS_BY_LEVEL[level]
+    gauges = {
+        key: GaugeMetricFamily(f'{NAMESPACE}_{level}_{name}', help_text, labels=list(labelnames))
+        for key, name, help_text in _SIZE_GAUGES
+        if key in size_keys
+    }
+
+    for labelvalues, record in entries:
+        for key, counter in counters.items():
+            if key in record:
+                counter.add_metric(labelvalues, record[key])
+        for key, gauge in gauges.items():
+            if key in record:
+                gauge.add_metric(labelvalues, record[key])
+
+    yield from counters.values()
+    yield from gauges.values()
+
+
+def _status_family(level: str, labelnames: Sequence[str], entries: Iterable[tuple[list[str], object]]) -> Metric:
+    """Status as a labelled indicator rather than the v1 numeric code.
+
+    `<level>_status{status="online"} 1` lets an alert name the state it cares
+    about instead of hardcoding a magic number from `_STATUS_CODE_MAP`, and
+    keeps working when a new status is added to the map.
+    """
+    family = GaugeMetricFamily(
+        f'{NAMESPACE}_{level}_status',
+        f'Current {level} status; 1 on the series carrying the active status label',
+        labels=list(labelnames) + ['status'],
+    )
+    for labelvalues, obj in entries:
+        family.add_metric(labelvalues + [getattr(obj, 'status', '')], 1)
+    return family
+
+
+def _health_family(level: str, labelnames: Sequence[str], entries: Iterable[tuple[list[str], object]]) -> Metric:
+    """Health as a plain 0/1 gauge, omitting objects with no verdict.
+
+    The v1 exporter reported NaN when `health_check` was None so it would not
+    read as unhealthy. Omitting the series says the same thing without asking
+    every consumer to special-case a float.
+    """
+    family = GaugeMetricFamily(
+        f'{NAMESPACE}_{level}_health_check',
+        '1 when the most recent health check passed, 0 when it failed',
+        labels=list(labelnames),
+    )
+    for labelvalues, obj in entries:
+        health = getattr(obj, 'health_check', None)
+        if health is not None:
+            family.add_metric(labelvalues, 1 if health else 0)
+    return family
+
+
+def _threshold_families(entries: Iterable[tuple[list[str], object]]) -> Iterator[Metric]:
+    """Configured capacity thresholds, as ratios to match the byte gauges.
+
+    Persisted as integer percentages on the cluster; `prov_cap_*` exceeds 100
+    by design because provisioning is allowed to overcommit.
+    """
+    families = {
+        'cap_warn': GaugeMetricFamily(
+            f'{NAMESPACE}_cluster_capacity_warning_threshold_ratio',
+            'Configured used-capacity ratio at which a warning is raised',
+            labels=_CLUSTER_LABELS),
+        'cap_crit': GaugeMetricFamily(
+            f'{NAMESPACE}_cluster_capacity_critical_threshold_ratio',
+            'Configured used-capacity ratio at which a critical alert is raised',
+            labels=_CLUSTER_LABELS),
+        'prov_cap_warn': GaugeMetricFamily(
+            f'{NAMESPACE}_cluster_provisioned_capacity_warning_threshold_ratio',
+            'Configured provisioned-capacity ratio at which a warning is raised',
+            labels=_CLUSTER_LABELS),
+        'prov_cap_crit': GaugeMetricFamily(
+            f'{NAMESPACE}_cluster_provisioned_capacity_critical_threshold_ratio',
+            'Configured provisioned-capacity ratio at which a critical alert is raised',
+            labels=_CLUSTER_LABELS),
+    }
+    for labelvalues, cluster in entries:
+        for key, family in families.items():
+            value = getattr(cluster, key, 0)
+            if value:
+                family.add_metric(labelvalues, value / 100)
+    yield from families.values()
+
+
+def _cpu_families(entries: Iterable[tuple[list[str], CpuStats]]) -> Iterator[Metric]:
+    """Reactor and thread tick counters, from the node stat record's cpu_dict.
+
+    Read from FDB like every other series — no RPC on the scrape path. Raw
+    ticks, not percentages: SPDK counts them cumulatively since reactor start,
+    so utilization is `rate(busy) / rate(busy + idle)` at query time.
+    """
+    reactor_families = [
+        (CounterMetricFamily(f'{NAMESPACE}_snode_{name}', help_text, labels=_CORE_LABELS), read)
+        for name, help_text, read in _REACTOR_COUNTERS
+    ]
+    thread_families = [
+        (CounterMetricFamily(f'{NAMESPACE}_snode_{name}', help_text, labels=_THREAD_LABELS), read)
+        for name, help_text, read in _THREAD_COUNTERS
+    ]
+
+    for labelvalues, cpu_dict in entries:
+        # An absent collection legitimately means "none of these"; an absent
+        # measurement does not mean zero. Only the former is defaulted.
+        for reactor in cpu_dict.get('reactors') or []:
+            lcore = reactor.get('lcore')
+            if lcore is None:
+                continue  # cannot identify which core these counters belong to
+            core_labels = labelvalues + [str(lcore)]
+            for family, read_reactor in reactor_families:
+                reactor_ticks = read_reactor(reactor)
+                if reactor_ticks is not None:
+                    family.add_metric(core_labels, reactor_ticks)
+
+            for thread in reactor.get('threads') or []:
+                thread_name = thread.get('name')
+                if thread_name is None:
+                    continue  # cannot label the series without a thread name
+                thread_labels = core_labels + [thread_name]
+                for family, read_thread in thread_families:
+                    thread_ticks = read_thread(thread)
+                    if thread_ticks is not None:
+                        family.add_metric(thread_labels, thread_ticks)
+
+    for family, _ in reactor_families:
+        yield family
+    for family, _ in thread_families:
+        yield family
+
+
+class SimplyblockCollector:
+    """Builds the full metric set from FoundationDB on every scrape."""
+
+    def collect(self) -> Iterator[Metric]:
+        cluster_stats: list[tuple[list[str], dict]] = []
+        cluster_objects: list[tuple[list[str], object]] = []
+        node_stats: list[tuple[list[str], dict]] = []
+        node_objects: list[tuple[list[str], object]] = []
+        cpu_entries: list[tuple[list[str], CpuStats]] = []
+        device_stats: list[tuple[list[str], dict]] = []
+        device_objects: list[tuple[list[str], object]] = []
+        pool_stats: list[tuple[list[str], dict]] = []
+        pool_objects: list[tuple[list[str], object]] = []
+        lvol_stats: list[tuple[list[str], dict]] = []
+        lvol_objects: list[tuple[list[str], object]] = []
+
+        for cluster in db.get_clusters():
+            cluster_labels = [cluster.get_id(), cluster.cluster_name]
+            cluster_objects.append((cluster_labels, cluster))
+            cluster_records = db.get_cluster_stats(cluster, 1)
+            if cluster_records:
+                cluster_stats.append((cluster_labels, cluster_records[0].get_clean_dict()))
+
+            for node in db.get_storage_nodes_by_cluster_id(cluster.get_id()):
+                # Status and health are emitted for every node regardless of
+                # state. The v1 exporter skipped non-ONLINE nodes before setting
+                # anything, so a node going down produced no sample at all —
+                # its series simply went stale, which no alert can distinguish
+                # from a scrape failure.
+                node_labels = cluster_labels + [node.get_id(), node.hostname]
+                node_objects.append((node_labels, node))
+                node_records = db.get_node_stats(node, 1)
+                if node_records:
+                    record = node_records[0]
+                    node_stats.append((node_labels, record.get_clean_dict()))
+                    if record.cpu_dict:
+                        cpu_entries.append((node_labels, record.cpu_dict))
+
+                for device in node.nvme_devices:
+                    device_labels = cluster_labels + [node.get_id(), device.get_id()]
+                    device_objects.append((device_labels, device))
+                    device_records = db.get_device_stats(device, 1)
+                    if device_records:
+                        device_stats.append((device_labels, device_records[0].get_clean_dict()))
+
+            # Scoped to the cluster being iterated. The v1 exporter called an
+            # unfiltered get_pools() inside its per-cluster loop, so every pool
+            # was emitted once per cluster, each time labelled with a different
+            # cluster.
+            for pool in db.get_pools(cluster_id=cluster.get_id()):
+                pool_labels = cluster_labels + [pool.get_id(), pool.pool_name]
+                pool_objects.append((pool_labels, pool))
+                pool_records = db.get_pool_stats(pool, 1)
+                if pool_records:
+                    pool_stats.append((pool_labels, pool_records[0].get_clean_dict()))
+
+            for lvol in db.get_lvols(cluster.get_id()):
+                # `pool` carries the pool uuid, matching the pool-level label.
+                # v1 set it to the pool *name* here but to the pool id on pool
+                # metrics, so the two levels could not be joined on it.
+                lvol_labels = cluster_labels + [
+                    lvol.pool_uuid, lvol.pool_name,
+                    lvol.get_id(), lvol.lvol_name, lvol.pvc_name,
+                ]
+                lvol_objects.append((lvol_labels, lvol))
+                lvol_records = db.get_lvol_stats(lvol, limit=1)
+                if lvol_records:
+                    lvol_stats.append((lvol_labels, lvol_records[0].get_clean_dict()))
+
+        yield from _stat_families('cluster', _CLUSTER_LABELS, cluster_stats)
+        yield _status_family('cluster', _CLUSTER_LABELS, cluster_objects)
+        yield from _threshold_families(cluster_objects)
+
+        yield from _stat_families('snode', _NODE_LABELS, node_stats)
+        yield _status_family('snode', _NODE_LABELS, node_objects)
+        yield _health_family('snode', _NODE_LABELS, node_objects)
+        yield from _cpu_families(cpu_entries)
+
+        yield from _stat_families('device', _DEVICE_LABELS, device_stats)
+        yield _status_family('device', _DEVICE_LABELS, device_objects)
+        yield _health_family('device', _DEVICE_LABELS, device_objects)
+
+        yield from _stat_families('pool', _POOL_LABELS, pool_stats)
+        yield _status_family('pool', _POOL_LABELS, pool_objects)
+
+        yield from _stat_families('lvol', _LVOL_LABELS, lvol_stats)
+        yield _status_family('lvol', _LVOL_LABELS, lvol_objects)
+        yield _health_family('lvol', _LVOL_LABELS, lvol_objects)
+
+
+@api.get('', response_class=Response, include_in_schema=False)
+def metrics() -> Response:
+    """Prometheus scrape endpoint.
+
+    The registry is per-request, so nothing survives between scrapes.
+    """
+    registry = CollectorRegistry()
+    registry.register(SimplyblockCollector())
+    return Response(generate_latest(registry), media_type=CONTENT_TYPE_LATEST)

--- a/simplyblock_web/settings.py
+++ b/simplyblock_web/settings.py
@@ -70,6 +70,19 @@ class Settings(BaseSettings):
         ),
         BeforeValidator(_parse_str_list),
     ] = []
+    k8s_metrics_service_accounts: Annotated[
+        list[str],
+        Field(
+            description=(
+                "Kubernetes service accounts granted read access to the metrics endpoint, "
+                "and nothing else. "
+                "Comma-separated list of fully-qualified names "
+                "(e.g. 'system:serviceaccount:monitoring:prometheus'). "
+                "Admin service accounts hold this access implicitly."
+            )
+        ),
+        BeforeValidator(_parse_str_list),
+    ] = []
 
     @model_validator(mode="after")
     def validate_cluster_secret_auth(self) -> "Settings":

--- a/tests/unit/test_cpu_stat_collection.py
+++ b/tests/unit/test_cpu_stat_collection.py
@@ -1,0 +1,148 @@
+# coding=utf-8
+"""Unit tests for CPU stat collection in the capacity-and-stats collector.
+
+The counters are persisted raw. SPDK reports reactor and thread busy/idle
+cumulatively since start, so a ratio taken here would be an average over the
+process lifetime rather than current load — utilization is derived at query
+time. These tests pin the shape that gets written and, importantly, that no
+value is ever invented for a counter SPDK did not report.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from simplyblock_core.rpc_client import RPCException
+from simplyblock_core.services import capacity_and_stats_collector as collector
+
+
+def _rpc(reactors, threads):
+    client = MagicMock()
+    client.framework_get_reactors.return_value = {'reactors': reactors}
+    client.thread_get_stats.return_value = {'threads': threads}
+    return client
+
+
+REACTOR = {'lcore': 3, 'busy': 700, 'idle': 300, 'irq': 5, 'sys': 10,
+           'lw_threads': [{'id': 1, 'name': 'app_thread'}]}
+THREAD_STATS = [{'id': 1, 'busy': 400, 'idle': 600}]
+
+
+class TestCollectedShape:
+
+    def test_reactor_counters_are_persisted_raw(self):
+        result = collector.get_cpu_stats(_rpc([REACTOR], THREAD_STATS))
+
+        reactor = result['reactors'][0]
+        assert reactor['lcore'] == 3
+        assert reactor['busy'] == 700
+        assert reactor['idle'] == 300
+        assert reactor['irq'] == 5
+        assert reactor['sys'] == 10
+
+    def test_thread_counters_are_matched_by_id(self):
+        result = collector.get_cpu_stats(_rpc([REACTOR], THREAD_STATS))
+
+        thread = result['reactors'][0]['threads'][0]
+        assert thread == {'id': 1, 'name': 'app_thread', 'busy': 400, 'idle': 600}
+
+    def test_no_percentage_is_computed(self):
+        """A ratio over counters cumulative since reactor start would be a
+        lifetime average, not current load."""
+        result = collector.get_cpu_stats(_rpc([REACTOR], THREAD_STATS))
+
+        assert set(result['reactors'][0]) == {
+            'lcore', 'busy', 'idle', 'irq', 'sys', 'threads'}
+
+    def test_multiple_reactors_and_threads(self):
+        second = dict(REACTOR, lcore=4, lw_threads=[{'id': 2, 'name': 'poller'}])
+        result = collector.get_cpu_stats(
+            _rpc([REACTOR, second], THREAD_STATS + [{'id': 2, 'busy': 1, 'idle': 2}]))
+
+        assert [r['lcore'] for r in result['reactors']] == [3, 4]
+        assert result['reactors'][1]['threads'][0]['name'] == 'poller'
+
+
+class TestAbsentValuesAreOmittedNotDefaulted:
+
+    def test_thread_without_stats_omits_its_counters(self):
+        """A thread present in the reactor listing but absent from
+        thread_get_stats appeared between the two calls. Its counters are
+        unknown — recording 0 would read as a genuine zero, and on a counter as
+        a reset."""
+        result = collector.get_cpu_stats(_rpc([REACTOR], []))
+
+        thread = result['reactors'][0]['threads'][0]
+        assert thread == {'id': 1, 'name': 'app_thread'}
+        assert 'busy' not in thread
+        assert 'idle' not in thread
+
+    def test_reactor_with_no_threads_yields_an_empty_list(self):
+        """An absent collection does mean 'none of these', unlike a measurement."""
+        result = collector.get_cpu_stats(
+            _rpc([dict(REACTOR, lw_threads=[])], THREAD_STATS))
+
+        assert result['reactors'][0]['threads'] == []
+
+    def test_missing_reactor_field_raises_rather_than_defaulting(self):
+        """The caller turns this into 'no CPU data for this cycle'."""
+        incomplete = {k: v for k, v in REACTOR.items() if k != 'irq'}
+
+        with pytest.raises(KeyError):
+            collector.get_cpu_stats(_rpc([incomplete], THREAD_STATS))
+
+    def test_empty_reply_yields_no_reactors(self):
+        client = MagicMock()
+        client.framework_get_reactors.return_value = None
+        client.thread_get_stats.return_value = None
+
+        with pytest.raises(KeyError):
+            collector.get_cpu_stats(client)
+
+    def test_rpc_failure_propagates(self):
+        client = MagicMock()
+        client.framework_get_reactors.side_effect = RPCException('unreachable')
+
+        with pytest.raises(RPCException):
+            collector.get_cpu_stats(client)
+
+
+class TestNodeRecord:
+
+    def test_cpu_dict_is_stored_on_the_node_record(self, monkeypatch):
+        monkeypatch.setattr(collector, 'db', MagicMock())
+        cpu: dict = {'reactors': [{'lcore': 0, 'busy': 1, 'idle': 2}]}
+        cluster, node = MagicMock(), MagicMock()
+        cluster.get_id.return_value = 'c1'
+        node.get_id.return_value = 'n1'
+
+        record = collector.add_node_stats(cluster, node, [], [], cpu)
+
+        assert record.cpu_dict == cpu
+
+    def test_absent_cpu_data_is_stored_empty(self, monkeypatch):
+        """Empty, not {'reactors': []} — the latter would assert the node has
+        zero reactors, which a failed RPC does not tell us."""
+        monkeypatch.setattr(collector, 'db', MagicMock())
+        cluster, node = MagicMock(), MagicMock()
+        cluster.get_id.return_value = 'c1'
+        node.get_id.return_value = 'n1'
+
+        record = collector.add_node_stats(cluster, node, [], [], None)
+
+        assert record.cpu_dict == {}
+
+    def test_cpu_dict_does_not_reach_the_cluster_roll_up(self):
+        """__add__ sums int/float attributes; a scalar CPU field would become a
+        meaningless cluster total. A dict is skipped."""
+        from simplyblock_core.models.stats import NodeStatObject
+
+        a = NodeStatObject(data={'uuid': 'n1', 'cluster_id': 'c1', 'read_bytes': 5,
+                                 'cpu_dict': {'reactors': [{'lcore': 0}]}})
+        b = NodeStatObject(data={'uuid': 'n2', 'cluster_id': 'c1', 'read_bytes': 7,
+                                 'cpu_dict': {'reactors': [{'lcore': 1}]}})
+
+        combined = a + b
+
+        assert combined.read_bytes == 12
+        assert not combined.to_dict().get('cpu_dict')

--- a/tests/unit/web/api/test_settings.py
+++ b/tests/unit/web/api/test_settings.py
@@ -81,6 +81,34 @@ class TestSettings:
         assert s.k8s_admin_service_accounts == ["system:serviceaccount:default:my-operator"]
 
 
+class TestMetricsServiceAccountsSetting:
+    def test_default_is_empty_list(self, monkeypatch):
+        monkeypatch.delenv("SB_K8S_METRICS_SERVICE_ACCOUNTS", raising=False)
+        s = Settings()
+        assert s.k8s_metrics_service_accounts == []
+
+    def test_parses_env_var(self, monkeypatch):
+        monkeypatch.setenv(
+            "SB_K8S_METRICS_SERVICE_ACCOUNTS",
+            "system:serviceaccount:monitoring:prometheus,system:serviceaccount:ns:agent",
+        )
+        s = Settings()
+        assert s.k8s_metrics_service_accounts == [
+            "system:serviceaccount:monitoring:prometheus",
+            "system:serviceaccount:ns:agent",
+        ]
+
+    def test_independent_of_admin_accounts(self, monkeypatch):
+        monkeypatch.setenv("SB_K8S_ADMIN_SERVICE_ACCOUNTS", "system:serviceaccount:default:op")
+        monkeypatch.setenv(
+            "SB_K8S_METRICS_SERVICE_ACCOUNTS",
+            "system:serviceaccount:monitoring:prometheus",
+        )
+        s = Settings()
+        assert s.k8s_admin_service_accounts == ["system:serviceaccount:default:op"]
+        assert s.k8s_metrics_service_accounts == ["system:serviceaccount:monitoring:prometheus"]
+
+
 class TestApiVersionsSetting:
     def test_default_is_all_versions(self, monkeypatch):
         monkeypatch.delenv("SB_API_VERSIONS", raising=False)

--- a/tests/unit/web/api/v2/conftest.py
+++ b/tests/unit/web/api/v2/conftest.py
@@ -38,6 +38,7 @@ import simplyblock_web.api.v2.cluster.storage_pool.volume as volume_module
 import simplyblock_web.api.v2.cluster.subsystem.migration as migration_module
 import simplyblock_web.api.v2.cluster.task as task_module
 import simplyblock_web.api.v2.management_node as management_node_module
+import simplyblock_web.api.v2.metrics as metrics_module
 
 from tests.unit.web.api.v2 import _factories as factories
 
@@ -83,6 +84,7 @@ def db(monkeypatch):
         volume_module,
         task_module,
         management_node_module,
+        metrics_module,
     ):
         monkeypatch.setattr(module, 'db', mock)
     monkeypatch.setattr(migration_module, '_db', mock)

--- a/tests/unit/web/api/v2/conftest.py
+++ b/tests/unit/web/api/v2/conftest.py
@@ -104,6 +104,7 @@ def app():
     app = FastAPI()
     app.include_router(v2.api, prefix='/api/v2')
     app.dependency_overrides[auth_module.verify_api_token] = lambda: None
+    app.dependency_overrides[auth_module.verify_metrics_token] = lambda: None
     return app
 
 

--- a/tests/unit/web/api/v2/test_auth.py
+++ b/tests/unit/web/api/v2/test_auth.py
@@ -224,3 +224,77 @@ class TestVerifyApiToken:
             with pytest.raises(HTTPException) as exc_info:
                 auth.verify_api_token(sa_name=None, authorized_cluster_id=None, cluster_id=None)
         assert exc_info.value.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# verify_metrics_token
+# ---------------------------------------------------------------------------
+
+class TestVerifyMetricsToken:
+    """The metrics gate is wider than the general one, and only wider there.
+
+    Every test that admits the metrics service account is paired with the same
+    principal being refused by `verify_api_token`, since the split is only
+    worth anything if the scrape credential stays confined to the exporter.
+    """
+
+    _ADMIN_SA = "system:serviceaccount:default:op"
+    _METRICS_SA = "system:serviceaccount:monitoring:prometheus"
+
+    def _settings(self, admins: list[str], metrics: list[str]) -> MagicMock:
+        s = MagicMock()
+        s.k8s_admin_service_accounts = admins
+        s.k8s_metrics_service_accounts = metrics
+        return s
+
+    def _both_lists(self) -> MagicMock:
+        return self._settings([self._ADMIN_SA], [self._METRICS_SA])
+
+    def test_passes_for_metrics_sa(self):
+        import simplyblock_web.api.v2._auth as auth
+
+        with patch.object(auth, "_web_settings", self._both_lists()):
+            auth.verify_metrics_token(sa_name=self._METRICS_SA, authorized_cluster_id=None)
+
+    def test_metrics_sa_is_refused_by_the_general_gate(self):
+        import simplyblock_web.api.v2._auth as auth
+
+        with patch.object(auth, "_web_settings", self._both_lists()):
+            with pytest.raises(HTTPException) as exc_info:
+                auth.verify_api_token(
+                    sa_name=self._METRICS_SA,
+                    authorized_cluster_id=None,
+                    cluster_id=None,
+                )
+        assert exc_info.value.status_code == 401
+
+    def test_passes_for_admin_sa(self):
+        import simplyblock_web.api.v2._auth as auth
+
+        with patch.object(auth, "_web_settings", self._both_lists()):
+            auth.verify_metrics_token(sa_name=self._ADMIN_SA, authorized_cluster_id=None)
+
+    def test_passes_for_cluster_auth(self):
+        import simplyblock_web.api.v2._auth as auth
+
+        with patch.object(auth, "_web_settings", self._both_lists()):
+            auth.verify_metrics_token(sa_name=None, authorized_cluster_id=uuid4())
+
+    def test_raises_401_for_unlisted_sa(self):
+        import simplyblock_web.api.v2._auth as auth
+
+        with patch.object(auth, "_web_settings", self._both_lists()):
+            with pytest.raises(HTTPException) as exc_info:
+                auth.verify_metrics_token(
+                    sa_name="system:serviceaccount:default:stranger",
+                    authorized_cluster_id=None,
+                )
+        assert exc_info.value.status_code == 401
+
+    def test_raises_401_when_metrics_list_is_empty(self):
+        import simplyblock_web.api.v2._auth as auth
+
+        with patch.object(auth, "_web_settings", self._settings([self._ADMIN_SA], [])):
+            with pytest.raises(HTTPException) as exc_info:
+                auth.verify_metrics_token(sa_name=self._METRICS_SA, authorized_cluster_id=None)
+        assert exc_info.value.status_code == 401

--- a/tests/unit/web/api/v2/test_metrics_endpoint.py
+++ b/tests/unit/web/api/v2/test_metrics_endpoint.py
@@ -1,0 +1,457 @@
+# coding=utf-8
+"""Unit tests for the v2 Prometheus exporter.
+
+The exporter's contract is not only "emits the right numbers" but also "emits
+nothing for objects that are gone" — the property the v1 exporter could not
+hold, because retained Gauge children outlive the objects they describe. The
+statelessness tests below are the regression guard for that.
+"""
+
+from simplyblock_core.models.stats import (
+    ClusterStatObject,
+    DeviceStatObject,
+    LVolStatObject,
+    NodeStatObject,
+    PoolStatObject,
+)
+from simplyblock_core.models.storage_node import StorageNode
+
+
+METRICS_URL = '/api/v2/metrics'
+
+
+def _samples(body, name):
+    """Every `metric_name{labels} value` line for one metric name."""
+    prefix = name + '{'
+    return [
+        line for line in body.splitlines()
+        if line.startswith(prefix) or line.startswith(name + ' ')
+    ]
+
+
+def _value(body, name, **labels):
+    """The single value of `name` whose label set contains all of `labels`."""
+    matches = [
+        line for line in _samples(body, name)
+        if all(f'{k}="{v}"' in line for k, v in labels.items())
+    ]
+    assert len(matches) == 1, f'expected one {name} sample for {labels}, got {matches}'
+    return float(matches[0].rsplit(' ', 1)[1])
+
+
+def _no_stats(db):
+    for accessor in (
+        'get_cluster_stats', 'get_node_stats', 'get_device_stats',
+        'get_pool_stats', 'get_lvol_stats',
+    ):
+        getattr(db, accessor).return_value = []
+
+
+class TestExportedValues:
+
+    def test_cluster_io_counters_and_capacity(self, client, db, cluster):
+        _no_stats(db)
+        db.get_storage_nodes_by_cluster_id.return_value = []
+        db.get_pools.return_value = []
+        db.get_lvols.return_value = []
+        db.get_cluster_stats.return_value = [ClusterStatObject(data={
+            'uuid': cluster.get_id(),
+            'cluster_id': cluster.get_id(),
+            'read_bytes': 4096,
+            'read_io': 8,
+            'read_latency_ticks': 800,
+            'size_total': 1000,
+            'size_used': 250,
+            'size_free': 750,
+        })]
+
+        body = client.get(METRICS_URL).text
+
+        assert _value(body, 'simplyblock_cluster_read_bytes_total', cluster=cluster.get_id()) == 4096
+        assert _value(body, 'simplyblock_cluster_read_operations_total', cluster=cluster.get_id()) == 8
+        assert _value(body, 'simplyblock_cluster_read_latency_ticks_total', cluster=cluster.get_id()) == 800
+        assert _value(body, 'simplyblock_cluster_size_used_bytes', cluster=cluster.get_id()) == 250
+
+    def test_io_counters_are_typed_as_counters(self, client, db, cluster):
+        """`rate()` needs the counter type to handle an SPDK restart."""
+        _no_stats(db)
+        db.get_storage_nodes_by_cluster_id.return_value = []
+        db.get_pools.return_value = []
+        db.get_lvols.return_value = []
+
+        body = client.get(METRICS_URL).text
+
+        assert '# TYPE simplyblock_cluster_read_bytes_total counter' in body
+        assert '# TYPE simplyblock_cluster_size_used_bytes gauge' in body
+
+    def test_derived_rate_fields_are_not_exported(self, client, db, cluster):
+        """The collectors' `_ps` fields are superseded by rate() over counters."""
+        _no_stats(db)
+        db.get_storage_nodes_by_cluster_id.return_value = []
+        db.get_pools.return_value = []
+        db.get_lvols.return_value = []
+        db.get_cluster_stats.return_value = [ClusterStatObject(data={
+            'uuid': cluster.get_id(), 'read_bytes_ps': 999, 'read_latency_ps': 42,
+        })]
+
+        body = client.get(METRICS_URL).text
+
+        assert 'read_bytes_ps' not in body
+        assert 'read_latency_ps' not in body
+        # `date` and the never-populated record_* fields are metadata, not metrics
+        assert 'simplyblock_cluster_date' not in body
+        assert 'record_duration' not in body
+
+    def test_capacity_percentages_are_not_exported(self, client, db, cluster):
+        """size_util is int-truncated in FDB; PromQL divides the byte gauges exactly."""
+        _no_stats(db)
+        db.get_storage_nodes_by_cluster_id.return_value = []
+        db.get_pools.return_value = []
+        db.get_lvols.return_value = []
+        db.get_cluster_stats.return_value = [ClusterStatObject(data={
+            'uuid': cluster.get_id(), 'size_util': 25, 'size_prov_util': 50,
+        })]
+
+        body = client.get(METRICS_URL).text
+
+        assert 'size_util' not in body
+        assert 'size_prov_util' not in body
+
+    def test_thresholds_exported_as_ratios(self, client, db, cluster):
+        _no_stats(db)
+        db.get_storage_nodes_by_cluster_id.return_value = []
+        db.get_pools.return_value = []
+        db.get_lvols.return_value = []
+        cluster.cap_crit = 90
+        cluster.prov_cap_crit = 190
+
+        body = client.get(METRICS_URL).text
+
+        assert _value(
+            body, 'simplyblock_cluster_capacity_critical_threshold_ratio',
+            cluster=cluster.get_id(),
+        ) == 0.9
+        assert _value(
+            body, 'simplyblock_cluster_provisioned_capacity_critical_threshold_ratio',
+            cluster=cluster.get_id(),
+        ) == 1.9
+
+    def test_provisioned_size_omitted_where_collector_never_sets_it(
+        self, client, db, cluster, storage_node, device,
+    ):
+        """A zero default must not be published as a real measurement."""
+        _no_stats(db)
+        db.get_pools.return_value = []
+        db.get_lvols.return_value = []
+        db.get_device_stats.return_value = [DeviceStatObject(data={
+            'uuid': device.get_id(), 'size_total': 100, 'size_used': 10,
+        })]
+
+        body = client.get(METRICS_URL).text
+
+        assert _samples(body, 'simplyblock_device_size_total_bytes')
+        assert not _samples(body, 'simplyblock_device_size_provisioned_bytes')
+        assert 'simplyblock_snode_size_provisioned_bytes' in body
+
+
+class TestStatusAndHealth:
+
+    def test_offline_node_still_reports_status(self, client, db, cluster, storage_node):
+        """v1 skipped non-ONLINE nodes entirely, so a node going down emitted
+        nothing and its series merely went stale — indistinguishable from a
+        failed scrape."""
+        _no_stats(db)
+        db.get_pools.return_value = []
+        db.get_lvols.return_value = []
+        storage_node.status = StorageNode.STATUS_OFFLINE
+        storage_node.nvme_devices = []
+
+        body = client.get(METRICS_URL).text
+
+        assert _value(
+            body, 'simplyblock_snode_status',
+            snode=storage_node.get_id(), status=StorageNode.STATUS_OFFLINE,
+        ) == 1
+
+    def test_node_with_no_devices_still_reports_status(self, client, db, cluster, storage_node):
+        _no_stats(db)
+        db.get_pools.return_value = []
+        db.get_lvols.return_value = []
+        storage_node.nvme_devices = []
+
+        body = client.get(METRICS_URL).text
+
+        assert _samples(body, 'simplyblock_snode_status')
+
+    def test_health_check_omitted_when_undetermined(self, client, db, cluster, storage_node):
+        """v1 reported NaN here; absence says the same without a float sentinel."""
+        _no_stats(db)
+        db.get_pools.return_value = []
+        db.get_lvols.return_value = []
+        storage_node.nvme_devices = []
+        storage_node.health_check = None
+
+        body = client.get(METRICS_URL).text
+
+        assert not _samples(body, 'simplyblock_snode_health_check')
+
+    def test_health_check_is_binary(self, client, db, cluster, storage_node):
+        _no_stats(db)
+        db.get_pools.return_value = []
+        db.get_lvols.return_value = []
+        storage_node.nvme_devices = []
+        storage_node.health_check = False
+
+        body = client.get(METRICS_URL).text
+
+        assert _value(
+            body, 'simplyblock_snode_health_check', snode=storage_node.get_id(),
+        ) == 0
+
+
+class TestLabelling:
+
+    def test_pools_scoped_to_their_cluster(self, client, db, cluster, pool):
+        """v1 called an unfiltered get_pools() inside its per-cluster loop, so
+        every pool was emitted once per cluster under a different label."""
+        _no_stats(db)
+        db.get_storage_nodes_by_cluster_id.return_value = []
+        db.get_lvols.return_value = []
+        db.get_pool_stats.return_value = [PoolStatObject(data={
+            'uuid': pool.get_id(), 'size_used': 7,
+        })]
+
+        client.get(METRICS_URL)
+
+        db.get_pools.assert_called_with(cluster_id=cluster.get_id())
+
+    def test_volume_pool_label_is_the_pool_uuid(self, client, db, cluster, pool, volume):
+        """v1 set `pool` to the pool name on volume metrics but to the pool id
+        on pool metrics, so the two levels could not be joined on it."""
+        _no_stats(db)
+        db.get_storage_nodes_by_cluster_id.return_value = []
+        db.get_lvol_stats.return_value = [LVolStatObject(data={
+            'uuid': volume.get_id(), 'pool_id': pool.get_id(), 'size_used': 3,
+        })]
+        db.get_pool_stats.return_value = [PoolStatObject(data={
+            'uuid': pool.get_id(), 'size_used': 3,
+        })]
+
+        body = client.get(METRICS_URL).text
+
+        assert _value(
+            body, 'simplyblock_lvol_size_used_bytes',
+            lvol=volume.get_id(), pool=pool.get_id(),
+        ) == 3
+        assert _value(
+            body, 'simplyblock_pool_size_used_bytes', pool=pool.get_id(),
+        ) == 3
+
+    def test_volume_carries_pool_name_for_human_facing_filters(
+        self, client, db, cluster, pool, volume,
+    ):
+        """The lvols dashboard's pool dropdown reads this label; v1 got names
+        from `pool` itself, which now holds the uuid."""
+        _no_stats(db)
+        db.get_storage_nodes_by_cluster_id.return_value = []
+        db.get_pools.return_value = []
+        db.get_lvol_stats.return_value = [LVolStatObject(data={
+            'uuid': volume.get_id(), 'pool_id': pool.get_id(), 'size_used': 3,
+        })]
+
+        body = client.get(METRICS_URL).text
+
+        assert _value(
+            body, 'simplyblock_lvol_size_used_bytes',
+            lvol=volume.get_id(), pool_name=volume.pool_name,
+        ) == 3
+
+
+class TestCpuMetrics:
+
+    def test_every_reactor_and_thread_counter_reports(
+        self, client, db, cluster, storage_node,
+    ):
+        """No RPC on the scrape path: CPU is read from FDB like everything else.
+
+        Asserts all six counters with distinct values. mypy cannot check the key
+        of a TypedDict `.get()`, so a typo in one of the accessors in
+        `_REACTOR_COUNTERS` / `_THREAD_COUNTERS` would silently read as absent —
+        this test is what catches that.
+        """
+        _no_stats(db)
+        db.get_pools.return_value = []
+        db.get_lvols.return_value = []
+        storage_node.nvme_devices = []
+        db.get_node_stats.return_value = [NodeStatObject(data={
+            'uuid': storage_node.get_id(),
+            'cpu_dict': {'reactors': [{
+                'lcore': 3, 'busy': 700, 'idle': 300, 'irq': 5, 'sys': 10,
+                'threads': [{'id': 1, 'name': 'app_thread', 'busy': 400, 'idle': 600}],
+            }]},
+        })]
+
+        body = client.get(METRICS_URL).text
+        node, core = storage_node.get_id(), '3'
+
+        for metric, expected in [
+            ('reactor_busy_ticks_total', 700),
+            ('reactor_idle_ticks_total', 300),
+            ('reactor_irq_ticks_total', 5),
+            ('reactor_sys_ticks_total', 10),
+        ]:
+            assert _value(
+                body, f'simplyblock_snode_{metric}', snode=node, core_id=core,
+            ) == expected, metric
+
+        for metric, expected in [
+            ('thread_busy_ticks_total', 400),
+            ('thread_idle_ticks_total', 600),
+        ]:
+            assert _value(
+                body, f'simplyblock_snode_{metric}',
+                snode=node, core_id=core, thread_name='app_thread',
+            ) == expected, metric
+
+    def test_cpu_exported_as_raw_ticks_not_a_percentage(
+        self, client, db, cluster, storage_node,
+    ):
+        """SPDK counts ticks cumulatively since reactor start, so a ratio taken
+        at collection time is a lifetime average, not current load."""
+        _no_stats(db)
+        db.get_pools.return_value = []
+        db.get_lvols.return_value = []
+        storage_node.nvme_devices = []
+        db.get_node_stats.return_value = [NodeStatObject(data={
+            'uuid': storage_node.get_id(),
+            'cpu_dict': {'reactors': [{'lcore': 0, 'busy': 700, 'idle': 300, 'threads': []}]},
+        })]
+
+        body = client.get(METRICS_URL).text
+
+        assert 'cpu_busy_percentage' not in body
+        assert 'cpu_core_utilization' not in body
+        assert '# TYPE simplyblock_snode_reactor_busy_ticks_total counter' in body
+
+    def test_absent_counter_is_omitted_rather_than_reported_as_zero(
+        self, client, db, cluster, storage_node,
+    ):
+        """CpuStats marks every key optional because records come back from FDB
+        and may predate a field. A missing counter must produce no sample: 0
+        would be indistinguishable from a genuine zero, and on a counter it
+        reads as a reset."""
+        _no_stats(db)
+        db.get_pools.return_value = []
+        db.get_lvols.return_value = []
+        storage_node.nvme_devices = []
+        db.get_node_stats.return_value = [NodeStatObject(data={
+            'uuid': storage_node.get_id(),
+            'cpu_dict': {'reactors': [{      # no irq/sys, as an older record
+                'lcore': 0, 'busy': 700, 'idle': 300,
+                'threads': [{'id': 1, 'name': 'app_thread', 'busy': 400}],
+            }]},
+        })]
+
+        body = client.get(METRICS_URL).text
+
+        assert _value(
+            body, 'simplyblock_snode_reactor_busy_ticks_total', core_id='0') == 700
+        assert not _samples(body, 'simplyblock_snode_reactor_irq_ticks_total')
+        assert not _samples(body, 'simplyblock_snode_reactor_sys_ticks_total')
+        # the present sibling still reports, and idle is untouched
+        assert _value(
+            body, 'simplyblock_snode_thread_busy_ticks_total',
+            thread_name='app_thread') == 400
+        assert not _samples(body, 'simplyblock_snode_thread_idle_ticks_total')
+
+    def test_reactor_without_lcore_is_skipped(self, client, db, cluster, storage_node):
+        """There is no correct core_id to label the series with."""
+        _no_stats(db)
+        db.get_pools.return_value = []
+        db.get_lvols.return_value = []
+        storage_node.nvme_devices = []
+        db.get_node_stats.return_value = [NodeStatObject(data={
+            'uuid': storage_node.get_id(),
+            'cpu_dict': {'reactors': [{'busy': 700, 'idle': 300}]},
+        })]
+
+        body = client.get(METRICS_URL).text
+
+        assert not _samples(body, 'simplyblock_snode_reactor_busy_ticks_total')
+
+    def test_thread_without_name_is_skipped(self, client, db, cluster, storage_node):
+        _no_stats(db)
+        db.get_pools.return_value = []
+        db.get_lvols.return_value = []
+        storage_node.nvme_devices = []
+        db.get_node_stats.return_value = [NodeStatObject(data={
+            'uuid': storage_node.get_id(),
+            'cpu_dict': {'reactors': [{
+                'lcore': 0, 'busy': 700, 'threads': [{'id': 1, 'busy': 400}]}]},
+        })]
+
+        body = client.get(METRICS_URL).text
+
+        assert _samples(body, 'simplyblock_snode_reactor_busy_ticks_total')
+        assert not _samples(body, 'simplyblock_snode_thread_busy_ticks_total')
+
+    def test_node_without_cpu_data_emits_no_cpu_series(
+        self, client, db, cluster, storage_node,
+    ):
+        _no_stats(db)
+        db.get_pools.return_value = []
+        db.get_lvols.return_value = []
+        storage_node.nvme_devices = []
+        db.get_node_stats.return_value = [NodeStatObject(data={'uuid': storage_node.get_id()})]
+
+        body = client.get(METRICS_URL).text
+
+        assert not _samples(body, 'simplyblock_snode_reactor_busy_ticks_total')
+
+
+class TestStatelessness:
+
+    def test_deleted_object_disappears_from_the_next_scrape(
+        self, client, db, cluster, pool, volume,
+    ):
+        """The core regression guard. With retained Gauge children a deleted
+        volume keeps reporting its last value until the process restarts."""
+        _no_stats(db)
+        db.get_storage_nodes_by_cluster_id.return_value = []
+        db.get_lvol_stats.return_value = [LVolStatObject(data={
+            'uuid': volume.get_id(), 'pool_id': pool.get_id(), 'size_used': 5,
+        })]
+
+        first = client.get(METRICS_URL).text
+        assert _samples(first, 'simplyblock_lvol_size_used_bytes')
+
+        db.get_lvols.return_value = []
+        db.get_lvol_stats.return_value = []
+        second = client.get(METRICS_URL).text
+
+        assert not _samples(second, 'simplyblock_lvol_size_used_bytes')
+        assert volume.get_id() not in second
+
+    def test_repeated_scrapes_do_not_accumulate_series(self, client, db, cluster, pool, volume):
+        _no_stats(db)
+        db.get_storage_nodes_by_cluster_id.return_value = []
+        db.get_lvol_stats.return_value = [LVolStatObject(data={
+            'uuid': volume.get_id(), 'pool_id': pool.get_id(), 'size_used': 5,
+        })]
+
+        first = client.get(METRICS_URL).text
+        second = client.get(METRICS_URL).text
+
+        assert _samples(first, 'simplyblock_lvol_size_used_bytes') == \
+            _samples(second, 'simplyblock_lvol_size_used_bytes')
+
+    def test_scrape_is_served_as_prometheus_text(self, client, db, cluster):
+        _no_stats(db)
+        db.get_storage_nodes_by_cluster_id.return_value = []
+        db.get_pools.return_value = []
+        db.get_lvols.return_value = []
+
+        response = client.get(METRICS_URL)
+
+        assert response.status_code == 200
+        assert response.headers['content-type'].startswith('text/plain')


### PR DESCRIPTION
The metrics that are exported for Prometheus were missing from API v2. This PR introduces them. Because of some issues with the v1 metrics, they are iterated on and both versions are not compatible:
- Dropped `size_util`/`size_prov_util`: v1's were lossy (`int(used/total*100)`), making them coarse for graphs. Dividing the byte gauges is exact.
- Status as `{status="degraded"}` label instead of numeric code. The label doesn't hardcode magic numbers and survives map changes.
- `health_check` absent instead of `NaN`: Same information, no float sentinel for consumers to special-case.
- Dropped `date`, `record_duration`, `record_start_time`, `record_end_time`: Metadata, the `record_*` trio was never populated by any collector.
- `simplyblock_` namespace: Avoids collision with the node and foundationdb jobs and allows coexistence with v1 metrics.
- Added pool_name to volume series: Preserves the human-readable $pool dropdown that v1 got for free from its (otherwise buggy) label.

Because there is no upgrade path for the prometheus config this will require manual intervention on upgrade. I'll do a follow up PR on the operator to point the helm charts in the right direction.

Part of the changes moves the CPU stats collection to the monitoring service, s.t. the endpoint only interacts with foundationdb.