### PR TITLE
fix: sync Pool->StoragePool CRD rename and maxLogicalVolumeCount->maxSubsystemCount field rename

### DIFF
--- a/.github/workflows/k8s-native-cross-cluster-restore.yaml
+++ b/.github/workflows/k8s-native-cross-cluster-restore.yaml
@@ -689,7 +689,7 @@ jobs:
           ${BACKUP_SPEC}
           ---
           apiVersion: storage.simplyblock.io/v1alpha1
-          kind: Pool
+          kind: StoragePool
           metadata:
             name: simplyblock-pool
             namespace: ${NS_C1}
@@ -710,7 +710,7 @@ jobs:
             mgmtIfname: ${MGMT_IFC}
             dataIfname:
               - ${DATA_NICS}
-            maxLogicalVolumeCount: ${MAX_LVOL}
+            maxSubsystemCount: ${MAX_LVOL}
             partitions: ${PARTITIONS}
             corePercentage: ${CORE_PERCENTAGE}
             journalManager:
@@ -784,7 +784,7 @@ jobs:
           ${BACKUP_SPEC}
           ---
           apiVersion: storage.simplyblock.io/v1alpha1
-          kind: Pool
+          kind: StoragePool
           metadata:
             name: simplyblock-pool
             namespace: ${NS_C2}
@@ -805,7 +805,7 @@ jobs:
             mgmtIfname: ${MGMT_IFC}
             dataIfname:
               - ${DATA_NICS}
-            maxLogicalVolumeCount: ${MAX_LVOL}
+            maxSubsystemCount: ${MAX_LVOL}
             partitions: ${PARTITIONS}
             corePercentage: ${CORE_PERCENTAGE}
             journalManager:

--- a/.github/workflows/k8s-native-e2e-add-node.yaml
+++ b/.github/workflows/k8s-native-e2e-add-node.yaml
@@ -971,7 +971,7 @@ jobs:
               baseURL: \"https://openbao.vault:8200\""
             ENCRYPTION_POOL_YAML="---
           apiVersion: storage.simplyblock.io/v1alpha1
-          kind: Pool
+          kind: StoragePool
           metadata:
             name: encryption-pool
             namespace: ${NAMESPACE}
@@ -1006,7 +1006,7 @@ jobs:
           ${VAULT_SETTINGS}
           ---
           apiVersion: storage.simplyblock.io/v1alpha1
-          kind: Pool
+          kind: StoragePool
           metadata:
             name: simplyblock-pool
             namespace: ${NAMESPACE}
@@ -1029,7 +1029,7 @@ jobs:
             mgmtIfname: ${MGMT_IFC}
             dataIfname:
               - ${DATA_NICS}
-            maxLogicalVolumeCount: ${MAX_LVOL}
+            maxSubsystemCount: ${MAX_LVOL}
           ${RESERVED_CPU_YAML}
             partitions: ${PARTITIONS}
             corePercentage: ${CORE_PERCENTAGE}

--- a/.github/workflows/k8s-native-e2e-node-migration.yaml
+++ b/.github/workflows/k8s-native-e2e-node-migration.yaml
@@ -967,7 +967,7 @@ jobs:
               baseURL: \"https://openbao.vault:8200\""
             ENCRYPTION_POOL_YAML="---
           apiVersion: storage.simplyblock.io/v1alpha1
-          kind: Pool
+          kind: StoragePool
           metadata:
             name: encryption-pool
             namespace: ${NAMESPACE}
@@ -1002,7 +1002,7 @@ jobs:
           ${VAULT_SETTINGS}
           ---
           apiVersion: storage.simplyblock.io/v1alpha1
-          kind: Pool
+          kind: StoragePool
           metadata:
             name: simplyblock-pool
             namespace: ${NAMESPACE}
@@ -1025,7 +1025,7 @@ jobs:
             mgmtIfname: ${MGMT_IFC}
             dataIfname:
               - ${DATA_NICS}
-            maxLogicalVolumeCount: ${MAX_LVOL}
+            maxSubsystemCount: ${MAX_LVOL}
           ${RESERVED_CPU_YAML}
             partitions: ${PARTITIONS}
             corePercentage: ${CORE_PERCENTAGE}

--- a/.github/workflows/k8s-native-e2e.yaml
+++ b/.github/workflows/k8s-native-e2e.yaml
@@ -878,7 +878,7 @@ jobs:
               baseURL: \"https://openbao.vault:8200\""
             ENCRYPTION_POOL_YAML="---
           apiVersion: storage.simplyblock.io/v1alpha1
