### PR TITLE
Remove unsupported parameter

### DIFF
--- a/simplyblock_core/cluster_ops.py
+++ b/simplyblock_core/cluster_ops.py
@@ -38,6 +38,16 @@ logger = utils.get_logger(__name__)
 
 db_controller = DBController()
 
+SUPPORTED_ERASURE_CODING_SCHEMES = {
+    (1, 0),
+    (1, 1),
+    (2, 1),
+    (4, 1),
+    (1, 2),
+    (2, 2),
+    (4, 2),
+}
+
 def _create_update_user(cluster_id, grafana_url, grafana_secret: SecretStr, user_secret: SecretStr, update_secret=False):
     session = requests.session()
     session.auth = ("admin", grafana_secret.get_secret_value())
@@ -256,6 +266,7 @@ def parse_protocols(input_str: str):
         "rdma": "rdma" in parts,
     }
 
+
 def create_cluster(blk_size, page_size_in_blocks, cli_pass,
                    cap_warn, cap_crit, prov_cap_warn, prov_cap_crit, ifname, mgmt_ip, log_del_interval, metrics_retention_period,
                    contact_point, grafana_endpoint, distr_ndcs, distr_npcs, distr_bs, distr_chunk_bs, ha_type, mode,
@@ -267,9 +278,8 @@ def create_cluster(blk_size, page_size_in_blocks, cli_pass,
                    enable_failure_domain=False,
                    enable_hang_device=False,
 ) -> str:
-
-    if distr_ndcs == 0 and distr_npcs == 0:
-        raise ValueError("both distr_ndcs and distr_npcs cannot be 0")
+    if (distr_ndcs, distr_npcs) not in SUPPORTED_ERASURE_CODING_SCHEMES:
+        raise ValueError("Unsupported erasure coding scheme")
 
     if max_fault_tolerance > 1:
         if ha_type != "ha":
@@ -560,8 +570,8 @@ def _add_cluster_impl(blk_size, page_size_in_blocks, cap_warn, cap_crit, prov_ca
             if existing.cluster_name and existing.cluster_name == name:
                 raise ValueError(f"A cluster with the name '{name}' already exists")
 
-    if distr_ndcs == 0 and distr_npcs == 0:
-        raise ValueError("both distr_ndcs and distr_npcs cannot be 0")
+    if (distr_ndcs, distr_npcs) not in SUPPORTED_ERASURE_CODING_SCHEMES:
+        raise ValueError("Unsupported erasure coding scheme")
 
     if max_fault_tolerance > 1:
         if ha_type != "ha":

--- a/simplyblock_web/api/v2/cluster/__init__.py
+++ b/simplyblock_web/api/v2/cluster/__init__.py
@@ -78,7 +78,6 @@ class ClusterParams(BaseModel):
     cr_namespace: str = ""
     cr_plural: str = ""
     client_data_nic: str = ""
-    max_fault_tolerance: int = 1
     nvmf_base_port: int = 4420
     rpc_base_port: int = 8080
     snode_api_port: int = 50001

--- a/simplyblock_web/api/v2/cluster/__init__.py
+++ b/simplyblock_web/api/v2/cluster/__init__.py
@@ -3,12 +3,13 @@ from typing import Annotated, List, Literal, Optional
 from uuid import UUID
 
 from fastapi import APIRouter, HTTPException, Request, Response
-from pydantic import BaseModel, Field, SecretStr
+from pydantic import BaseModel, Field, SecretStr, computed_field, model_validator
 from pydantic.networks import AnyUrl, UrlConstraints
 
 from simplyblock_core.db_controller import DBController
 from simplyblock_core.models.cluster import HashicorpVaultSettings as ModelVaultSettings
 from simplyblock_core import cluster_ops
+from simplyblock_core.cluster_ops import SUPPORTED_ERASURE_CODING_SCHEMES
 
 from .._dependencies import Cluster
 from .backup import api as backup_api
@@ -85,6 +86,16 @@ class ClusterParams(BaseModel):
     hashicorp_vault_settings: Optional[HashicorpVaultSettings] = None
     enable_failure_domain: bool = False
 
+    @model_validator(mode="after")
+    def validate_erasure_coding_scheme(self):
+        if (self.distr_ndcs, self.distr_npcs) not in SUPPORTED_ERASURE_CODING_SCHEMES:
+            raise ValueError("Invalid erasure coding scheme selected")
+        return self
+
+    @computed_field
+    def max_fault_tolerance(self) -> int:
+        return self.distr_npcs
+
 
 @api.get('/', name='clusters:list')
 def list() -> List[ClusterDTO]:
@@ -102,8 +113,6 @@ def list() -> List[ClusterDTO]:
 def add(request: Request, parameters: ClusterParams, response_format: util.CreationResponseFormatParameter = "full"):
     try:
         params = parameters.model_dump(exclude_none=True)
-        npcs = params.get('distr_npcs', 1)
-        params['max_fault_tolerance'] = min(npcs, 2) if npcs >= 1 else 1
         if "hashicorp_vault_settings" in params:
             params["hashicorp_vault_settings"] = ModelVaultSettings(params["hashicorp_vault_settings"])
         cluster_id_or_false = cluster_ops.add_cluster(**params)

--- a/tests/integration/test_dual_fault_tolerance.py
+++ b/tests/integration/test_dual_fault_tolerance.py
@@ -168,7 +168,7 @@ class TestCreateClusterValidation(unittest.TestCase):
     def test_max_ft_1_no_validation_error(self, mock_db):
         """max_fault_tolerance=1 should not hit the new validation even with single ha_type."""
         import simplyblock_core.cluster_ops as ops
-        # Will fail later (e.g. distr_ndcs/npcs both 0), but not on max_ft validation
+        # Will fail later (e.g. on the erasure coding scheme), but not on max_ft validation
         with self.assertRaises(ValueError) as ctx:
             ops.create_cluster(
                 4096, 2097152, "pass", 89, 99, 250, 500,
@@ -178,8 +178,8 @@ class TestCreateClusterValidation(unittest.TestCase):
                 None, "hostip", "", "tcp", False, "",
                 max_fault_tolerance=1,
             )
-        # Should fail on ndcs/npcs both 0, not on max_ft
-        assert "distr_ndcs" in str(ctx.exception)
+        # Should fail on the unsupported (0, 0) scheme, not on max_ft
+        assert "erasure coding scheme" in str(ctx.exception)
 
 
 # ===========================================================================

--- a/tests/unit/web/api/v2/test_cluster_endpoints.py
+++ b/tests/unit/web/api/v2/test_cluster_endpoints.py
@@ -36,19 +36,11 @@ class TestCreateCluster:
         kwargs = cluster_ops.add_cluster.call_args.kwargs
         assert kwargs['name'] == 'cluster-1'
         assert kwargs['distr_npcs'] == 2
-        assert kwargs['max_fault_tolerance'] == 2
         assert kwargs['blk_size'] == 512
         assert kwargs['ha_type'] == 'ha'
         assert response.json()['id'] == CLUSTER_ID
         assert response.headers['Location'].endswith(f'/clusters/{CLUSTER_ID}/')
         db.get_cluster_by_id.assert_called_once_with(CLUSTER_ID)
-
-    def test_caps_max_fault_tolerance_at_two(self, client, db, cluster, cluster_ops):
-        cluster_ops.add_cluster.return_value = CLUSTER_ID
-
-        client.post('/api/v2/clusters/', json={'distr_npcs': 4})
-
-        assert cluster_ops.add_cluster.call_args.kwargs['max_fault_tolerance'] == 2
 
     def test_conflict_maps_to_409(self, client, db, cluster_ops):
         cluster_ops.add_cluster.side_effect = ValueError('cluster exists')

--- a/tests/unit/web/api/v2/test_cluster_endpoints.py
+++ b/tests/unit/web/api/v2/test_cluster_endpoints.py
@@ -30,11 +30,13 @@ class TestCreateCluster:
     def test_calls_add_cluster_with_parameters(self, client, db, cluster, cluster_ops):
         cluster_ops.add_cluster.return_value = CLUSTER_ID
 
-        response = client.post('/api/v2/clusters/', json={'name': 'cluster-1', 'distr_npcs': 2})
-
+        response = client.post('/api/v2/clusters/', json={'name': 'cluster-1', 'distr_ndcs': 1, 'distr_npcs': 2})
+        response.raise_for_status()
         assert response.status_code == 201
+
         kwargs = cluster_ops.add_cluster.call_args.kwargs
         assert kwargs['name'] == 'cluster-1'
+        assert kwargs['distr_ndcs'] == 1
         assert kwargs['distr_npcs'] == 2
         assert kwargs['blk_size'] == 512
         assert kwargs['ha_type'] == 'ha'
@@ -45,9 +47,17 @@ class TestCreateCluster:
     def test_conflict_maps_to_409(self, client, db, cluster_ops):
         cluster_ops.add_cluster.side_effect = ValueError('cluster exists')
 
-        response = client.post('/api/v2/clusters/', json={'name': 'cluster-1'})
+        response = client.post('/api/v2/clusters/', json={'name': 'cluster-1', 'distr_ndcs': 1, 'distr_npcs': 2})
 
         assert response.status_code == 409
+
+    def test_invalid_erasure_coding_scheme_caught(self, client, db, cluster_ops):
+        response = client.post('/api/v2/clusters/', json={'name': 'cluster-1', 'distr_ndcs': 3, 'distr_npcs': 2})
+        assert response.status_code == 422
+        response = client.post('/api/v2/clusters/', json={'name': 'cluster-1', 'distr_ndcs': 1, 'distr_npcs': 5})
+        assert response.status_code == 422
+        response = client.post('/api/v2/clusters/', json={'name': 'cluster-1', 'distr_ndcs': -1, 'distr_npcs': 2})
+        assert response.status_code == 422
 
 
 class TestGetCluster:


### PR DESCRIPTION
The max-fault-tolerance has been removed from the CLI and is derived in the API. This removes it to avoid users setting it, expecting something to happen. While at it, I also introduced validation to limit the erasure coding scheme to those advertised in the documentation.