-          kind: Pool
+          kind: StoragePool
           metadata:
             name: encryption-pool
             namespace: ${NAMESPACE}
@@ -913,7 +913,7 @@ jobs:
           ${VAULT_SETTINGS}
           ---
           apiVersion: storage.simplyblock.io/v1alpha1
-          kind: Pool
+          kind: StoragePool
           metadata:
             name: simplyblock-pool
             namespace: ${NAMESPACE}
@@ -936,7 +936,7 @@ jobs:
             mgmtIfname: ${MGMT_IFC}
             dataIfname:
               - ${DATA_NICS}
-            maxLogicalVolumeCount: ${MAX_LVOL}
+            maxSubsystemCount: ${MAX_LVOL}
           ${RESERVED_CPU_YAML}
             partitions: ${PARTITIONS}
             corePercentage: ${CORE_PERCENTAGE}
@@ -977,7 +977,7 @@ jobs:
           ${VAULT_SETTINGS}
           ---
           apiVersion: storage.simplyblock.io/v1alpha1
-          kind: Pool
+          kind: StoragePool
           metadata:
             name: simplyblock-pool
             namespace: ${NAMESPACE}
@@ -1000,7 +1000,7 @@ jobs:
             mgmtIfname: ${MGMT_IFC}
             dataIfname:
               - ${DATA_NICS}
-            maxLogicalVolumeCount: ${MAX_LVOL}
+            maxSubsystemCount: ${MAX_LVOL}
           ${RESERVED_CPU_YAML}
             partitions: ${PARTITIONS}
             corePercentage: ${CORE_PERCENTAGE}

--- a/.github/workflows/k8s-native-stress.yaml
+++ b/.github/workflows/k8s-native-stress.yaml
@@ -728,7 +728,7 @@ jobs:
               baseURL: \"https://openbao.vault:8200\""
             ENCRYPTION_POOL_YAML="---
           apiVersion: storage.simplyblock.io/v1alpha1
-          kind: Pool
+          kind: StoragePool
           metadata:
             name: encryption-pool
             namespace: ${NAMESPACE}
@@ -762,7 +762,7 @@ jobs:
           ${VAULT_SETTINGS}
           ---
           apiVersion: storage.simplyblock.io/v1alpha1
-          kind: Pool
+          kind: StoragePool
           metadata:
             name: simplyblock-pool
             namespace: ${NAMESPACE}
@@ -785,7 +785,7 @@ jobs:
             mgmtIfname: ${MGMT_IFC}
             dataIfname:
               - ${DATA_NICS}
-            maxLogicalVolumeCount: ${MAX_LVOL}
+            maxSubsystemCount: ${MAX_LVOL}
           ${RESERVED_CPU_YAML}
             partitions: ${PARTITIONS}
             corePercentage: ${CORE_PERCENTAGE}
@@ -825,7 +825,7 @@ jobs:
           ${VAULT_SETTINGS}
           ---
           apiVersion: storage.simplyblock.io/v1alpha1
-          kind: Pool
+          kind: StoragePool
           metadata:
             name: simplyblock-pool
             namespace: ${NAMESPACE}
@@ -848,7 +848,7 @@ jobs:
             mgmtIfname: ${MGMT_IFC}
             dataIfname:
               - ${DATA_NICS}
-            maxLogicalVolumeCount: ${MAX_LVOL}
+            maxSubsystemCount: ${MAX_LVOL}
           ${RESERVED_CPU_YAML}
             partitions: ${PARTITIONS}
             corePercentage: ${CORE_PERCENTAGE}

--- a/.github/workflows/k8s-native-upgrade.yaml
+++ b/.github/workflows/k8s-native-upgrade.yaml
@@ -572,7 +572,7 @@ jobs:
           ${VAULT_SETTINGS}
           ---
           apiVersion: storage.simplyblock.io/v1alpha1
-          kind: Pool
+          kind: StoragePool
           metadata:
             name: simplyblock-pool
             namespace: ${NAMESPACE}
@@ -594,7 +594,7 @@ jobs:
             mgmtIfname: ${MGMT_IFC}
             dataIfname:
               - ${DATA_NICS}
-            maxLogicalVolumeCount: ${MAX_LVOL}
+            maxSubsystemCount: ${MAX_LVOL}
           ${RESERVED_CPU_YAML}
             partitions: ${PARTITIONS}
             corePercentage: ${CORE_PERCENTAGE}

--- a/.github/workflows/monitoring-suite-k8s-native.yaml
+++ b/.github/workflows/monitoring-suite-k8s-native.yaml
@@ -652,7 +652,7 @@ jobs:
               baseURL: \"https://openbao.vault:8200\""
             ENCRYPTION_POOL_YAML="---
           apiVersion: storage.simplyblock.io/v1alpha1
-          kind: Pool
+          kind: StoragePool
           metadata:
             name: encryption-pool
             namespace: ${NAMESPACE}
@@ -685,7 +685,7 @@ jobs:
           ${VAULT_SETTINGS}
           ---
           apiVersion: storage.simplyblock.io/v1alpha1
-          kind: Pool
+          kind: StoragePool
           metadata:
             name: simplyblock-pool
             namespace: ${NAMESPACE}
@@ -708,7 +708,7 @@ jobs:
             mgmtIfname: ${MGMT_IFC}
             dataIfname:
               - ${DATA_NICS}
-            maxLogicalVolumeCount: ${MAX_LVOL}
+            maxSubsystemCount: ${MAX_LVOL}
           ${RESERVED_CPU_YAML}
             partitions: ${PARTITIONS}
             corePercentage: ${CORE_PERCENTAGE}

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -650,7 +650,7 @@ spec:
     provisionedCapacity: 98
 ---
 apiVersion: storage.simplyblock.io/v1alpha1
-kind: Pool
+kind: StoragePool
 metadata:
   name: <EXISTING_POOL_NAME>       # Must match the pool name from R25 (e.g., testing1)
   namespace: simplyblock
@@ -670,7 +670,7 @@ spec:
   mgmtIfname: ens18
   dataIfname:
     - enp1s0
-  maxLogicalVolumeCount: 30
+  maxSubsystemCount: 30
   enableCpuTopology: true
   workerNodes:
     - <worker-node-1>
@@ -687,7 +687,7 @@ Verify adoption (status should reflect existing UUIDs, not `in_creation`):
 ```bash
 kubectl get storagecluster -n simplyblock -o yaml
 kubectl get storagenode -n simplyblock -o yaml
-kubectl get pool -n simplyblock -o yaml
+kubectl get storagepool -n simplyblock -o yaml
 ```
 
 ### Step 8 — Run R25 to R26 Data Migration Script

--- a/e2e/e2e_tests/backup/backup-operator.md
+++ b/e2e/e2e_tests/backup/backup-operator.md
@@ -99,7 +99,7 @@ spec:
   clusterName: simplyblock-cluster
   clusterImage: simplyblock/simplyblock:main
   mgmtIfname: eth0
-  maxLogicalVolumeCount: 10
+  maxSubsystemCount: 10
   partitions: 0
   corePercentage: 65
   coreIsolation: false
@@ -116,7 +116,7 @@ create storage pool
 ```
 kubectl apply -f - <<'EOF'
 apiVersion: storage.simplyblock.io/v1alpha1
-kind: Pool
+kind: StoragePool
 metadata:
   name: pool3
   namespace: cluster1

--- a/e2e/e2e_tests/cluster_test_base.py
+++ b/e2e/e2e_tests/cluster_test_base.py
@@ -277,7 +277,7 @@ class TestClusterBase:
         if not self.k8s_test:
             self.sbcli_utils.delete_all_storage_pools()
         else:
-            # In K8s mode, avoid deleting pools during setup — the Pool CRD
+            # In K8s mode, avoid deleting pools during setup — the StoragePool CRD
             # reconciliation is async and deleting+recreating pools between
             # tests causes long waits or failures.  Tests create pools via
             # _add_pool_dual() which reuses existing pools.
@@ -411,13 +411,13 @@ class TestClusterBase:
         return self.pool_name
 
     def _verify_pool_exists_dual(self, pool_name=None):
-        """Assert that a pool exists. In K8s mode checks the Pool CRD;
+        """Assert that a pool exists. In K8s mode checks the StoragePool CRD;
         in Docker mode checks sbcli pool list."""
         pool_name = pool_name or self.pool_name
         if self.k8s_test:
             exists = self.sbcli_utils.pool_crd_exists(pool_name)
             assert exists, (
-                f"Pool CRD for '{pool_name}' not found in K8s"
+                f"StoragePool CRD for '{pool_name}' not found in K8s"
             )
         else:
             pools = self.sbcli_utils.list_storage_pools()
@@ -425,7 +425,7 @@ class TestClusterBase:
                 f"Pool {pool_name} not present in list of pools: {pools}"
 
     def _delete_pool_dual(self, pool_name=None):
-        """Delete a storage pool. In K8s mode, deletes the Pool CRD.
+        """Delete a storage pool. In K8s mode, deletes the StoragePool CRD.
 
         Skipped entirely when pool_name doesn't match any existing pool
         (avoids errors from trying to delete a pool that was already
@@ -439,7 +439,7 @@ class TestClusterBase:
                 k8s_name = f"simplyblock-{pool_name.lower().replace('_', '-')}"
                 ns = self._ensure_k8s_utils().namespace
                 self._ensure_k8s_utils()._exec_kubectl(
-                    f"kubectl delete pools {k8s_name} -n {ns} "
+                    f"kubectl delete storagepools {k8s_name} -n {ns} "
                     f"--timeout=60s 2>/dev/null || true"
                 )
                 return

--- a/e2e/e2e_tests/upgrade_tests/k8s_major_upgrade.py
+++ b/e2e/e2e_tests/upgrade_tests/k8s_major_upgrade.py
@@ -1918,7 +1918,7 @@ spec:
     provisionedCapacity: 98
 ---
 apiVersion: storage.simplyblock.io/v1alpha1
-kind: Pool
+kind: StoragePool
 metadata:
   name: {self.pool_cr_name}
   namespace: {_NAMESPACE}
@@ -1938,7 +1938,7 @@ spec:
   mgmtIfname: {mgmt_ifc}
   dataIfname:
     - {data_nics}
-  maxLogicalVolumeCount: {max_lvol}
+  maxSubsystemCount: {max_lvol}
   enableCpuTopology: true
   workerNodes:
 {worker_yaml}"""
@@ -2139,7 +2139,7 @@ spec:
         # helm chart (default: "testing1"). The chart's logicalVolume config
         # auto-created StorageClass "simplyblock-csi-sc" referencing this pool.
         pool_name = "testing1"
-        # R25 has no operator — create pool directly via sbcli CLI, not Pool CRD
+        # R25 has no operator — create pool directly via sbcli CLI, not StoragePool CRD
         actual_pool = self.sbcli_utils.add_storage_pool_direct(
             pool_name, sbcli_cmd="sbcli-dev"
         )
@@ -2447,7 +2447,7 @@ spec:
     provisionedCapacity: 98
 ---
 apiVersion: storage.simplyblock.io/v1alpha1
-kind: Pool
+kind: StoragePool
 metadata:
   name: {self.pool_cr_name}
   namespace: {_NAMESPACE}
@@ -2467,7 +2467,7 @@ spec:
   mgmtIfname: {mgmt_ifc}
   dataIfname:
     - {data_nics}
-  maxLogicalVolumeCount: {max_lvol}
+  maxSubsystemCount: {max_lvol}
   enableCpuTopology: true
   nodesPerSocket: {self.nodes_per_socket}
   workerNodes:

--- a/e2e/utils/k8s_utils.py
+++ b/e2e/utils/k8s_utils.py
@@ -3457,7 +3457,7 @@ class K8sSbcliUtils:
         Returns the actual pool name to use (may differ from *pool_name* if an
         existing pool with a different name was found).
 
-        The operator creates pools from Pool CRDs. The pool name in the
+        The operator creates pools from StoragePool CRDs. The pool name in the
         backend (visible via ``sbcli pool list``) is set by the operator and
         may differ from the CRD metadata.name.  This method waits for the
         operator to reconcile the pool so that the real pool name can be
@@ -3471,10 +3471,10 @@ class K8sSbcliUtils:
             self.logger.info(f"[pool] Using existing pool '{actual}'")
             return actual
 
-        # 2. Check if Pool CRDs exist (operator may still be reconciling)
+        # 2. Check if StoragePool CRDs exist (operator may still be reconciling)
         ns = self.k8s.namespace
         out, _ = self.k8s._exec_kubectl(
-            f"kubectl get pools -n {ns} --no-headers "
+            f"kubectl get storagepools -n {ns} --no-headers "
             f"-o custom-columns=NAME:.metadata.name 2>/dev/null || true"
         )
         existing_crds = [r.strip() for r in out.strip().splitlines() if r.strip()]
@@ -3491,7 +3491,7 @@ class K8sSbcliUtils:
             )
 
             # Look up the StorageCluster CRD name from K8s to ensure
-            # the Pool CRD references the correct CRD resource name.
+            # the StoragePool CRD references the correct CRD resource name.
             sc_out, _ = self.k8s._exec_kubectl(
                 f"kubectl get storageclusters -n {ns} --no-headers "
                 f"-o custom-columns=NAME:.metadata.name 2>/dev/null || true"
@@ -3513,7 +3513,7 @@ class K8sSbcliUtils:
 
             yaml_content = (
                 f"apiVersion: storage.simplyblock.io/v1alpha1\n"
-                f"kind: Pool\n"
+                f"kind: StoragePool\n"
                 f"metadata:\n"
                 f"  name: {k8s_resource_name}\n"
                 f"  namespace: {ns}\n"
@@ -3530,11 +3530,11 @@ class K8sSbcliUtils:
             existing_crds = [k8s_resource_name]
         else:
             self.logger.info(
-                f"[pool] Found existing Pool CRD(s): {existing_crds} — "
+                f"[pool] Found existing StoragePool CRD(s): {existing_crds} — "
                 f"waiting for operator to reconcile"
             )
 
-        # 4. Wait for operator to reconcile the Pool CRD into an actual pool
+        # 4. Wait for operator to reconcile the StoragePool CRD into an actual pool
         #    visible via sbcli pool list.  Use 300s timeout to handle slow
         #    reconciliation after pool deletion/recreation cycles.
         for attempt in range(60):  # up to 300s
@@ -3549,7 +3549,7 @@ class K8sSbcliUtils:
             if attempt % 5 == 4:
                 self.logger.info(
                     f"[pool] Still waiting for operator to reconcile "
-                    f"Pool CRD(s) {existing_crds} (attempt {attempt})"
+                    f"StoragePool CRD(s) {existing_crds} (attempt {attempt})"
                 )
             sleep_n_sec(5)
 
@@ -3558,16 +3558,16 @@ class K8sSbcliUtils:
         #    pools that don't exist on the backend, leading to PVC bind failures.
         raise TimeoutError(
             f"[pool] Pool not visible in sbcli after 300s. "
-            f"Pool CRD(s): {existing_crds}. "
+            f"StoragePool CRD(s): {existing_crds}. "
             f"Operator may not have reconciled the pool."
         )
 
     def add_storage_pool_direct(self, pool_name, cluster_id=None, sbcli_cmd=None):
         """Create a pool directly via ``sbcli pool add`` (kubectl exec).
 
-        Unlike ``add_storage_pool()``, this does NOT create a Pool CRD —
+        Unlike ``add_storage_pool()``, this does NOT create a StoragePool CRD —
         it calls the CLI directly in the admin pod.  Use this for R25
-        clusters that have no operator to reconcile Pool CRDs.
+        clusters that have no operator to reconcile StoragePool CRDs.
 
         sbcli_cmd: override the CLI binary name (e.g. "sbcli-dev" for R25).
                    Defaults to self.sbcli_cmd.
@@ -3612,22 +3612,22 @@ class K8sSbcliUtils:
         )
 
     def pool_crd_exists(self, pool_name):
-        """Check if a Pool CRD exists in K8s (with or without simplyblock- prefix).
+        """Check if a StoragePool CRD exists in K8s (with or without simplyblock- prefix).
 
-        Returns True if the Pool CRD is found, False otherwise.
+        Returns True if the StoragePool CRD is found, False otherwise.
         """
         ns = self.k8s.namespace
         # Try with simplyblock- prefix first (add_storage_pool creates these)
         k8s_name = f"simplyblock-{pool_name.lower().replace('_', '-')}"
         out, _ = self.k8s._exec_kubectl(
-            f"kubectl get pools {k8s_name} -n {ns} "
+            f"kubectl get storagepools {k8s_name} -n {ns} "
             f"-o jsonpath='{{.metadata.name}}' 2>/dev/null || true"
         )
         if out.strip():
             return True
         # Try with exact pool_name (ensure_pool_exists creates these)
         out, _ = self.k8s._exec_kubectl(
-            f"kubectl get pools {pool_name} -n {ns} "
+            f"kubectl get storagepools {pool_name} -n {ns} "
             f"-o jsonpath='{{.metadata.name}}' 2>/dev/null || true"
         )
         return bool(out.strip())
@@ -3657,7 +3657,7 @@ class K8sSbcliUtils:
         )
 
         # Look up the StorageCluster CRD name from K8s to ensure
-        # the Pool CRD references the correct CRD resource name.
+        # the StoragePool CRD references the correct CRD resource name.
         ns = self.k8s.namespace
         sc_out, _ = self.k8s._exec_kubectl(
             f"kubectl get storageclusters -n {ns} --no-headers "
@@ -3684,7 +3684,7 @@ class K8sSbcliUtils:
 
         yaml_content = (
             f"apiVersion: storage.simplyblock.io/v1alpha1\n"
-            f"kind: Pool\n"
+            f"kind: StoragePool\n"
             f"metadata:\n"
             f"  name: {pool_name}\n"
             f"  namespace: {ns}\n"
@@ -3709,7 +3709,7 @@ class K8sSbcliUtils:
             sleep_n_sec(5)
         raise RuntimeError(
             f"[pool] Pool '{pool_name}' not confirmed after kubectl apply "
-            f"— operator did not reconcile the Pool CRD within 180s"
+            f"— operator did not reconcile the StoragePool CRD within 180s"
         )
 
     def add_host_to_pool(self, pool_id, host_nqn):
@@ -3733,7 +3733,7 @@ class K8sSbcliUtils:
         self.logger.info(f"[pool] Deleting pool CRD '{pool_name}'")
         ns = self.k8s.namespace
         self.k8s._exec_kubectl(
-            f"kubectl delete pools {pool_name} -n {ns} "
+            f"kubectl delete storagepools {pool_name} -n {ns} "
             f"--timeout=60s 2>/dev/null || true"
         )
         # Wait for pool to disappear from sbcli
@@ -3748,14 +3748,14 @@ class K8sSbcliUtils:
         """Delete all storage pool CRD resources."""
         ns = self.k8s.namespace
         out, _ = self.k8s._exec_kubectl(
-            f"kubectl get pools -n {ns} --no-headers "
+            f"kubectl get storagepools -n {ns} --no-headers "
             f"-o custom-columns=NAME:.metadata.name 2>/dev/null || true"
         )
         resources = [r.strip() for r in out.strip().splitlines() if r.strip()]
         for res in resources:
             self.logger.info(f"[pool] Deleting pool CRD '{res}'")
             self.k8s._exec_kubectl(
-                f"kubectl delete pools {res} -n {ns} "
+                f"kubectl delete storagepools {res} -n {ns} "
                 f"--timeout=60s 2>/dev/null || true"
             )
 


### PR DESCRIPTION
## Summary
Syncs sbcli's CI workflows, UPGRADE.md, and e2e test helpers with two CRD changes made in simplyblock-operator:
- `kind: Pool` -> `kind: StoragePool` ([simplyblock-operator#414](https://github.com/simplyblock/simplyblock-operator/pull/414))
- StorageNodeSet field `maxLogicalVolumeCount` -> `maxSubsystemCount` ([simplyblock-operator#413](https://github.com/simplyblock/simplyblock-operator/pull/413))

Also updates `kubectl get pools`/`kubectl delete pools` calls (and matching doc/comment references to "Pool CRD") in the e2e helpers to use the new `storagepools` plural resource name.

sbcli's own backend/CLI "pool" concept (`simplyblock_cli`, `pool_controller`, `storage_pool` REST API) mirrors the sbcli backend API, not the K8s CRD, and is intentionally left untouched — same scope boundary the operator PR used.

## Files changed
- `.github/workflows/k8s-native-*.yaml` (7 workflow files) — inline CR manifests
- `UPGRADE.md` — upgrade runbook example manifests/commands
- `e2e/e2e_tests/backup/backup-operator.md` — doc example manifests
- `e2e/e2e_tests/upgrade_tests/k8s_major_upgrade.py` — generated CR YAML
- `e2e/e2e_tests/cluster_test_base.py`, `e2e/utils/k8s_utils.py` — kubectl get/delete resource name + doc comments

## Test plan
- [ ] Run the k8s-native-e2e workflow against an operator build with both renames applied (e.g. [simplyblock-operator#416](https://github.com/simplyblock/simplyblock-operator/pull/416)) to confirm the applied CRs are accepted and e2e helper kubectl calls succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)