### PR TITLE
Fix cross-cluster backup/restore, upgrade tests, resource preservation, CI pipelines, and Slack thread notifications

### DIFF
--- a/.github/workflows/e2e-bootstrap.yml
+++ b/.github/workflows/e2e-bootstrap.yml
@@ -1783,6 +1783,21 @@ jobs:
             ssh "${SSH_OPTS[@]}" "${SSH_USER}@${MGMT_IP}" "rm -rf '${REMOTE_OUTPUT_DIR}'" 2>/dev/null || true
           done
           echo "=== Log collection complete (${CHUNK} chunks, newest-first): ${OUTPUT_DIR} ==="
+      - name: Notify Slack log collection complete
+        if: always() && inputs.send_slack_notification != false
+        shell: bash
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          SLACK_WF_NAME: "E2E Bootstrap"
+          RUN_BASE_DIR: ${{ env.RUN_BASE_DIR }}
+        run: |
+          if [ -z "${SLACK_WEBHOOK_URL:-}" ]; then exit 0; fi
+          MSG=":white_check_mark: *Log collection complete* for *SimplyBlock ${SLACK_WF_NAME}*\n:file_folder: \`${RUN_BASE_DIR:-N/A}/graylog_collected/\`\n:link: <${SLACK_RUN_URL}|View Run>"
+          curl -s -X POST "${SLACK_WEBHOOK_URL}" \
+            -H 'Content-Type: application/json' \
+            -d "{\"text\":\"${MSG}\"}" || true
+
       - name: Stop MinIO trace logging and save
         if: always()
         shell: bash

--- a/.github/workflows/e2e-bootstrap.yml
+++ b/.github/workflows/e2e-bootstrap.yml
@@ -1858,6 +1858,9 @@ jobs:
           else
             echo "No MinIO trace log found (backup tests may not have run)"
           fi
+          # Cleanup: delete trace logs and kill any orphaned mc trace processes
+          rm -f /tmp/minio-trace-*.log 2>/dev/null || true
+          pkill -f "mc admin trace" 2>/dev/null || true
 
       - name: Upload logs (always)
         if: always()

--- a/.github/workflows/e2e-bootstrap.yml
+++ b/.github/workflows/e2e-bootstrap.yml
@@ -884,7 +884,7 @@ jobs:
           fi
           NEW_NODES_ARGS=()
           if [[ -n "${NEW_NODE_IPS:-}" ]]; then
-            NEW_NODES_ARGS=(--new_nodes ${NEW_NODE_IPS})
+            NEW_NODES_ARGS=(--new_nodes "${NEW_NODE_IPS}")
           fi
           # Build extra cluster args for inter-test reset
           # These are passed directly to 'sbcli cluster create' so use

--- a/.github/workflows/e2e-bootstrap.yml
+++ b/.github/workflows/e2e-bootstrap.yml
@@ -851,16 +851,10 @@ jobs:
           set -euxo pipefail
 
           # 1. Install mc (MinIO Client)
-          if ! command -v mc &>/dev/null; then
-            if curl -fsSL https://dl.min.io/client/mc/release/linux-amd64/mc -o /usr/local/bin/mc 2>/dev/null; then
-              chmod +x /usr/local/bin/mc
-            else
-              curl -fsSL https://dl.min.io/client/mc/release/linux-amd64/mc -o /tmp/mc
-              chmod +x /tmp/mc
-              export PATH="/tmp:$PATH"
-              echo "/tmp" >> "$GITHUB_PATH"
-            fi
-          fi
+          curl -fsSL https://dl.min.io/client/mc/release/linux-amd64/mc -o /tmp/mc
+          chmod +x /tmp/mc
+          export PATH="/tmp:$PATH"
+          echo "/tmp" >> "$GITHUB_PATH"
 
           # 2. Configure mc alias to external MinIO
           mc alias set myminio http://192.168.10.164:9000 "${MINIO_ACCESS_KEY}" "${MINIO_SECRET_KEY}"

--- a/.github/workflows/e2e-bootstrap.yml
+++ b/.github/workflows/e2e-bootstrap.yml
@@ -1522,6 +1522,8 @@ jobs:
         shell: bash
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
           JOB_STATUS: ${{ job.status }}
           SLACK_RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           GITHUB_REF_NAME: ${{ github.ref_name }}
@@ -1532,9 +1534,11 @@ jobs:
           python3 - <<'PYEOF'
           import json, os, re, sys, urllib.request, urllib.error
 
-          webhook = os.environ.get("SLACK_WEBHOOK_URL", "")
-          if not webhook:
-              print("No SLACK_WEBHOOK_URL set, skipping.")
+          bot_token = os.environ.get("SLACK_BOT_TOKEN", "")
+          channel   = os.environ.get("SLACK_CHANNEL_ID", "")
+          webhook   = os.environ.get("SLACK_WEBHOOK_URL", "")
+          if not bot_token and not webhook:
+              print("No SLACK_BOT_TOKEN or SLACK_WEBHOOK_URL set, skipping.")
               sys.exit(0)
 
           out_log = "sbcli/e2e/output.log"
@@ -1630,17 +1634,46 @@ jobs:
               f":hourglass_flowing_sand: _Logs are being collected and will be available shortly._",
           ]
 
-          payload = {"text": "\n".join(lines)}
-          req = urllib.request.Request(
-              webhook,
-              data=json.dumps(payload).encode(),
-              headers={"Content-Type": "application/json"},
-          )
-          try:
-              urllib.request.urlopen(req, timeout=15)
-              print("Slack notification sent.")
-          except Exception as exc:
-              print(f"WARN: Slack notification failed: {exc}", file=sys.stderr)
+          # --- Send ---
+          gh_env = os.environ.get("GITHUB_ENV", "")
+          text   = "\n".join(lines)
+
+          if bot_token and channel:
+              api_payload = json.dumps({"channel": channel, "text": text}).encode()
+              req = urllib.request.Request(
+                  "https://slack.com/api/chat.postMessage",
+                  data=api_payload,
+                  headers={
+                      "Content-Type": "application/json; charset=utf-8",
+                      "Authorization": f"Bearer {bot_token}",
+                  },
+              )
+              try:
+                  resp = urllib.request.urlopen(req, timeout=15)
+                  body = json.loads(resp.read().decode())
+                  if body.get("ok"):
+                      ts = body.get("ts", "")
+                      print(f"Slack notification sent via Bot API (ts={ts}).")
+                      if gh_env and ts:
+                          with open(gh_env, "a") as f:
+                              f.write(f"SLACK_MSG_TS={ts}\n")
+                  else:
+                      print(f"WARN: Slack API error: {body.get('error')}", file=sys.stderr)
+              except Exception as exc:
+                  print(f"WARN: Slack Bot API failed: {exc}", file=sys.stderr)
+          elif webhook:
+              req = urllib.request.Request(
+                  webhook,
+                  data=json.dumps({"text": text}).encode(),
+                  headers={"Content-Type": "application/json"},
+              )
+              try:
+                  urllib.request.urlopen(req, timeout=15)
+                  print("Slack notification sent via webhook (no thread support).")
+              except Exception as exc:
+                  print(f"WARN: Slack webhook failed: {exc}", file=sys.stderr)
+          else:
+              print("No SLACK_BOT_TOKEN or SLACK_WEBHOOK_URL set, skipping.")
           PYEOF
 
 
@@ -1787,16 +1820,25 @@ jobs:
         if: always() && inputs.send_slack_notification != false
         shell: bash
         env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
+          SLACK_MSG_TS: ${{ env.SLACK_MSG_TS }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           SLACK_WF_NAME: "E2E Bootstrap"
           RUN_BASE_DIR: ${{ env.RUN_BASE_DIR }}
         run: |
-          if [ -z "${SLACK_WEBHOOK_URL:-}" ]; then exit 0; fi
           MSG=":white_check_mark: *Log collection complete* for *SimplyBlock ${SLACK_WF_NAME}*\n:file_folder: \`${RUN_BASE_DIR:-N/A}/graylog_collected/\`\n:link: <${SLACK_RUN_URL}|View Run>"
-          curl -s -X POST "${SLACK_WEBHOOK_URL}" \
-            -H 'Content-Type: application/json' \
-            -d "{\"text\":\"${MSG}\"}" || true
+          if [ -n "${SLACK_BOT_TOKEN:-}" ] && [ -n "${SLACK_CHANNEL_ID:-}" ] && [ -n "${SLACK_MSG_TS:-}" ]; then
+            curl -s -X POST "https://slack.com/api/chat.postMessage" \
+              -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
+              -H "Content-Type: application/json; charset=utf-8" \
+              -d "{\"channel\":\"${SLACK_CHANNEL_ID}\",\"thread_ts\":\"${SLACK_MSG_TS}\",\"text\":\"${MSG}\"}" || true
+          elif [ -n "${SLACK_WEBHOOK_URL:-}" ]; then
+            curl -s -X POST "${SLACK_WEBHOOK_URL}" \
+              -H "Content-Type: application/json" \
+              -d "{\"text\":\"${MSG}\"}" || true
+          fi
 
       - name: Stop MinIO trace logging and save
         if: always()

--- a/.github/workflows/e2e-docker.yml
+++ b/.github/workflows/e2e-docker.yml
@@ -241,66 +241,246 @@ jobs:
 
       - name: Write Job Summary
         if: always()
+        shell: bash
         run: |
-          {
-            echo "## E2E Docker Run Summary"
-            echo ""
-            if [[ "${{ job.status }}" == "success" ]]; then
-              echo "**Result:** SUCCESS"
-            else
-              echo "**Result:** FAILED"
-            fi
-            echo ""
-            echo "### Test Results"
-            echo "- **Total:** ${TOTAL_TESTS:-?} | **Passed:** ${PASSED_TESTS:-?} | **Failed:** ${FAILED_TESTS:-?} | **Skipped:** ${SKIPPED_TESTS:-0}"
-            echo ""
-            echo "### Run Info"
-            echo "- **Branch:** \`${{ github.ref_name }}\`"
-            echo "- **Duration:** ${TEST_TIME_HOURS:-0}h ${TEST_TIME_MINS:-0}m ${TEST_TIME_SECS:-0}s"
-            echo ""
-            echo "> **Note:** Graylog/OpenSearch logs are currently being collected and will be available in the NFS log directory shortly."
-          } >> "$GITHUB_STEP_SUMMARY"
+          set -euxo pipefail
 
-      - name: Send Slack Notification
-        if: always() && (github.event_name == 'schedule' || env.send_slack_notification == 'true')
+          dur_fmt="${TEST_TIME_HOURS:-0}h ${TEST_TIME_MINS:-0}m ${TEST_TIME_SECS:-0}s"
+
+          # --- Parse test counts ---
+          total_cases="${TOTAL_TESTS:-0}"
+          passed_cases="${PASSED_TESTS:-0}"
+          failed_cases="${FAILED_TESTS:-0}"
+          skipped_cases="${SKIPPED_TESTS:-0}"
+
+          pass_pct=0; fail_pct=0; skip_pct=0
+          if [[ "${total_cases}" =~ ^[0-9]+$ && "${total_cases}" -gt 0 ]]; then
+            pass_pct=$(( (passed_cases  * 100) / total_cases ))
+            fail_pct=$(( (failed_cases  * 100) / total_cases ))
+            skip_pct=$(( (skipped_cases * 100) / total_cases ))
+          fi
+
+          # --- Parse per-test status from log ---
+          test_details_table=""
+          log_file=""
+          for f in $GITHUB_WORKSPACE/e2e/logs/*.log; do
+            [ -s "$f" ] && log_file="$f"
+          done
+          if [[ -n "${log_file}" ]]; then
+            while IFS= read -r line; do
+              clean="$(printf '%s' "${line}" | sed 's/\x1b\[[0-9;]*m//g')"
+              test_name="$(printf '%s' "${clean}" | grep -oE 'Test[A-Za-z0-9_]+' | head -n1 || true)"
+              [[ -z "${test_name}" ]] && continue
+              if   printf '%s' "${clean}" | grep -qi 'PASSED CASE';  then icon="✅"; status="PASSED"
+              elif printf '%s' "${clean}" | grep -qi 'FAILED CASE';  then icon="❌"; status="FAILED"
+              elif printf '%s' "${clean}" | grep -qi 'SKIPPED CASE'; then icon="⏭"; status="SKIPPED"
+              else continue
+              fi
+              test_details_table+="| \`${test_name}\` | ${icon} ${status} |"$'\n'
+            done < <(grep -iE 'PASSED CASE|FAILED CASE|SKIPPED CASE' "${log_file}" 2>/dev/null || true)
+          fi
+
+          # --- Failure reason ---
+          failure_reason=""
+          if [[ -n "${log_file}" ]]; then
+            multi="$(grep 'MultipleExceptions:' "${log_file}" | sed 's/\x1b\[[0-9;]*m//g' || true)"
+            if [[ -n "${multi}" ]]; then
+              failure_reason="${multi}"
+            elif grep -Eqi 'Traceback \(most recent call last\)|Exception:|AssertionError|Input/output error' "${log_file}"; then
+              failure_reason="$(grep -Ei 'Traceback \(most recent call last\)|Exception:|AssertionError|Input/output error' "${log_file}" | tail -n 3 | sed 's/\x1b\[[0-9;]*m//g' || true)"
+            fi
+          fi
+
+          # --- Overall result ---
+          conclusion="✅ SUCCESS"
+          if [[ "${{ job.status }}" != "success" ]]; then
+            conclusion="❌ FAILED"
+          fi
+
+          {
+            echo "## SimplyBlock E2E Docker Run Summary"
+            echo ""
+            echo "**Result:** ${conclusion} &nbsp;|&nbsp; **Duration:** ${dur_fmt}"
+            echo ""
+
+            echo "### Test Results"
+            echo "| | Count | % |"
+            echo "|---|---|---|"
+            echo "| ✅ Passed  | ${passed_cases}  | ${pass_pct}% |"
+            echo "| ❌ Failed  | ${failed_cases}  | ${fail_pct}% |"
+            echo "| ⏭ Skipped | ${skipped_cases} | ${skip_pct}% |"
+            echo "| **Total**  | **${total_cases}** | |"
+            echo ""
+
+            if [[ -n "${test_details_table}" ]]; then
+              echo "### Test Case Details"
+              echo "| Test | Result |"
+              echo "|---|---|"
+              printf '%s' "${test_details_table}"
+              echo ""
+            fi
+
+            echo "### Run Info"
+            echo "- **Test class:** \`${TEST_CASE:-all}\`"
+            echo "- **Branch:** \`${{ github.ref_name }}\`"
+            echo "- **Cluster:** \`${CLUSTER:-?}\`"
+            echo "- **NDCS/NPCS:** \`${NDCS}/${NPCS}\`"
+            echo "- **BS/Chunk BS:** \`${BS}/${CHUNK_BS}\`"
+            echo ""
+
+            if [[ -n "${failure_reason}" ]]; then
+              echo "### Failure Reason"
+              echo '```'
+              printf '%s\n' "${failure_reason}"
+              echo '```'
+              echo ""
+            fi
+
+            echo "> **Note:** Graylog/OpenSearch logs are currently being collected and will be available shortly."
+          } >> "$GITHUB_STEP_SUMMARY"
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          GITHUB_SERVER_URL: ${{ github.server_url }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
-          RUN_ID: ${{ github.run_id }}
-          PASSED_TESTS: ${{ env.PASSED_TESTS }}
-          FAILED_TESTS: ${{ env.FAILED_TESTS }}
-          TOTAL_TESTS: ${{ env.TOTAL_TESTS }}
-          PASSED_CASES: ${{ env.PASSED_CASES }}
-          FAILED_CASES: ${{ env.FAILED_CASES }}
-          SKIPPED_CASES: ${{ env.SKIPPED_CASES }}
-          PASSED_CASES_BULLETS: ${{ env.PASSED_CASES_BULLETS }}
-          FAILED_CASES_BULLETS: ${{ env.FAILED_CASES_BULLETS }}
-          SKIPPED_CASES_BULLETS: ${{ env.SKIPPED_CASES_BULLETS }}
-          BRANCH_NAME: ${{ github.ref_name }}
-          TEST_TIME_HOURS: ${{ env.TEST_TIME_HOURS }}
-          TEST_TIME_MINS: ${{ env.TEST_TIME_MINS }}
-          TEST_TIME_SECS: ${{ env.TEST_TIME_SECS }}
           NDCS: ${{ github.event.inputs.ndcs || 1 }}
           NPCS: ${{ github.event.inputs.npcs || 1 }}
           BS: ${{ github.event.inputs.bs || 4096 }}
           CHUNK_BS: ${{ github.event.inputs.chunk_bs || 4096 }}
+          TEST_CASE: ${{ inputs.test_case_to_run || '' }}
+          CLUSTER: ${{ inputs.cluster || 'c141' }}
+
+      - name: Send Slack Notification
+        if: always() && (github.event_name == 'schedule' || env.send_slack_notification == 'true')
+        shell: bash
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          JOB_STATUS: ${{ job.status }}
+          SLACK_RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          GITHUB_REF_NAME: ${{ github.ref_name }}
+          SLACK_WF_NAME: "E2E Docker"
+          TESTNAME: ${{ inputs.test_case_to_run || 'all' }}
+          NDCS: ${{ github.event.inputs.ndcs || 1 }}
+          NPCS: ${{ github.event.inputs.npcs || 1 }}
+          BS: ${{ github.event.inputs.bs || 4096 }}
+          CHUNK_BS: ${{ github.event.inputs.chunk_bs || 4096 }}
+          TEST_START_TIME: ${{ env.TEST_START_TIME }}
+          TEST_END_TIME: ${{ env.TEST_END_TIME }}
         run: |
-          GITHUB_RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}"
-          LOGS_URL="http://192.168.10.164:9001/browser/e2e-run-logs/${RUN_ID}%2F"
-          if [[ ${{ job.status }} == 'success' ]]; then
-            OVERALL_STATUS=":white_check_mark: Overall Status: SUCCESS"
-          else
-            OVERALL_STATUS=":x: Overall Status: FAILURE <!channel>"
-          fi
+          python3 - <<'PYEOF'
+          import json, os, re, sys, urllib.request, urllib.error
 
-          TIME_TAKEN="${TEST_TIME_HOURS}h ${TEST_TIME_MINS}m ${TEST_TIME_SECS}s"
-          COMMIT_SHA=$(git rev-parse --short HEAD)
-          COMMIT_AUTHOR=$(git log -1 --pretty=format:'%an')
+          webhook = os.environ.get("SLACK_WEBHOOK_URL", "")
+          if not webhook:
+              print("No SLACK_WEBHOOK_URL set, skipping.")
+              sys.exit(0)
 
-          MESSAGE="Python E2E tests run triggered on branch *${BRANCH_NAME}* at ${COMMIT_SHA} by ${COMMIT_AUTHOR}. \nTotal Time Taken to run the tests: ${TIME_TAKEN}. \n\n${OVERALL_STATUS}\nGitHub Run: ${GITHUB_RUN_URL}\nAWS Logs: ${LOGS_URL}\n\n*Configuration*: *NDCS: ${NDCS}, NPCS: ${NPCS}, Block Size: ${BS}, Chunk Block Size: ${CHUNK_BS}*\n\nTotal Tests: *${TOTAL_TESTS}*, Passed Tests: *${PASSED_TESTS}*, Failed Tests: *${FAILED_TESTS}*\n\n:hourglass_flowing_sand: _Logs are being collected and will be available shortly._\n\n-- Test Cases Passed :white_check_mark:\n${PASSED_CASES_BULLETS}\n\n-- Test Cases Failed :x:\n${FAILED_CASES_BULLETS}\n\n-- Test Cases Skipped :x:\n${SKIPPED_CASES_BULLETS}"
+          # Find latest log file
+          import glob
+          log_dir = os.path.join(os.environ.get("GITHUB_WORKSPACE", "."), "e2e", "logs")
+          log_files = sorted(glob.glob(os.path.join(log_dir, "*.log")), key=os.path.getmtime, reverse=True)
+          content = ""
+          for lf in log_files:
+              if os.path.getsize(lf) > 0:
+                  content = open(lf).read()
+                  break
 
-          curl -X POST -H 'Content-type: application/json' --data "{\"text\":\"${MESSAGE}\"}" $SLACK_WEBHOOK_URL
+          # --- Counts (e2e.py format) ---
+          def px(pat):
+              m = re.search(pat, content)
+              return int(m.group(1)) if m else 0
+          total   = px(r'Number of Total Cases:\s*(\d+)')
+          passed  = px(r'Number of Passed Cases:\s*(\d+)')
+          failed  = px(r'Number of Failed Cases:\s*(\d+)')
+          skipped = px(r'Number of Skipped Cases:\s*(\d+)')
+          pass_pct = (passed * 100 // total) if total > 0 else 0
+
+          # --- Per-test results ---
+          ansi = re.compile(r'\x1b\[[0-9;]*m')
+          test_results = []
+          for line in content.splitlines():
+              clean = ansi.sub('', line)
+              if not re.search(r'(PASSED|FAILED|SKIPPED) CASE', clean):
+                  continue
+              m = re.search(r'Test[A-Za-z0-9_]+', clean)
+              if not m:
+                  continue
+              name = m.group(0)
+              if   'PASSED CASE'  in clean: test_results.append(('PASSED',  name))
+              elif 'FAILED CASE'  in clean: test_results.append(('FAILED',  name))
+              elif 'SKIPPED CASE' in clean: test_results.append(('SKIPPED', name))
+
+          # --- Failure reason ---
+          failure_reason = ""
+          multi = [ansi.sub('', l) for l in content.splitlines() if 'MultipleExceptions:' in l]
+          if multi:
+              failure_reason = multi[0][:2000]
+          elif content:
+              exc_lines = [ansi.sub('', l) for l in content.splitlines()
+                           if re.search(r'(Exception:|AssertionError|Input/output error)', l)]
+              if exc_lines:
+                  failure_reason = '\n'.join(exc_lines[-5:])[:2000]
+
+          # --- Env ---
+          s    = int(os.environ.get("TEST_START_TIME", "0") or "0")
+          e    = int(os.environ.get("TEST_END_TIME",   "0") or "0")
+          secs = max(0, e - s) if e >= s > 0 else 0
+          dur  = f"{secs//3600}h {(secs%3600)//60}m {secs%60}s"
+          run_url  = os.environ.get("SLACK_RUN_URL",   "")
+          ndcs     = os.environ.get("NDCS",            "?")
+          npcs     = os.environ.get("NPCS",            "?")
+          bs       = os.environ.get("BS",              "?")
+          chunk_bs = os.environ.get("CHUNK_BS",        "?")
+          test_cls = os.environ.get("TESTNAME",        "") or "all"
+          branch   = os.environ.get("GITHUB_REF_NAME", "?")
+          wf_name  = os.environ.get("SLACK_WF_NAME",   "Run")
+          ok       = os.environ.get("JOB_STATUS",      "") == "success"
+
+          icon    = ":white_check_mark:" if ok else ":x:"
+          status  = "SUCCESS" if ok else "FAILURE"
+          mention = "" if ok else " <!channel>"
+
+          lines = [
+              f"{icon} *SimplyBlock {wf_name}*{mention}",
+              f"*Status:* {status}  |  *Duration:* {dur}",
+              f"*Branch:* `{branch}`  |  *Test class:* `{test_cls}`",
+              f"*Config:* NDCS={ndcs} NPCS={npcs} BS={bs} ChunkBS={chunk_bs}",
+              "",
+          ]
+
+          if total > 0:
+              lines += [
+                  f":white_check_mark: *Passed:*  {passed}/{total}  ({pass_pct}%)",
+                  f":x: *Failed:*  {failed}",
+                  f":fast_forward: *Skipped:*  {skipped}",
+              ]
+          else:
+              lines.append("_(test counts not found in log)_")
+
+          if test_results:
+              lines.append("")
+              lines.append("*Test Results:*")
+              icons = {'PASSED': ':white_check_mark:', 'FAILED': ':x:', 'SKIPPED': ':fast_forward:'}
+              for st, nm in test_results:
+                  lines.append(f"{icons.get(st, ':grey_question:')} `{nm}`")
+
+          if failure_reason:
+              lines += ["", "*Failure:*", f"```{failure_reason}```"]
+
+          lines += [
+              "",
+              f":link: *Run:* <{run_url}|View on GitHub>",
+              f":hourglass_flowing_sand: _Logs are being collected and will be available shortly._",
+          ]
+
+          payload = {"text": "\n".join(lines)}
+          req = urllib.request.Request(
+              webhook,
+              data=json.dumps(payload).encode(),
+              headers={"Content-Type": "application/json"},
+          )
+          try:
+              urllib.request.urlopen(req, timeout=15)
+              print("Slack notification sent.")
+          except Exception as exc:
+              print(f"WARN: Slack notification failed: {exc}", file=sys.stderr)
+          PYEOF
 
 
       - name: Collect Graylog/OpenSearch logs
@@ -440,6 +620,19 @@ jobs:
             ssh "${SSH_OPTS[@]}" "root@${MGMT_IP}" "rm -rf '${REMOTE_OUTPUT_DIR}'" 2>/dev/null || true
           done
           echo "=== Log collection complete (${CHUNK} chunks, newest-first): ${OUTPUT_DIR} ==="
+
+      - name: Notify Slack log collection complete
+        if: always() && (github.event_name == 'schedule' || env.send_slack_notification == 'true')
+        shell: bash
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+        run: |
+          if [ -z "${SLACK_WEBHOOK_URL:-}" ]; then exit 0; fi
+          MSG=":white_check_mark: *Log collection complete* for *SimplyBlock E2E Docker*\n:link: <${SLACK_RUN_URL}|View Run>"
+          curl -s -X POST "${SLACK_WEBHOOK_URL}" \
+            -H 'Content-Type: application/json' \
+            -d "{\"text\":\"${MSG}\"}" || true
 
       - name: Upload automation and docker logs to miniio
         run: |

--- a/.github/workflows/e2e-docker.yml
+++ b/.github/workflows/e2e-docker.yml
@@ -351,6 +351,8 @@ jobs:
         shell: bash
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
           JOB_STATUS: ${{ job.status }}
           SLACK_RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           GITHUB_REF_NAME: ${{ github.ref_name }}
@@ -366,9 +368,11 @@ jobs:
           python3 - <<'PYEOF'
           import json, os, re, sys, urllib.request, urllib.error
 
-          webhook = os.environ.get("SLACK_WEBHOOK_URL", "")
-          if not webhook:
-              print("No SLACK_WEBHOOK_URL set, skipping.")
+          bot_token = os.environ.get("SLACK_BOT_TOKEN", "")
+          channel   = os.environ.get("SLACK_CHANNEL_ID", "")
+          webhook   = os.environ.get("SLACK_WEBHOOK_URL", "")
+          if not bot_token and not webhook:
+              print("No SLACK_BOT_TOKEN or SLACK_WEBHOOK_URL set, skipping.")
               sys.exit(0)
 
           # Find latest log file
@@ -469,17 +473,46 @@ jobs:
               f":hourglass_flowing_sand: _Logs are being collected and will be available shortly._",
           ]
 
-          payload = {"text": "\n".join(lines)}
-          req = urllib.request.Request(
-              webhook,
-              data=json.dumps(payload).encode(),
-              headers={"Content-Type": "application/json"},
-          )
-          try:
-              urllib.request.urlopen(req, timeout=15)
-              print("Slack notification sent.")
-          except Exception as exc:
-              print(f"WARN: Slack notification failed: {exc}", file=sys.stderr)
+          # --- Send ---
+          gh_env = os.environ.get("GITHUB_ENV", "")
+          text   = "\n".join(lines)
+
+          if bot_token and channel:
+              api_payload = json.dumps({"channel": channel, "text": text}).encode()
+              req = urllib.request.Request(
+                  "https://slack.com/api/chat.postMessage",
+                  data=api_payload,
+                  headers={
+                      "Content-Type": "application/json; charset=utf-8",
+                      "Authorization": f"Bearer {bot_token}",
+                  },
+              )
+              try:
+                  resp = urllib.request.urlopen(req, timeout=15)
+                  body = json.loads(resp.read().decode())
+                  if body.get("ok"):
+                      ts = body.get("ts", "")
+                      print(f"Slack notification sent via Bot API (ts={ts}).")
+                      if gh_env and ts:
+                          with open(gh_env, "a") as f:
+                              f.write(f"SLACK_MSG_TS={ts}\n")
+                  else:
+                      print(f"WARN: Slack API error: {body.get('error')}", file=sys.stderr)
+              except Exception as exc:
+                  print(f"WARN: Slack Bot API failed: {exc}", file=sys.stderr)
+          elif webhook:
+              req = urllib.request.Request(
+                  webhook,
+                  data=json.dumps({"text": text}).encode(),
+                  headers={"Content-Type": "application/json"},
+              )
+              try:
+                  urllib.request.urlopen(req, timeout=15)
+                  print("Slack notification sent via webhook (no thread support).")
+              except Exception as exc:
+                  print(f"WARN: Slack webhook failed: {exc}", file=sys.stderr)
+          else:
+              print("No SLACK_BOT_TOKEN or SLACK_WEBHOOK_URL set, skipping.")
           PYEOF
 
 
@@ -625,14 +658,23 @@ jobs:
         if: always() && (github.event_name == 'schedule' || env.send_slack_notification == 'true')
         shell: bash
         env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
+          SLACK_MSG_TS: ${{ env.SLACK_MSG_TS }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
         run: |
-          if [ -z "${SLACK_WEBHOOK_URL:-}" ]; then exit 0; fi
           MSG=":white_check_mark: *Log collection complete* for *SimplyBlock E2E Docker*\n:link: <${SLACK_RUN_URL}|View Run>"
-          curl -s -X POST "${SLACK_WEBHOOK_URL}" \
-            -H 'Content-Type: application/json' \
-            -d "{\"text\":\"${MSG}\"}" || true
+          if [ -n "${SLACK_BOT_TOKEN:-}" ] && [ -n "${SLACK_CHANNEL_ID:-}" ] && [ -n "${SLACK_MSG_TS:-}" ]; then
+            curl -s -X POST "https://slack.com/api/chat.postMessage" \
+              -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
+              -H "Content-Type: application/json; charset=utf-8" \
+              -d "{\"channel\":\"${SLACK_CHANNEL_ID}\",\"thread_ts\":\"${SLACK_MSG_TS}\",\"text\":\"${MSG}\"}" || true
+          elif [ -n "${SLACK_WEBHOOK_URL:-}" ]; then
+            curl -s -X POST "${SLACK_WEBHOOK_URL}" \
+              -H "Content-Type: application/json" \
+              -d "{\"text\":\"${MSG}\"}" || true
+          fi
 
       - name: Upload automation and docker logs to miniio
         run: |

--- a/.github/workflows/e2e-only.yml
+++ b/.github/workflows/e2e-only.yml
@@ -372,7 +372,7 @@ jobs:
           fi
           NEW_NODES_ARGS=()
           if [[ -n "${NEW_NODE_IPS:-}" ]]; then
-            NEW_NODES_ARGS=(--new_nodes ${NEW_NODE_IPS})
+            NEW_NODES_ARGS=(--new_nodes "${NEW_NODE_IPS}")
           fi
           python3 -u e2e.py \
             "${TESTNAME_ARGS[@]}" \

--- a/.github/workflows/e2e-only.yml
+++ b/.github/workflows/e2e-only.yml
@@ -910,6 +910,8 @@ jobs:
         shell: bash
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
           JOB_STATUS: ${{ job.status }}
           SLACK_RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           GITHUB_REF_NAME: ${{ github.ref_name }}
@@ -919,9 +921,11 @@ jobs:
           python3 - <<'PYEOF'
           import json, os, re, sys, urllib.request, urllib.error
 
-          webhook = os.environ.get("SLACK_WEBHOOK_URL", "")
-          if not webhook:
-              print("No SLACK_WEBHOOK_URL set, skipping.")
+          bot_token = os.environ.get("SLACK_BOT_TOKEN", "")
+          channel   = os.environ.get("SLACK_CHANNEL_ID", "")
+          webhook   = os.environ.get("SLACK_WEBHOOK_URL", "")
+          if not bot_token and not webhook:
+              print("No SLACK_BOT_TOKEN or SLACK_WEBHOOK_URL set, skipping.")
               sys.exit(0)
 
           out_log = "sbcli/e2e/output.log"
@@ -1016,17 +1020,46 @@ jobs:
               f":hourglass_flowing_sand: _Logs are being collected and will be available shortly._",
           ]
 
-          payload = {"text": "\n".join(lines)}
-          req = urllib.request.Request(
-              webhook,
-              data=json.dumps(payload).encode(),
-              headers={"Content-Type": "application/json"},
-          )
-          try:
-              urllib.request.urlopen(req, timeout=15)
-              print("Slack notification sent.")
-          except Exception as exc:
-              print(f"WARN: Slack notification failed: {exc}", file=sys.stderr)
+          # --- Send ---
+          gh_env = os.environ.get("GITHUB_ENV", "")
+          text   = "\n".join(lines)
+
+          if bot_token and channel:
+              api_payload = json.dumps({"channel": channel, "text": text}).encode()
+              req = urllib.request.Request(
+                  "https://slack.com/api/chat.postMessage",
+                  data=api_payload,
+                  headers={
+                      "Content-Type": "application/json; charset=utf-8",
+                      "Authorization": f"Bearer {bot_token}",
+                  },
+              )
+              try:
+                  resp = urllib.request.urlopen(req, timeout=15)
+                  body = json.loads(resp.read().decode())
+                  if body.get("ok"):
+                      ts = body.get("ts", "")
+                      print(f"Slack notification sent via Bot API (ts={ts}).")
+                      if gh_env and ts:
+                          with open(gh_env, "a") as f:
+                              f.write(f"SLACK_MSG_TS={ts}\n")
+                  else:
+                      print(f"WARN: Slack API error: {body.get('error')}", file=sys.stderr)
+              except Exception as exc:
+                  print(f"WARN: Slack Bot API failed: {exc}", file=sys.stderr)
+          elif webhook:
+              req = urllib.request.Request(
+                  webhook,
+                  data=json.dumps({"text": text}).encode(),
+                  headers={"Content-Type": "application/json"},
+              )
+              try:
+                  urllib.request.urlopen(req, timeout=15)
+                  print("Slack notification sent via webhook (no thread support).")
+              except Exception as exc:
+                  print(f"WARN: Slack webhook failed: {exc}", file=sys.stderr)
+          else:
+              print("No SLACK_BOT_TOKEN or SLACK_WEBHOOK_URL set, skipping.")
           PYEOF
 
       - name: Upload logs (always)

--- a/.github/workflows/k8s-e2e-ha.yaml
+++ b/.github/workflows/k8s-e2e-ha.yaml
@@ -440,63 +440,238 @@ jobs:
 
       - name: Write Job Summary
         if: always()
+        shell: bash
         run: |
-          {
-            echo "## K8s E2E HA Run Summary"
-            echo ""
-            if [[ "${{ job.status }}" == "success" ]]; then
-              echo "**Result:** SUCCESS"
-            else
-              echo "**Result:** FAILED"
+          set -euxo pipefail
+
+          dur_fmt="${TEST_TIME_HOURS:-0}h ${TEST_TIME_MINS:-0}m ${TEST_TIME_SECS:-0}s"
+
+          # --- Parse test counts ---
+          total_cases="${TOTAL_TESTS:-0}"
+          passed_cases="${PASSED_TESTS:-0}"
+          failed_cases="${FAILED_TESTS:-0}"
+          skipped_cases=0
+
+          pass_pct=0; fail_pct=0
+          if [[ "${total_cases}" =~ ^[0-9]+$ && "${total_cases}" -gt 0 ]]; then
+            pass_pct=$(( (passed_cases  * 100) / total_cases ))
+            fail_pct=$(( (failed_cases  * 100) / total_cases ))
+          fi
+
+          # --- Parse per-test status from log ---
+          test_details_table=""
+          log_file=""
+          for f in $GITHUB_WORKSPACE/e2e/logs/*.log; do
+            [ -s "$f" ] && log_file="$f"
+          done
+          if [[ -n "${log_file}" ]]; then
+            while IFS= read -r line; do
+              clean="$(printf '%s' "${line}" | sed 's/\x1b\[[0-9;]*m//g')"
+              test_name="$(printf '%s' "${clean}" | grep -oE 'Test[A-Za-z0-9_]+' | head -n1 || true)"
+              [[ -z "${test_name}" ]] && continue
+              if   printf '%s' "${clean}" | grep -qi 'PASSED CASE';  then icon="✅"; status="PASSED"
+              elif printf '%s' "${clean}" | grep -qi 'FAILED CASE';  then icon="❌"; status="FAILED"
+              elif printf '%s' "${clean}" | grep -qi 'SKIPPED CASE'; then icon="⏭"; status="SKIPPED"
+              else continue
+              fi
+              test_details_table+="| \`${test_name}\` | ${icon} ${status} |"$'\n'
+            done < <(grep -iE 'PASSED CASE|FAILED CASE|SKIPPED CASE' "${log_file}" 2>/dev/null || true)
+          fi
+
+          # --- Failure reason ---
+          failure_reason=""
+          if [[ -n "${log_file}" ]]; then
+            multi="$(grep 'MultipleExceptions:' "${log_file}" | sed 's/\x1b\[[0-9;]*m//g' || true)"
+            if [[ -n "${multi}" ]]; then
+              failure_reason="${multi}"
+            elif grep -Eqi 'Traceback \(most recent call last\)|Exception:|AssertionError|Input/output error' "${log_file}"; then
+              failure_reason="$(grep -Ei 'Traceback \(most recent call last\)|Exception:|AssertionError|Input/output error' "${log_file}" | tail -n 3 | sed 's/\x1b\[[0-9;]*m//g' || true)"
             fi
+          fi
+
+          # --- Overall result ---
+          conclusion="✅ SUCCESS"
+          if [[ "${{ job.status }}" != "success" ]]; then
+            conclusion="❌ FAILED"
+          fi
+
+          {
+            echo "## SimplyBlock K8s E2E HA Run Summary"
             echo ""
+            echo "**Result:** ${conclusion} &nbsp;|&nbsp; **Duration:** ${dur_fmt}"
+            echo ""
+
             echo "### Test Results"
-            echo "- **Total:** ${TOTAL_TESTS:-?} | **Passed:** ${PASSED_TESTS:-?} | **Failed:** ${FAILED_TESTS:-?}"
+            echo "| | Count | % |"
+            echo "|---|---|---|"
+            echo "| ✅ Passed  | ${passed_cases}  | ${pass_pct}% |"
+            echo "| ❌ Failed  | ${failed_cases}  | ${fail_pct}% |"
+            echo "| **Total**  | **${total_cases}** | |"
             echo ""
+
+            if [[ -n "${test_details_table}" ]]; then
+              echo "### Test Case Details"
+              echo "| Test | Result |"
+              echo "|---|---|"
+              printf '%s' "${test_details_table}"
+              echo ""
+            fi
+
             echo "### Run Info"
+            echo "- **Test class:** \`${TESTNAME:-all}\`"
             echo "- **Branch:** \`${{ github.ref_name }}\`"
-            echo "- **Duration:** ${TEST_TIME_HOURS:-0}h ${TEST_TIME_MINS:-0}m ${TEST_TIME_SECS:-0}s"
+            echo "- **NDCS/NPCS:** \`${NDCS}/${NPCS}\`"
+            echo "- **BS/Chunk BS:** \`${BS}/${CHUNK_BS}\`"
             echo ""
-            echo "> **Note:** Graylog/OpenSearch logs are currently being collected and will be available in the NFS log directory shortly."
+
+            if [[ -n "${failure_reason}" ]]; then
+              echo "### Failure Reason"
+              echo '```'
+              printf '%s\n' "${failure_reason}"
+              echo '```'
+              echo ""
+            fi
           } >> "$GITHUB_STEP_SUMMARY"
+        env:
+          TESTNAME: ${{ github.event.inputs.testname || '' }}
+          NDCS: ${{ env.NDCS }}
+          NPCS: ${{ env.NPCS }}
+          BS: ${{ env.BS }}
+          CHUNK_BS: ${{ env.CHUNK_BS }}
 
       - name: Send Slack Notification
         if: always() && (github.event_name == 'schedule' || env.send_slack_notification == 'true')
+        shell: bash
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          GITHUB_SERVER_URL: ${{ github.server_url }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
-          S3_BUCKET_NAME: "simplyblock-e2e-test-logs"
-          RUN_ID: ${{ github.run_id }}
-          PASSED_TESTS: ${{ env.PASSED_TESTS }}
-          FAILED_TESTS: ${{ env.FAILED_TESTS }}
-          TOTAL_TESTS: ${{ env.TOTAL_TESTS }}
-          PASSED_CASES: ${{ env.PASSED_CASES }}
-          FAILED_CASES: ${{ env.FAILED_CASES }}
-          PASSED_CASES_BULLETS: ${{ env.PASSED_CASES_BULLETS }}
-          FAILED_CASES_BULLETS: ${{ env.FAILED_CASES_BULLETS }}
-          BRANCH_NAME: ${{ github.ref_name }}
-          TEST_TIME_HOURS: ${{ env.TEST_TIME_HOURS }}
-          TEST_TIME_MINS: ${{ env.TEST_TIME_MINS }}
-          TEST_TIME_SECS: ${{ env.TEST_TIME_SECS }}
+          JOB_STATUS: ${{ job.status }}
+          SLACK_RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          GITHUB_REF_NAME: ${{ github.ref_name }}
+          SLACK_WF_NAME: "K8s E2E HA"
+          TESTNAME: ${{ github.event.inputs.testname || 'all' }}
           NDCS: ${{ env.NDCS }}
           NPCS: ${{ env.NPCS }}
-          CHUNK_BS: ${{ env.CHUNK_BS }}
           BS: ${{ env.BS }}
+          CHUNK_BS: ${{ env.CHUNK_BS }}
+          TEST_START_TIME: ${{ env.TEST_START_TIME }}
+          TEST_END_TIME: ${{ env.TEST_END_TIME }}
         run: |
-          GITHUB_RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}"
-          AWS_LOGS_URL="https://s3.console.aws.amazon.com/s3/buckets/${S3_BUCKET_NAME}?prefix=${RUN_ID}/&region=us-east-2"
-          if [[ ${{ job.status }} == 'success' ]]; then
-            OVERALL_STATUS=":white_check_mark: Overall Status: SUCCESS"
-          else
-            OVERALL_STATUS=":x: Overall Status: FAILURE <!channel>"
-          fi
+          python3 - <<'PYEOF'
+          import json, os, re, sys, urllib.request, urllib.error, glob
 
-          TIME_TAKEN="${TEST_TIME_HOURS}h ${TEST_TIME_MINS}m ${TEST_TIME_SECS}s"
+          webhook = os.environ.get("SLACK_WEBHOOK_URL", "")
+          if not webhook:
+              print("No SLACK_WEBHOOK_URL set, skipping.")
+              sys.exit(0)
 
-          MESSAGE="Python E2E *K8s* tests run triggered on branch *${BRANCH_NAME}*. \nTotal Time Taken to run the tests: ${TIME_TAKEN}. \n\n${OVERALL_STATUS}\nGitHub Run: ${GITHUB_RUN_URL}\nAWS Logs: ${AWS_LOGS_URL}\n\n*Configuration*: *NDCS: ${NDCS}, NPCS: ${NPCS}, Block Size: ${BS}, Chunk Block Size: ${CHUNK_BS}*\n\nTotal Tests: *${TOTAL_TESTS}*, Passed Tests: *${PASSED_TESTS}*, Failed Tests: *${FAILED_TESTS}*\n\n:hourglass_flowing_sand: _Logs are being collected and will be available shortly._\n\n-- Test Cases Passed :white_check_mark:\n${PASSED_CASES_BULLETS}\n\n-- Test Cases Failed :x:\n${FAILED_CASES_BULLETS}"
+          # Find latest log file
+          log_dir = os.path.join(os.environ.get("GITHUB_WORKSPACE", "."), "e2e", "logs")
+          log_files = sorted(glob.glob(os.path.join(log_dir, "*.log")), key=os.path.getmtime, reverse=True)
+          content = ""
+          for lf in log_files:
+              if os.path.getsize(lf) > 0:
+                  content = open(lf).read()
+                  break
 
-          curl -X POST -H 'Content-type: application/json' --data "{\"text\":\"${MESSAGE}\"}" $SLACK_WEBHOOK_URL
+          # --- Counts (e2e.py format) ---
+          def px(pat):
+              m = re.search(pat, content)
+              return int(m.group(1)) if m else 0
+          total   = px(r'Number of Total Cases:\s*(\d+)')
+          passed  = px(r'Number of Passed Cases:\s*(\d+)')
+          failed  = px(r'Number of Failed Cases:\s*(\d+)')
+          skipped = px(r'Number of Skipped Cases:\s*(\d+)')
+          pass_pct = (passed * 100 // total) if total > 0 else 0
+
+          # --- Per-test results ---
+          ansi = re.compile(r'\x1b\[[0-9;]*m')
+          test_results = []
+          for line in content.splitlines():
+              clean = ansi.sub('', line)
+              if not re.search(r'(PASSED|FAILED|SKIPPED) CASE', clean):
+                  continue
+              m = re.search(r'Test[A-Za-z0-9_]+', clean)
+              if not m:
+                  continue
+              name = m.group(0)
+              if   'PASSED CASE'  in clean: test_results.append(('PASSED',  name))
+              elif 'FAILED CASE'  in clean: test_results.append(('FAILED',  name))
+              elif 'SKIPPED CASE' in clean: test_results.append(('SKIPPED', name))
+
+          # --- Failure reason ---
+          failure_reason = ""
+          multi = [ansi.sub('', l) for l in content.splitlines() if 'MultipleExceptions:' in l]
+          if multi:
+              failure_reason = multi[0][:2000]
+          elif content:
+              exc_lines = [ansi.sub('', l) for l in content.splitlines()
+                           if re.search(r'(Exception:|AssertionError|Input/output error)', l)]
+              if exc_lines:
+                  failure_reason = '\n'.join(exc_lines[-5:])[:2000]
+
+          # --- Env ---
+          s    = int(os.environ.get("TEST_START_TIME", "0") or "0")
+          e    = int(os.environ.get("TEST_END_TIME",   "0") or "0")
+          secs = max(0, e - s) if e >= s > 0 else 0
+          dur  = f"{secs//3600}h {(secs%3600)//60}m {secs%60}s"
+          run_url  = os.environ.get("SLACK_RUN_URL",   "")
+          ndcs     = os.environ.get("NDCS",            "?")
+          npcs     = os.environ.get("NPCS",            "?")
+          bs       = os.environ.get("BS",              "?")
+          chunk_bs = os.environ.get("CHUNK_BS",        "?")
+          test_cls = os.environ.get("TESTNAME",        "") or "all"
+          branch   = os.environ.get("GITHUB_REF_NAME", "?")
+          wf_name  = os.environ.get("SLACK_WF_NAME",   "Run")
+          ok       = os.environ.get("JOB_STATUS",      "") == "success"
+
+          icon    = ":white_check_mark:" if ok else ":x:"
+          status  = "SUCCESS" if ok else "FAILURE"
+          mention = "" if ok else " <!channel>"
+
+          lines = [
+              f"{icon} *SimplyBlock {wf_name}*{mention}",
+              f"*Status:* {status}  |  *Duration:* {dur}",
+              f"*Branch:* `{branch}`  |  *Test class:* `{test_cls}`",
+              f"*Config:* NDCS={ndcs} NPCS={npcs} BS={bs} ChunkBS={chunk_bs}",
+              "",
+          ]
+
+          if total > 0:
+              lines += [
+                  f":white_check_mark: *Passed:*  {passed}/{total}  ({pass_pct}%)",
+                  f":x: *Failed:*  {failed}",
+                  f":fast_forward: *Skipped:*  {skipped}",
+              ]
+          else:
+              lines.append("_(test counts not found in log)_")
+
+          if test_results:
+              lines.append("")
+              lines.append("*Test Results:*")
+              icons = {'PASSED': ':white_check_mark:', 'FAILED': ':x:', 'SKIPPED': ':fast_forward:'}
+              for st, nm in test_results:
+                  lines.append(f"{icons.get(st, ':grey_question:')} `{nm}`")
+
+          if failure_reason:
+              lines += ["", "*Failure:*", f"```{failure_reason}```"]
+
+          lines += [
+              "",
+              f":link: *Run:* <{run_url}|View on GitHub>",
+          ]
+
+          payload = {"text": "\n".join(lines)}
+          req = urllib.request.Request(
+              webhook,
+              data=json.dumps(payload).encode(),
+              headers={"Content-Type": "application/json"},
+          )
+          try:
+              urllib.request.urlopen(req, timeout=15)
+              print("Slack notification sent.")
+          except Exception as exc:
+              print(f"WARN: Slack notification failed: {exc}", file=sys.stderr)
+          PYEOF
 
 
       - name: Upload automation and docker logs to s3
@@ -512,6 +687,151 @@ jobs:
           AWS_REGION: ${{ secrets.AWS_REGION }}
           S3_BUCKET_NAME: "simplyblock-e2e-test-logs"
           RUN_ID: ${{ github.run_id }}
+      - name: Collect Graylog/OpenSearch logs
+        if: '!cancelled()'
+        timeout-minutes: 60
+        run: |
+          set +e
+          echo "=== Collecting Graylog/OpenSearch logs ==="
+
+          MGMT_IP="${{ steps.terraform_outputs.outputs.mgmt_private_ip }}"
+          BASTION_IP="${{ steps.terraform_outputs.outputs.bastion_public_ip }}"
+          KEY_NAME="${{ steps.terraform_outputs.outputs.key_name }}"
+          CLUSTER_ID="${{ steps.bootstrap_cluster.outputs.cluster_id }}"
+
+          if [ -z "${MGMT_IP}" ] || [ -z "${BASTION_IP}" ]; then
+            echo "WARN: MGMT_IP or BASTION_IP not available, skipping"
+            exit 0
+          fi
+          if [ -z "${TEST_START_TIME:-}" ] || [ -z "${TEST_END_TIME:-}" ]; then
+            echo "WARN: TEST_START_TIME or TEST_END_TIME not set, skipping"
+            exit 0
+          fi
+
+          ELAPSED=$((TEST_END_TIME - TEST_START_TIME))
+          [ "${ELAPSED}" -le 0 ] && exit 0
+
+          SSH_OPTS=(-i "$HOME/.ssh/${KEY_NAME}" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10)
+          PROXY_CMD="ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i $HOME/.ssh/${KEY_NAME} -W %h:%p ec2-user@${BASTION_IP}"
+          SSH_CMD=(ssh "${SSH_OPTS[@]}" -o "ProxyCommand=${PROXY_CMD}" "ec2-user@${MGMT_IP}")
+
+          WINDOW_START=$((TEST_START_TIME - 3600))
+          WINDOW_END=$((TEST_END_TIME + 3600))
+
+          OUTPUT_DIR="$GITHUB_WORKSPACE/e2e/logs/graylog_collected"
+          mkdir -p "${OUTPUT_DIR}" 2>/dev/null || true
+
+          epoch_to_iso() {
+            python3 -c "from datetime import datetime,timezone; print(datetime.fromtimestamp($1,tz=timezone.utc).strftime('%Y-%m-%dT%H:%M:%S'))"
+          }
+
+          _CHUNK_STARTS=()
+          _C=${WINDOW_START}
+          while [ ${_C} -lt ${WINDOW_END} ]; do
+            _CHUNK_STARTS+=(${_C})
+            _C=$((_C + 3600))
+          done
+          NUM_CHUNKS=${#_CHUNK_STARTS[@]}
+
+          run_collect() {
+            local iso=$1 mins=$2 outdir=$3 extra_flag=${4:-}
+            "${SSH_CMD[@]}" \
+              "python3 -m simplyblock_core.scripts.collect_logs \
+                '${iso}' '${mins}' \
+                --mode docker \
+                --output-dir '${outdir}' \
+                ${extra_flag} \
+                ${CLUSTER_ID:+--cluster-id '${CLUSTER_ID}'}" \
+            2>&1
+            local rc=$?
+            [ $rc -ne 0 ] && return $rc
+            local has_content
+            has_content=$("${SSH_CMD[@]}" "find '${outdir}' -name '*.tar.gz' -size +0 2>/dev/null | head -1")
+            [ -z "${has_content}" ] && return 1
+          }
+
+          collect_adaptive() {
+            local start_epoch=$1 end_epoch=$2 outdir=$3 extra_flag=${4:-}
+            local duration=$((end_epoch - start_epoch))
+            local mins=$(( (duration + 59) / 60 ))
+            local iso=$(epoch_to_iso ${start_epoch})
+            if run_collect "${iso}" "${mins}" "${outdir}" "${extra_flag}"; then
+              return 0
+            fi
+            echo "  WARN: ${mins}m window failed, retrying with 5-min sub-windows..."
+            local sub_start=${start_epoch}
+            while [ ${sub_start} -lt ${end_epoch} ]; do
+              local sub_end=$((sub_start + 300))
+              [ ${sub_end} -gt ${end_epoch} ] && sub_end=${end_epoch}
+              local sub_mins=$(( ((sub_end - sub_start) + 59) / 60 ))
+              local sub_iso=$(epoch_to_iso ${sub_start})
+              run_collect "${sub_iso}" "${sub_mins}" "${outdir}" "${extra_flag}" || \
+                echo "  WARN: 5-min sub-window at ${sub_iso} failed"
+              sub_start=${sub_end}
+            done
+          }
+
+          SCP_OPTS=(-i "$HOME/.ssh/${KEY_NAME}" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o "ProxyCommand=${PROXY_CMD}")
+
+          PREFER_OPENSEARCH=""
+          CHUNK=0
+          for (( _IDX=NUM_CHUNKS-1; _IDX>=0; _IDX-- )); do
+            CHUNK=$((CHUNK + 1))
+            CHUNK_START=${_CHUNK_STARTS[$_IDX]}
+            CHUNK_END=$((CHUNK_START + 3600))
+            [ ${CHUNK_END} -gt ${WINDOW_END} ] && CHUNK_END=${WINDOW_END}
+            CHUNK_MINUTES=$(( ((CHUNK_END - CHUNK_START) + 59) / 60 ))
+            CHUNK_ISO=$(epoch_to_iso ${CHUNK_START})
+            echo "--- Chunk ${CHUNK}/${NUM_CHUNKS}: ${CHUNK_ISO} for ${CHUNK_MINUTES}m ---"
+
+            REMOTE_DIR="/tmp/graylog_collect_chunk${CHUNK}"
+            "${SSH_CMD[@]}" "mkdir -p '${REMOTE_DIR}'" 2>/dev/null || true
+
+            if [ -z "${PREFER_OPENSEARCH}" ]; then
+              if run_collect "${CHUNK_ISO}" "${CHUNK_MINUTES}" "${REMOTE_DIR}" "--use-opensearch"; then
+                PREFER_OPENSEARCH=true
+                echo "  OpenSearch works — using it for all chunks"
+              else
+                PREFER_OPENSEARCH=false
+                echo "  OpenSearch unavailable — using Graylog"
+                "${SSH_CMD[@]}" "rm -rf '${REMOTE_DIR}'; mkdir -p '${REMOTE_DIR}'" 2>/dev/null || true
+                collect_adaptive ${CHUNK_START} ${CHUNK_END} "${REMOTE_DIR}" || true
+              fi
+            elif [ "${PREFER_OPENSEARCH}" = "true" ]; then
+              collect_adaptive ${CHUNK_START} ${CHUNK_END} "${REMOTE_DIR}" "--use-opensearch" || \
+                collect_adaptive ${CHUNK_START} ${CHUNK_END} "${REMOTE_DIR}" || true
+            else
+              collect_adaptive ${CHUNK_START} ${CHUNK_END} "${REMOTE_DIR}" || \
+                collect_adaptive ${CHUNK_START} ${CHUNK_END} "${REMOTE_DIR}" "--use-opensearch" || true
+            fi
+
+            TARBALLS=$("${SSH_CMD[@]}" "find '${REMOTE_DIR}' -name '*.tar.gz' -type f 2>/dev/null") || true
+            if [ -n "${TARBALLS}" ]; then
+              for TB in ${TARBALLS}; do
+                scp "${SCP_OPTS[@]}" "ec2-user@${MGMT_IP}:${TB}" "${OUTPUT_DIR}/$(basename ${TB})" 2>&1 || true
+              done
+              for TB_FILE in "${OUTPUT_DIR}"/*.tar.gz; do
+                [ -f "${TB_FILE}" ] && tar -xzf "${TB_FILE}" -C "${OUTPUT_DIR}/" 2>/dev/null || true
+              done
+            fi
+            "${SSH_CMD[@]}" "rm -rf '${REMOTE_DIR}'" 2>/dev/null || true
+          done
+          echo "=== Log collection complete (${CHUNK} chunks): ${OUTPUT_DIR} ==="
+
+      - name: Notify Slack log collection complete
+        if: always() && (github.event_name == 'schedule' || env.send_slack_notification == 'true')
+        shell: bash
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          SLACK_WF_NAME: "K8s E2E HA"
+        run: |
+          if [ -z "${SLACK_WEBHOOK_URL:-}" ]; then exit 0; fi
+          MSG=":white_check_mark: *Log collection complete* for *SimplyBlock ${SLACK_WF_NAME}*\n:link: <${SLACK_RUN_URL}|View Run>"
+          curl -s -X POST "${SLACK_WEBHOOK_URL}" \
+            -H 'Content-Type: application/json' \
+            -d "{\"text\":\"${MSG}\"}" || true
+
       - name: Destroy Cluster
         if: always()
         run: |

--- a/.github/workflows/k8s-e2e-ha.yaml
+++ b/.github/workflows/k8s-e2e-ha.yaml
@@ -544,6 +544,8 @@ jobs:
         shell: bash
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
           JOB_STATUS: ${{ job.status }}
           SLACK_RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           GITHUB_REF_NAME: ${{ github.ref_name }}
@@ -559,9 +561,11 @@ jobs:
           python3 - <<'PYEOF'
           import json, os, re, sys, urllib.request, urllib.error, glob
 
-          webhook = os.environ.get("SLACK_WEBHOOK_URL", "")
-          if not webhook:
-              print("No SLACK_WEBHOOK_URL set, skipping.")
+          bot_token = os.environ.get("SLACK_BOT_TOKEN", "")
+          channel   = os.environ.get("SLACK_CHANNEL_ID", "")
+          webhook   = os.environ.get("SLACK_WEBHOOK_URL", "")
+          if not bot_token and not webhook:
+              print("No SLACK_BOT_TOKEN or SLACK_WEBHOOK_URL set, skipping.")
               sys.exit(0)
 
           # Find latest log file
@@ -660,17 +664,46 @@ jobs:
               f":link: *Run:* <{run_url}|View on GitHub>",
           ]
 
-          payload = {"text": "\n".join(lines)}
-          req = urllib.request.Request(
-              webhook,
-              data=json.dumps(payload).encode(),
-              headers={"Content-Type": "application/json"},
-          )
-          try:
-              urllib.request.urlopen(req, timeout=15)
-              print("Slack notification sent.")
-          except Exception as exc:
-              print(f"WARN: Slack notification failed: {exc}", file=sys.stderr)
+          # --- Send ---
+          gh_env = os.environ.get("GITHUB_ENV", "")
+          text   = "\n".join(lines)
+
+          if bot_token and channel:
+              api_payload = json.dumps({"channel": channel, "text": text}).encode()
+              req = urllib.request.Request(
+                  "https://slack.com/api/chat.postMessage",
+                  data=api_payload,
+                  headers={
+                      "Content-Type": "application/json; charset=utf-8",
+                      "Authorization": f"Bearer {bot_token}",
+                  },
+              )
+              try:
+                  resp = urllib.request.urlopen(req, timeout=15)
+                  body = json.loads(resp.read().decode())
+                  if body.get("ok"):
+                      ts = body.get("ts", "")
+                      print(f"Slack notification sent via Bot API (ts={ts}).")
+                      if gh_env and ts:
+                          with open(gh_env, "a") as f:
+                              f.write(f"SLACK_MSG_TS={ts}\n")
+                  else:
+                      print(f"WARN: Slack API error: {body.get('error')}", file=sys.stderr)
+              except Exception as exc:
+                  print(f"WARN: Slack Bot API failed: {exc}", file=sys.stderr)
+          elif webhook:
+              req = urllib.request.Request(
+                  webhook,
+                  data=json.dumps({"text": text}).encode(),
+                  headers={"Content-Type": "application/json"},
+              )
+              try:
+                  urllib.request.urlopen(req, timeout=15)
+                  print("Slack notification sent via webhook (no thread support).")
+              except Exception as exc:
+                  print(f"WARN: Slack webhook failed: {exc}", file=sys.stderr)
+          else:
+              print("No SLACK_BOT_TOKEN or SLACK_WEBHOOK_URL set, skipping.")
           PYEOF
 
 
@@ -822,15 +855,24 @@ jobs:
         if: always() && (github.event_name == 'schedule' || env.send_slack_notification == 'true')
         shell: bash
         env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
+          SLACK_MSG_TS: ${{ env.SLACK_MSG_TS }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           SLACK_WF_NAME: "K8s E2E HA"
         run: |
-          if [ -z "${SLACK_WEBHOOK_URL:-}" ]; then exit 0; fi
           MSG=":white_check_mark: *Log collection complete* for *SimplyBlock ${SLACK_WF_NAME}*\n:link: <${SLACK_RUN_URL}|View Run>"
-          curl -s -X POST "${SLACK_WEBHOOK_URL}" \
-            -H 'Content-Type: application/json' \
-            -d "{\"text\":\"${MSG}\"}" || true
+          if [ -n "${SLACK_BOT_TOKEN:-}" ] && [ -n "${SLACK_CHANNEL_ID:-}" ] && [ -n "${SLACK_MSG_TS:-}" ]; then
+            curl -s -X POST "https://slack.com/api/chat.postMessage" \
+              -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
+              -H "Content-Type: application/json; charset=utf-8" \
+              -d "{\"channel\":\"${SLACK_CHANNEL_ID}\",\"thread_ts\":\"${SLACK_MSG_TS}\",\"text\":\"${MSG}\"}" || true
+          elif [ -n "${SLACK_WEBHOOK_URL:-}" ]; then
+            curl -s -X POST "${SLACK_WEBHOOK_URL}" \
+              -H "Content-Type: application/json" \
+              -d "{\"text\":\"${MSG}\"}" || true
+          fi
 
       - name: Destroy Cluster
         if: always()

--- a/.github/workflows/k8s-native-cross-cluster-restore.yaml
+++ b/.github/workflows/k8s-native-cross-cluster-restore.yaml
@@ -1190,6 +1190,9 @@ jobs:
           if [ -f "${MINIO_TRACE_LOG:-}" ]; then
             cp "${MINIO_TRACE_LOG}" $GITHUB_WORKSPACE/e2e/minio-trace.log 2>/dev/null || true
           fi
+          # Cleanup: delete trace logs and kill any orphaned mc trace processes
+          rm -f /tmp/minio-trace-*.log 2>/dev/null || true
+          pkill -f "mc admin trace" 2>/dev/null || true
 
       - name: Upload MinIO trace log
         if: always()

--- a/.github/workflows/k8s-native-cross-cluster-restore.yaml
+++ b/.github/workflows/k8s-native-cross-cluster-restore.yaml
@@ -490,13 +490,9 @@ jobs:
       - name: Start MinIO trace logging
         run: |
           set -euxo pipefail
-          if curl -fsSL https://dl.min.io/client/mc/release/linux-amd64/mc -o /usr/local/bin/mc 2>/dev/null; then
-            chmod +x /usr/local/bin/mc
-          else
-            curl -fsSL https://dl.min.io/client/mc/release/linux-amd64/mc -o /tmp/mc
-            chmod +x /tmp/mc
-            export PATH="/tmp:$PATH"
-          fi
+          curl -fsSL https://dl.min.io/client/mc/release/linux-amd64/mc -o /tmp/mc
+          chmod +x /tmp/mc
+          export PATH="/tmp:$PATH"
           kubectl -n minio port-forward svc/minio 9000:9000 &
           echo "MC_PORT_FWD_PID=$!" >> "$GITHUB_ENV"
           sleep 3

--- a/.github/workflows/k8s-native-cross-cluster-restore.yaml
+++ b/.github/workflows/k8s-native-cross-cluster-restore.yaml
@@ -1208,6 +1208,8 @@ jobs:
         shell: bash
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
           JOB_STATUS: ${{ job.status }}
           SLACK_RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           GITHUB_REF_NAME: ${{ github.ref_name }}
@@ -1223,9 +1225,11 @@ jobs:
           python3 - <<'PYEOF'
           import json, os, re, sys, urllib.request, urllib.error
 
-          webhook = os.environ.get("SLACK_WEBHOOK_URL", "")
-          if not webhook:
-              print("No SLACK_WEBHOOK_URL set, skipping.")
+          bot_token = os.environ.get("SLACK_BOT_TOKEN", "")
+          channel   = os.environ.get("SLACK_CHANNEL_ID", "")
+          webhook   = os.environ.get("SLACK_WEBHOOK_URL", "")
+          if not bot_token and not webhook:
+              print("No SLACK_BOT_TOKEN or SLACK_WEBHOOK_URL set, skipping.")
               sys.exit(0)
 
           out_log = os.path.join(os.environ.get("GITHUB_WORKSPACE", "."), "e2e", "output.log")
@@ -1319,17 +1323,46 @@ jobs:
               f":link: *Run:* <{run_url}|View on GitHub>",
           ]
 
-          payload = {"text": "\n".join(lines)}
-          req = urllib.request.Request(
-              webhook,
-              data=json.dumps(payload).encode(),
-              headers={"Content-Type": "application/json"},
-          )
-          try:
-              urllib.request.urlopen(req, timeout=15)
-              print("Slack notification sent.")
-          except Exception as exc:
-              print(f"WARN: Slack notification failed: {exc}", file=sys.stderr)
+          # --- Send ---
+          gh_env = os.environ.get("GITHUB_ENV", "")
+          text   = "\n".join(lines)
+
+          if bot_token and channel:
+              api_payload = json.dumps({"channel": channel, "text": text}).encode()
+              req = urllib.request.Request(
+                  "https://slack.com/api/chat.postMessage",
+                  data=api_payload,
+                  headers={
+                      "Content-Type": "application/json; charset=utf-8",
+                      "Authorization": f"Bearer {bot_token}",
+                  },
+              )
+              try:
+                  resp = urllib.request.urlopen(req, timeout=15)
+                  body = json.loads(resp.read().decode())
+                  if body.get("ok"):
+                      ts = body.get("ts", "")
+                      print(f"Slack notification sent via Bot API (ts={ts}).")
+                      if gh_env and ts:
+                          with open(gh_env, "a") as f:
+                              f.write(f"SLACK_MSG_TS={ts}\n")
+                  else:
+                      print(f"WARN: Slack API error: {body.get('error')}", file=sys.stderr)
+              except Exception as exc:
+                  print(f"WARN: Slack Bot API failed: {exc}", file=sys.stderr)
+          elif webhook:
+              req = urllib.request.Request(
+                  webhook,
+                  data=json.dumps({"text": text}).encode(),
+                  headers={"Content-Type": "application/json"},
+              )
+              try:
+                  urllib.request.urlopen(req, timeout=15)
+                  print("Slack notification sent via webhook (no thread support).")
+              except Exception as exc:
+                  print(f"WARN: Slack webhook failed: {exc}", file=sys.stderr)
+          else:
+              print("No SLACK_BOT_TOKEN or SLACK_WEBHOOK_URL set, skipping.")
           PYEOF
 
       - name: Calculate log collection timeout
@@ -1562,12 +1595,21 @@ jobs:
         if: always() && (github.event.inputs.send_slack_notification || 'true') == 'true'
         shell: bash
         env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
+          SLACK_MSG_TS: ${{ env.SLACK_MSG_TS }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           RUN_BASE_DIR: ${{ env.RUN_BASE_DIR }}
         run: |
-          if [ -z "${SLACK_WEBHOOK_URL:-}" ]; then exit 0; fi
           MSG=":white_check_mark: *Log collection complete* for *SimplyBlock K8s Cross-Cluster Restore*\n:file_folder: \`${RUN_BASE_DIR:-N/A}/graylog_collected/\`\n:link: <${SLACK_RUN_URL}|View Run>"
-          curl -s -X POST "${SLACK_WEBHOOK_URL}" \
-            -H 'Content-Type: application/json' \
-            -d "{\"text\":\"${MSG}\"}" || true
+          if [ -n "${SLACK_BOT_TOKEN:-}" ] && [ -n "${SLACK_CHANNEL_ID:-}" ] && [ -n "${SLACK_MSG_TS:-}" ]; then
+            curl -s -X POST "https://slack.com/api/chat.postMessage" \
+              -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
+              -H "Content-Type: application/json; charset=utf-8" \
+              -d "{\"channel\":\"${SLACK_CHANNEL_ID}\",\"thread_ts\":\"${SLACK_MSG_TS}\",\"text\":\"${MSG}\"}" || true
+          elif [ -n "${SLACK_WEBHOOK_URL:-}" ]; then
+            curl -s -X POST "${SLACK_WEBHOOK_URL}" \
+              -H "Content-Type: application/json" \
+              -d "{\"text\":\"${MSG}\"}" || true
+          fi

--- a/.github/workflows/k8s-native-cross-cluster-restore.yaml
+++ b/.github/workflows/k8s-native-cross-cluster-restore.yaml
@@ -1072,29 +1072,112 @@ jobs:
         if: always()
         shell: bash
         run: |
-          set +e
+          set -euxo pipefail
+
           out_log="$GITHUB_WORKSPACE/e2e/output.log"
           dur_fmt="${TEST_TIME_HOURS:-0}h ${TEST_TIME_MINS:-0}m ${TEST_TIME_SECS:-0}s"
-          conclusion="SUCCESS"
-          [[ "${{ job.status }}" != "success" ]] && conclusion="FAILED"
+
+          # --- Parse test counts ---
+          total_cases=0; passed_cases=0; failed_cases=0; skipped_cases=0
+          if [[ -f "${out_log}" ]]; then
+            v="$(grep -m1 'Number of Total Cases:'  "${out_log}" | grep -oE '[0-9]+$' 2>/dev/null || true)"; [[ "${v}" =~ ^[0-9]+$ ]] && total_cases="${v}"
+            v="$(grep -m1 'Number of Passed Cases:'  "${out_log}" | grep -oE '[0-9]+$' 2>/dev/null || true)"; [[ "${v}" =~ ^[0-9]+$ ]] && passed_cases="${v}"
+            v="$(grep -m1 'Number of Failed Cases:'  "${out_log}" | grep -oE '[0-9]+$' 2>/dev/null || true)"; [[ "${v}" =~ ^[0-9]+$ ]] && failed_cases="${v}"
+            v="$(grep -m1 'Number of Skipped Cases:' "${out_log}" | grep -oE '[0-9]+$' 2>/dev/null || true)"; [[ "${v}" =~ ^[0-9]+$ ]] && skipped_cases="${v}"
+          fi
+
+          pass_pct=0; fail_pct=0; skip_pct=0
+          if [[ "${total_cases}" -gt 0 ]]; then
+            pass_pct=$(( (passed_cases  * 100) / total_cases ))
+            fail_pct=$(( (failed_cases  * 100) / total_cases ))
+            skip_pct=$(( (skipped_cases * 100) / total_cases ))
+          fi
+
+          # --- Parse per-test status ---
+          test_details_table=""
+          if [[ -f "${out_log}" ]]; then
+            while IFS= read -r line; do
+              clean="$(printf '%s' "${line}" | sed 's/\x1b\[[0-9;]*m//g')"
+              test_name="$(printf '%s' "${clean}" | grep -oE 'Test[A-Za-z0-9_]+' | head -n1 || true)"
+              [[ -z "${test_name}" ]] && continue
+              if   printf '%s' "${clean}" | grep -qi 'PASSED';  then icon="✅"; status="PASSED"
+              elif printf '%s' "${clean}" | grep -qi 'FAILED';  then icon="❌"; status="FAILED"
+              elif printf '%s' "${clean}" | grep -qi 'SKIPPED'; then icon="⏭"; status="SKIPPED"
+              else continue
+              fi
+              test_details_table+="| \`${test_name}\` | ${icon} ${status} |"$'\n'
+            done < <(grep -iE 'PASSED CASE|FAILED CASE|SKIPPED CASE' "${out_log}" 2>/dev/null || true)
+          fi
+
+          # --- Failure reason ---
+          failure_reason=""
+          if [[ -f "${out_log}" ]]; then
+            multi="$(grep 'MultipleExceptions:' "${out_log}" | sed 's/\x1b\[[0-9;]*m//g' || true)"
+            if [[ -n "${multi}" ]]; then
+              failure_reason="${multi}"
+            elif grep -Eqi 'Traceback \(most recent call last\)|Exception:|AssertionError|Input/output error' "${out_log}"; then
+              failure_reason="$(grep -Ei 'Traceback \(most recent call last\)|Exception:|AssertionError|Input/output error' "${out_log}" | tail -n 3 | sed 's/\x1b\[[0-9;]*m//g' || true)"
+            fi
+          fi
+
+          # --- Overall result ---
+          conclusion="✅ SUCCESS"
+          if [[ "${{ job.status }}" != "success" ]]; then
+            conclusion="❌ FAILED"
+          fi
+
           {
-            echo "## K8s Cross-Cluster Restore Test Summary"
+            echo "## SimplyBlock K8s Cross-Cluster Restore Test Summary"
             echo ""
-            echo "**Result:** ${conclusion}"
+            echo "**Result:** ${conclusion} &nbsp;|&nbsp; **Duration:** ${dur_fmt}"
             echo ""
+
+            echo "### Test Results"
+            echo "| | Count | % |"
+            echo "|---|---|---|"
+            echo "| ✅ Passed  | ${passed_cases}  | ${pass_pct}% |"
+            echo "| ❌ Failed  | ${failed_cases}  | ${fail_pct}% |"
+            echo "| ⏭ Skipped | ${skipped_cases} | ${skip_pct}% |"
+            echo "| **Total**  | **${total_cases}** | |"
+            echo ""
+
+            if [[ -n "${test_details_table}" ]]; then
+              echo "### Test Case Details"
+              echo "| Test | Result |"
+              echo "|---|---|"
+              printf '%s' "${test_details_table}"
+              echo ""
+            fi
+
             echo "### Run Info"
             echo "- **Cluster-1 ID:** \`${C1_CLUSTER_ID}\` (namespace: \`${NS_C1}\`)"
             echo "- **Cluster-2 ID:** \`${C2_CLUSTER_ID}\` (namespace: \`${NS_C2}\`)"
             echo "- **C1 workers:** \`${C1_WORKERS}\`"
             echo "- **C2 workers:** \`${C2_WORKERS}\`"
             echo "- **NDCS/NPCS:** \`${NDCS}/${NPCS}\`"
-            echo "- **Duration:** ${dur_fmt}"
+            echo "- **Branch:** \`${{ github.ref_name }}\`"
             echo ""
+
+            if [[ -n "${failure_reason}" ]]; then
+              echo "### Failure Reason"
+              echo '```'
+              printf '%s\n' "${failure_reason}"
+              echo '```'
+              echo ""
+            fi
+
             if [[ -f "${out_log}" ]]; then
-              echo "### Last 30 lines"
+              echo "<details><summary>Last 30 lines of output.log</summary>"
+              echo ""
               echo '```'
               tail -n 30 "${out_log}" | sed 's/\x1b\[[0-9;]*m//g' || true
               echo '```'
+              echo "</details>"
+            fi
+
+            if [[ -n "${RUN_BASE_DIR:-}" ]]; then
+              echo ""
+              echo "**Logs:** \`${RUN_BASE_DIR}\`"
             fi
           } >> "$GITHUB_STEP_SUMMARY"
 
@@ -1127,9 +1210,364 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           JOB_STATUS: ${{ job.status }}
           SLACK_RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          GITHUB_REF_NAME: ${{ github.ref_name }}
+          SLACK_WF_NAME: "K8s Cross-Cluster Restore"
+          C1_CLUSTER_ID: ${{ env.C1_CLUSTER_ID }}
+          C2_CLUSTER_ID: ${{ env.C2_CLUSTER_ID }}
+          RUN_BASE_DIR: ${{ env.RUN_BASE_DIR }}
+          NDCS: ${{ env.NDCS }}
+          NPCS: ${{ env.NPCS }}
+          TEST_START_TIME: ${{ env.TEST_START_TIME }}
+          TEST_END_TIME: ${{ env.TEST_END_TIME }}
+        run: |
+          python3 - <<'PYEOF'
+          import json, os, re, sys, urllib.request, urllib.error
+
+          webhook = os.environ.get("SLACK_WEBHOOK_URL", "")
+          if not webhook:
+              print("No SLACK_WEBHOOK_URL set, skipping.")
+              sys.exit(0)
+
+          out_log = os.path.join(os.environ.get("GITHUB_WORKSPACE", "."), "e2e", "output.log")
+          content = open(out_log).read() if os.path.isfile(out_log) else ""
+
+          # --- Counts ---
+          def px(pat):
+              m = re.search(pat, content)
+              return int(m.group(1)) if m else 0
+          total   = px(r'Number of Total Cases:\s*(\d+)')
+          passed  = px(r'Number of Passed Cases:\s*(\d+)')
+          failed  = px(r'Number of Failed Cases:\s*(\d+)')
+          skipped = px(r'Number of Skipped Cases:\s*(\d+)')
+          pass_pct = (passed * 100 // total) if total > 0 else 0
+
+          # --- Per-test results ---
+          ansi = re.compile(r'\x1b\[[0-9;]*m')
+          test_results = []
+          for line in content.splitlines():
+              clean = ansi.sub('', line)
+              if not re.search(r'(PASSED|FAILED|SKIPPED) CASE', clean):
+                  continue
+              m = re.search(r'Test[A-Za-z0-9_]+', clean)
+              if not m:
+                  continue
+              name = m.group(0)
+              if   'PASSED CASE'  in clean: test_results.append(('PASSED',  name))
+              elif 'FAILED CASE'  in clean: test_results.append(('FAILED',  name))
+              elif 'SKIPPED CASE' in clean: test_results.append(('SKIPPED', name))
+
+          # --- Failure reason ---
+          failure_reason = ""
+          multi = [ansi.sub('', l) for l in content.splitlines() if 'MultipleExceptions:' in l]
+          if multi:
+              failure_reason = multi[0][:2000]
+          elif content:
+              exc_lines = [ansi.sub('', l) for l in content.splitlines()
+                           if re.search(r'(Exception:|AssertionError|Input/output error)', l)]
+              if exc_lines:
+                  failure_reason = '\n'.join(exc_lines[-5:])[:2000]
+
+          # --- Env ---
+          s    = int(os.environ.get("TEST_START_TIME", "0") or "0")
+          e    = int(os.environ.get("TEST_END_TIME",   "0") or "0")
+          secs = max(0, e - s) if e >= s > 0 else 0
+          dur  = f"{secs//3600}h {(secs%3600)//60}m {secs%60}s"
+          run_url  = os.environ.get("SLACK_RUN_URL",   "")
+          log_dir  = os.environ.get("RUN_BASE_DIR",    "N/A")
+          c1_id    = os.environ.get("C1_CLUSTER_ID",   "?")
+          c2_id    = os.environ.get("C2_CLUSTER_ID",   "?")
+          ndcs     = os.environ.get("NDCS",            "?")
+          npcs     = os.environ.get("NPCS",            "?")
+          branch   = os.environ.get("GITHUB_REF_NAME", "?")
+          wf_name  = os.environ.get("SLACK_WF_NAME",   "Run")
+          ok       = os.environ.get("JOB_STATUS",      "") == "success"
+
+          icon    = ":white_check_mark:" if ok else ":x:"
+          status  = "SUCCESS" if ok else "FAILURE"
+          mention = "" if ok else " <!channel>"
+
+          lines = [
+              f"{icon} *SimplyBlock {wf_name}*{mention}",
+              f"*Status:* {status}  |  *Duration:* {dur}",
+              f"*Branch:* `{branch}`  |  *NDCS/NPCS:* `{ndcs}/{npcs}`",
+              f"*C1:* `{c1_id}`  |  *C2:* `{c2_id}`",
+              "",
+          ]
+
+          if total > 0:
+              lines += [
+                  f":white_check_mark: *Passed:*  {passed}/{total}  ({pass_pct}%)",
+                  f":x: *Failed:*  {failed}",
+                  f":fast_forward: *Skipped:*  {skipped}",
+              ]
+          else:
+              lines.append("_(test counts not found in log)_")
+
+          if test_results:
+              lines.append("")
+              lines.append("*Test Results:*")
+              icons = {'PASSED': ':white_check_mark:', 'FAILED': ':x:', 'SKIPPED': ':fast_forward:'}
+              for st, nm in test_results:
+                  lines.append(f"{icons.get(st, ':grey_question:')} `{nm}`")
+
+          if failure_reason:
+              lines += ["", "*Failure:*", f"```{failure_reason}```"]
+
+          lines += [
+              "",
+              f":file_folder: *Final Logs:* `{log_dir}`",
+              f":link: *Run:* <{run_url}|View on GitHub>",
+          ]
+
+          payload = {"text": "\n".join(lines)}
+          req = urllib.request.Request(
+              webhook,
+              data=json.dumps(payload).encode(),
+              headers={"Content-Type": "application/json"},
+          )
+          try:
+              urllib.request.urlopen(req, timeout=15)
+              print("Slack notification sent.")
+          except Exception as exc:
+              print(f"WARN: Slack notification failed: {exc}", file=sys.stderr)
+          PYEOF
+
+      - name: Calculate log collection timeout
+        if: always()
+        run: |
+          TEST_TIME=$((${TEST_END_TIME:-0} - ${TEST_START_TIME:-0}))
+          LOG_COLLECT_TIMEOUT_MINS=$(( (TEST_TIME + 119) / 120 ))
+          [ "$LOG_COLLECT_TIMEOUT_MINS" -lt 30 ] && LOG_COLLECT_TIMEOUT_MINS=30
+          echo "LOG_COLLECT_TIMEOUT_MINS=$LOG_COLLECT_TIMEOUT_MINS" >> $GITHUB_ENV
+
+      - name: Collect Graylog/OpenSearch logs
+        if: '!cancelled()'
+        timeout-minutes: ${{ fromJSON(env.LOG_COLLECT_TIMEOUT_MINS || '60') }}
+        run: |
+          set +e
+          echo "=== Collecting Graylog/OpenSearch logs ==="
+          NAMESPACE=${NS_C1}
+
+          if [ -z "${TEST_START_TIME}" ] || [ -z "${TEST_END_TIME}" ]; then
+            echo "WARN: TEST_START_TIME or TEST_END_TIME not set, skipping"
+            exit 0
+          fi
+
+          ELAPSED=$((TEST_END_TIME - TEST_START_TIME))
+          if [ "${ELAPSED}" -le 0 ]; then
+            echo "WARN: Elapsed time is zero or negative, skipping"
+            exit 0
+          fi
+
+          WINDOW_START=$((TEST_START_TIME - 3600))
+          WINDOW_END=$((TEST_END_TIME + 3600))
+          TOTAL_SECONDS=$((WINDOW_END - WINDOW_START))
+          TOTAL_HOURS=$(( (TOTAL_SECONDS + 3599) / 3600 ))
+          echo "  Total window: ${TOTAL_HOURS} hour(s) to collect"
+
+          ADMIN_POD=""
+          for i in $(seq 1 12); do
+            ADMIN_POD=$(kubectl -n ${NAMESPACE} get pods \
+              -l app=simplyblock-admin-control \
+              -o jsonpath='{.items[0].metadata.name}' 2>/dev/null) || true
+            if [ -n "${ADMIN_POD}" ]; then
+              PHASE=$(kubectl -n ${NAMESPACE} get pod "${ADMIN_POD}" \
+                -o jsonpath='{.status.phase}' 2>/dev/null) || true
+              [ "${PHASE}" = "Running" ] && break
+              ADMIN_POD=""
+            fi
+            sleep 10
+          done
+          if [ -z "${ADMIN_POD}" ]; then
+            echo "ERROR: No running admin pod found, skipping"
+            exit 0
+          fi
+
+          BUILTIN_SCRIPT="/usr/local/lib/python3.12/site-packages/simplyblock_core/scripts/collect_logs.py"
+          DEPLOYED_SCRIPT="/tmp/collect_logs.py"
+          SCRIPT_SRC="${GITHUB_WORKSPACE}/scripts/collect_logs.py"
+          if [ -f "${SCRIPT_SRC}" ]; then
+            kubectl -n ${NAMESPACE} cp "${SCRIPT_SRC}" "${ADMIN_POD}:${DEPLOYED_SCRIPT}" 2>/dev/null || \
+              echo "WARN: failed to deploy updated collect_logs.py, using built-in version"
+          fi
+          COLLECT_SCRIPT="${BUILTIN_SCRIPT}"
+          if kubectl -n ${NAMESPACE} exec "${ADMIN_POD}" -- test -f "${DEPLOYED_SCRIPT}" 2>/dev/null; then
+            COLLECT_SCRIPT="${DEPLOYED_SCRIPT}"
+            echo "  Using deployed script: ${COLLECT_SCRIPT}"
+          else
+            echo "  Using built-in script: ${COLLECT_SCRIPT}"
+          fi
+
+          MGMT_IP=$(kubectl get svc -n ${NAMESPACE} | grep graylog | awk '{print $3}')
+          OPENSEARCH_IP=$(kubectl get svc opensearch-cluster-master -n ${NAMESPACE} -o jsonpath='{.spec.clusterIP}' 2>/dev/null || echo "")
+
+          OUTPUT_DIR=""
+          if [ -n "${RUN_BASE_DIR:-}" ] && [ -d "${RUN_BASE_DIR}" ]; then
+            OUTPUT_DIR="${RUN_BASE_DIR}/graylog_collected"
+          else
+            NFS_BASE="${NFS_MOUNTPOINT:-/mnt/nfs_share}"
+            TIMESTAMP=$(date -u "+%Y%m%d-%H%M%S")
+            OUTPUT_DIR="${NFS_BASE}/graylog_collected-${TIMESTAMP}"
+          fi
+          mkdir -p "${OUTPUT_DIR}" 2>/dev/null || true
+
+          epoch_to_iso() {
+            local ep=$1
+            local iso
+            iso=$(date -u -d "@${ep}" "+%Y-%m-%dT%H:%M:%S" 2>/dev/null)
+            if [ -z "${iso}" ]; then
+              iso=$(python3 -c "from datetime import datetime,timezone; print(datetime.fromtimestamp(${ep},tz=timezone.utc).strftime('%Y-%m-%dT%H:%M:%S'))")
+            fi
+            echo "${iso}"
+          }
+
+          _CHUNK_STARTS=()
+          _C=${WINDOW_START}
+          while [ ${_C} -lt ${WINDOW_END} ]; do
+            _CHUNK_STARTS+=(${_C})
+            _C=$((_C + 3600))
+          done
+          NUM_CHUNKS=${#_CHUNK_STARTS[@]}
+
+          run_collect() {
+            local iso=$1 mins=$2 outdir=$3 extra_flag=${4:-}
+            local mgmt_ip_to_use="${MGMT_IP}"
+            if [[ "${extra_flag}" == *"--use-opensearch"* ]] && [ -n "${OPENSEARCH_IP}" ]; then
+              mgmt_ip_to_use="${OPENSEARCH_IP}"
+            fi
+            kubectl -n ${NAMESPACE} exec "${ADMIN_POD}" -- \
+              python3 "${COLLECT_SCRIPT}" \
+                "${iso}" "${mins}" \
+                --mode kubernetes \
+                --namespace "${NAMESPACE}" \
+                --monitoring-secret "${MON_SECRET}" \
+                --output-dir "${outdir}" \
+                ${extra_flag} \
+                ${mgmt_ip_to_use:+--mgmt-ip "${mgmt_ip_to_use}"} \
+                ${C1_CLUSTER_ID:+--cluster-id "${C1_CLUSTER_ID}"} \
+            2>&1
+            local rc=$?
+            [ $rc -ne 0 ] && return $rc
+            local has_content
+            has_content=$(kubectl -n ${NAMESPACE} exec "${ADMIN_POD}" -- \
+              find "${outdir}" -name "*.tar.gz" -size +0 2>/dev/null | head -1)
+            if [ -z "${has_content}" ]; then
+              echo "  WARN: collect_logs.py succeeded but no .tar.gz output found"
+              return 1
+            fi
+          }
+
+          collect_adaptive() {
+            local start_epoch=$1 end_epoch=$2 outdir=$3 extra_flag=${4:-}
+            local duration=$((end_epoch - start_epoch))
+            local mins=$(( (duration + 59) / 60 ))
+            local iso=$(epoch_to_iso ${start_epoch})
+            if run_collect "${iso}" "${mins}" "${outdir}" "${extra_flag}"; then
+              return 0
+            fi
+            echo "  WARN: ${mins}m window failed, retrying with 5-min sub-windows..."
+            local sub_start=${start_epoch}
+            while [ ${sub_start} -lt ${end_epoch} ]; do
+              local sub_end=$((sub_start + 300))
+              [ ${sub_end} -gt ${end_epoch} ] && sub_end=${end_epoch}
+              local sub_mins=$(( ((sub_end - sub_start) + 59) / 60 ))
+              local sub_iso=$(epoch_to_iso ${sub_start})
+              if ! run_collect "${sub_iso}" "${sub_mins}" "${outdir}" "${extra_flag}"; then
+                echo "  WARN: 5-min window at ${sub_iso} failed, retrying with 1-min windows..."
+                local micro_start=${sub_start}
+                while [ ${micro_start} -lt ${sub_end} ]; do
+                  local micro_end=$((micro_start + 60))
+                  [ ${micro_end} -gt ${sub_end} ] && micro_end=${sub_end}
+                  local micro_mins=$(( ((micro_end - micro_start) + 59) / 60 ))
+                  local micro_iso=$(epoch_to_iso ${micro_start})
+                  run_collect "${micro_iso}" "${micro_mins}" "${outdir}" "${extra_flag}" || \
+                    echo "  WARN: 1-min window at ${micro_iso} also failed"
+                  micro_start=${micro_end}
+                done
+              fi
+              sub_start=${sub_end}
+            done
+          }
+
+          PREFER_OPENSEARCH=""
+          CHUNK=0
+
+          for (( _IDX=NUM_CHUNKS-1; _IDX>=0; _IDX-- )); do
+            CHUNK=$((CHUNK + 1))
+            CHUNK_START=${_CHUNK_STARTS[$_IDX]}
+            CHUNK_END=$((CHUNK_START + 3600))
+            [ ${CHUNK_END} -gt ${WINDOW_END} ] && CHUNK_END=${WINDOW_END}
+            CHUNK_MINUTES=$(( ((CHUNK_END - CHUNK_START) + 59) / 60 ))
+            CHUNK_ISO=$(epoch_to_iso ${CHUNK_START})
+
+            echo ""
+            echo "--- Chunk ${CHUNK}/${NUM_CHUNKS}: ${CHUNK_ISO} for ${CHUNK_MINUTES}m (newest-first) ---"
+
+            POD_OUTPUT_DIR="/tmp/graylog_collect_chunk${CHUNK}"
+            kubectl -n ${NAMESPACE} exec "${ADMIN_POD}" -- mkdir -p "${POD_OUTPUT_DIR}" 2>/dev/null || true
+
+            if [ -z "${PREFER_OPENSEARCH}" ]; then
+              echo "  Probing OpenSearch availability..."
+              if run_collect "${CHUNK_ISO}" "${CHUNK_MINUTES}" "${POD_OUTPUT_DIR}" "--use-opensearch"; then
+                PREFER_OPENSEARCH=true
+                echo "  OpenSearch works — using it for all chunks"
+              else
+                PREFER_OPENSEARCH=false
+                echo "  OpenSearch unavailable — using Graylog for all chunks"
+                kubectl -n ${NAMESPACE} exec "${ADMIN_POD}" -- rm -rf "${POD_OUTPUT_DIR}" 2>/dev/null || true
+                kubectl -n ${NAMESPACE} exec "${ADMIN_POD}" -- mkdir -p "${POD_OUTPUT_DIR}" 2>/dev/null || true
+                collect_adaptive ${CHUNK_START} ${CHUNK_END} "${POD_OUTPUT_DIR}" || \
+                  echo "WARN: Graylog also failed for chunk ${CHUNK}"
+              fi
+            elif [ "${PREFER_OPENSEARCH}" = "true" ]; then
+              collect_adaptive ${CHUNK_START} ${CHUNK_END} "${POD_OUTPUT_DIR}" "--use-opensearch" || {
+                echo "WARN: OpenSearch failed for chunk ${CHUNK}, falling back to Graylog..."
+                collect_adaptive ${CHUNK_START} ${CHUNK_END} "${POD_OUTPUT_DIR}" || \
+                  echo "WARN: Graylog fallback also failed for chunk ${CHUNK}"
+              }
+            else
+              collect_adaptive ${CHUNK_START} ${CHUNK_END} "${POD_OUTPUT_DIR}" || {
+                echo "WARN: Graylog failed for chunk ${CHUNK}, falling back to OpenSearch..."
+                collect_adaptive ${CHUNK_START} ${CHUNK_END} "${POD_OUTPUT_DIR}" "--use-opensearch" || \
+                  echo "WARN: OpenSearch fallback also failed for chunk ${CHUNK}"
+              }
+            fi
+
+            TARBALLS=$(kubectl -n ${NAMESPACE} exec "${ADMIN_POD}" -- \
+              find "${POD_OUTPUT_DIR}" -name "*.tar.gz" -type f 2>/dev/null) || true
+            if [ -n "${TARBALLS}" ]; then
+              for TB in ${TARBALLS}; do
+                TB_NAME=$(basename "${TB}")
+                echo "  Copying ${TB_NAME}..."
+                kubectl -n ${NAMESPACE} cp "${ADMIN_POD}:${TB}" "${OUTPUT_DIR}/${TB_NAME}" 2>&1 || true
+              done
+              for TB_FILE in "${OUTPUT_DIR}"/*.tar.gz; do
+                [ -f "${TB_FILE}" ] && tar -xzf "${TB_FILE}" -C "${OUTPUT_DIR}/" 2>/dev/null || true
+              done
+            else
+              echo "WARN: No tarballs found for chunk ${CHUNK}"
+            fi
+
+            kubectl -n ${NAMESPACE} exec "${ADMIN_POD}" -- rm -rf "${POD_OUTPUT_DIR}" 2>/dev/null || true
+          done
+
+          echo ""
+          echo "=== Log collection complete (${CHUNK} chunks, newest-first): ${OUTPUT_DIR} ==="
+          ls -la "${OUTPUT_DIR}/" 2>/dev/null || true
+        env:
+          C1_CLUSTER_ID: ${{ env.C1_CLUSTER_ID }}
+          MON_SECRET: ${{ secrets.MON_SECRET }}
+
+      - name: Notify Slack log collection complete
+        if: always() && (github.event.inputs.send_slack_notification || 'true') == 'true'
+        shell: bash
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          RUN_BASE_DIR: ${{ env.RUN_BASE_DIR }}
         run: |
           if [ -z "${SLACK_WEBHOOK_URL:-}" ]; then exit 0; fi
-          STATUS_EMOJI="$([ "$JOB_STATUS" = "success" ] && echo ":white_check_mark:" || echo ":x:")"
+          MSG=":white_check_mark: *Log collection complete* for *SimplyBlock K8s Cross-Cluster Restore*\n:file_folder: \`${RUN_BASE_DIR:-N/A}/graylog_collected/\`\n:link: <${SLACK_RUN_URL}|View Run>"
           curl -s -X POST "${SLACK_WEBHOOK_URL}" \
             -H 'Content-Type: application/json' \
-            -d "{\"text\":\"${STATUS_EMOJI} *K8s Cross-Cluster Restore*: ${JOB_STATUS}\\nC1: \`${C1_CLUSTER_ID:-?}\` | C2: \`${C2_CLUSTER_ID:-?}\`\\nNDCS/NPCS: ${NDCS}/${NPCS}\\n<${SLACK_RUN_URL}|View Run>\"}" || true
+            -d "{\"text\":\"${MSG}\"}" || true

--- a/.github/workflows/k8s-native-cross-cluster-restore.yaml
+++ b/.github/workflows/k8s-native-cross-cluster-restore.yaml
@@ -490,8 +490,13 @@ jobs:
       - name: Start MinIO trace logging
         run: |
           set -euxo pipefail
-          curl -fsSL https://dl.min.io/client/mc/release/linux-amd64/mc -o /usr/local/bin/mc
-          chmod +x /usr/local/bin/mc
+          if curl -fsSL https://dl.min.io/client/mc/release/linux-amd64/mc -o /usr/local/bin/mc 2>/dev/null; then
+            chmod +x /usr/local/bin/mc
+          else
+            curl -fsSL https://dl.min.io/client/mc/release/linux-amd64/mc -o /tmp/mc
+            chmod +x /tmp/mc
+            export PATH="/tmp:$PATH"
+          fi
           kubectl -n minio port-forward svc/minio 9000:9000 &
           echo "MC_PORT_FWD_PID=$!" >> "$GITHUB_ENV"
           sleep 3

--- a/.github/workflows/k8s-native-e2e-add-node.yaml
+++ b/.github/workflows/k8s-native-e2e-add-node.yaml
@@ -1594,6 +1594,8 @@ jobs:
         shell: bash
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
           JOB_STATUS: ${{ job.status }}
           SLACK_RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           GITHUB_REF_NAME: ${{ github.ref_name }}
@@ -1607,9 +1609,11 @@ jobs:
         run: |
           python3 - <<'PYEOF'
           import json, os, re, sys, urllib.request, urllib.error
-          webhook = os.environ.get("SLACK_WEBHOOK_URL", "")
-          if not webhook:
-              print("No SLACK_WEBHOOK_URL set, skipping.")
+          bot_token = os.environ.get("SLACK_BOT_TOKEN", "")
+          channel   = os.environ.get("SLACK_CHANNEL_ID", "")
+          webhook   = os.environ.get("SLACK_WEBHOOK_URL", "")
+          if not bot_token and not webhook:
+              print("No SLACK_BOT_TOKEN or SLACK_WEBHOOK_URL set, skipping.")
               sys.exit(0)
           out_log = os.path.join(os.environ.get("GITHUB_WORKSPACE", "."), "e2e", "output.log")
           total = passed = failed = skipped = 0
@@ -1689,17 +1693,46 @@ jobs:
               f":link: *Run:* <{run_url}|View on GitHub>",
               f":hourglass_flowing_sand: _Logs are being collected and will be available shortly._",
           ]
-          payload = {"text": "\n".join(lines)}
-          req = urllib.request.Request(
-              webhook,
-              data=json.dumps(payload).encode(),
-              headers={"Content-Type": "application/json"},
-          )
-          try:
-              urllib.request.urlopen(req, timeout=15)
-              print("Slack notification sent.")
-          except Exception as exc:
-              print(f"WARN: Slack notification failed: {exc}", file=sys.stderr)
+          # --- Send ---
+          gh_env = os.environ.get("GITHUB_ENV", "")
+          text   = "\n".join(lines)
+
+          if bot_token and channel:
+              api_payload = json.dumps({"channel": channel, "text": text}).encode()
+              req = urllib.request.Request(
+                  "https://slack.com/api/chat.postMessage",
+                  data=api_payload,
+                  headers={
+                      "Content-Type": "application/json; charset=utf-8",
+                      "Authorization": f"Bearer {bot_token}",
+                  },
+              )
+              try:
+                  resp = urllib.request.urlopen(req, timeout=15)
+                  body = json.loads(resp.read().decode())
+                  if body.get("ok"):
+                      ts = body.get("ts", "")
+                      print(f"Slack notification sent via Bot API (ts={ts}).")
+                      if gh_env and ts:
+                          with open(gh_env, "a") as f:
+                              f.write(f"SLACK_MSG_TS={ts}\n")
+                  else:
+                      print(f"WARN: Slack API error: {body.get('error')}", file=sys.stderr)
+              except Exception as exc:
+                  print(f"WARN: Slack Bot API failed: {exc}", file=sys.stderr)
+          elif webhook:
+              req = urllib.request.Request(
+                  webhook,
+                  data=json.dumps({"text": text}).encode(),
+                  headers={"Content-Type": "application/json"},
+              )
+              try:
+                  urllib.request.urlopen(req, timeout=15)
+                  print("Slack notification sent via webhook (no thread support).")
+              except Exception as exc:
+                  print(f"WARN: Slack webhook failed: {exc}", file=sys.stderr)
+          else:
+              print("No SLACK_BOT_TOKEN or SLACK_WEBHOOK_URL set, skipping.")
           PYEOF
 
 
@@ -1948,16 +1981,25 @@ jobs:
         if: always() && inputs.send_slack_notification != false
         shell: bash
         env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
+          SLACK_MSG_TS: ${{ env.SLACK_MSG_TS }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           SLACK_WF_NAME: "K8s Native Add Node"
           RUN_BASE_DIR: ${{ env.RUN_BASE_DIR }}
         run: |
-          if [ -z "${SLACK_WEBHOOK_URL:-}" ]; then exit 0; fi
           MSG=":white_check_mark: *Log collection complete* for *SimplyBlock ${SLACK_WF_NAME}*\n:file_folder: \`${RUN_BASE_DIR:-N/A}/graylog_collected/\`\n:link: <${SLACK_RUN_URL}|View Run>"
-          curl -s -X POST "${SLACK_WEBHOOK_URL}" \
-            -H 'Content-Type: application/json' \
-            -d "{\"text\":\"${MSG}\"}" || true
+          if [ -n "${SLACK_BOT_TOKEN:-}" ] && [ -n "${SLACK_CHANNEL_ID:-}" ] && [ -n "${SLACK_MSG_TS:-}" ]; then
+            curl -s -X POST "https://slack.com/api/chat.postMessage" \
+              -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
+              -H "Content-Type: application/json; charset=utf-8" \
+              -d "{\"channel\":\"${SLACK_CHANNEL_ID}\",\"thread_ts\":\"${SLACK_MSG_TS}\",\"text\":\"${MSG}\"}" || true
+          elif [ -n "${SLACK_WEBHOOK_URL:-}" ]; then
+            curl -s -X POST "${SLACK_WEBHOOK_URL}" \
+              -H "Content-Type: application/json" \
+              -d "{\"text\":\"${MSG}\"}" || true
+          fi
 
       - name: Stop MinIO trace logging and save
         if: always()

--- a/.github/workflows/k8s-native-e2e-add-node.yaml
+++ b/.github/workflows/k8s-native-e2e-add-node.yaml
@@ -2021,6 +2021,9 @@ jobs:
           else
             echo "No MinIO trace log found (backup tests may not have run)"
           fi
+          # Cleanup: delete trace logs and kill any orphaned mc trace processes
+          rm -f /tmp/minio-trace-*.log 2>/dev/null || true
+          pkill -f "mc admin trace" 2>/dev/null || true
 
       - name: Upload MinIO trace log
         if: always()

--- a/.github/workflows/k8s-native-e2e-add-node.yaml
+++ b/.github/workflows/k8s-native-e2e-add-node.yaml
@@ -683,13 +683,9 @@ jobs:
           set -euxo pipefail
 
           # 1. Install mc (MinIO Client)
-          if curl -fsSL https://dl.min.io/client/mc/release/linux-amd64/mc -o /usr/local/bin/mc 2>/dev/null; then
-            chmod +x /usr/local/bin/mc
-          else
-            curl -fsSL https://dl.min.io/client/mc/release/linux-amd64/mc -o /tmp/mc
-            chmod +x /tmp/mc
-            export PATH="/tmp:$PATH"
-          fi
+          curl -fsSL https://dl.min.io/client/mc/release/linux-amd64/mc -o /tmp/mc
+          chmod +x /tmp/mc
+          export PATH="/tmp:$PATH"
 
           # 2. Port-forward MinIO service to localhost
           kubectl -n minio port-forward svc/minio 9000:9000 &

--- a/.github/workflows/k8s-native-e2e-add-node.yaml
+++ b/.github/workflows/k8s-native-e2e-add-node.yaml
@@ -683,8 +683,13 @@ jobs:
           set -euxo pipefail
 
           # 1. Install mc (MinIO Client)
-          curl -fsSL https://dl.min.io/client/mc/release/linux-amd64/mc -o /usr/local/bin/mc
-          chmod +x /usr/local/bin/mc
+          if curl -fsSL https://dl.min.io/client/mc/release/linux-amd64/mc -o /usr/local/bin/mc 2>/dev/null; then
+            chmod +x /usr/local/bin/mc
+          else
+            curl -fsSL https://dl.min.io/client/mc/release/linux-amd64/mc -o /tmp/mc
+            chmod +x /tmp/mc
+            export PATH="/tmp:$PATH"
+          fi
 
           # 2. Port-forward MinIO service to localhost
           kubectl -n minio port-forward svc/minio 9000:9000 &

--- a/.github/workflows/k8s-native-e2e-add-node.yaml
+++ b/.github/workflows/k8s-native-e2e-add-node.yaml
@@ -1943,6 +1943,22 @@ jobs:
         env:
           CLUSTER_ID: ${{ env.CLUSTER_ID }}
           MON_SECRET: ${{ secrets.MON_SECRET }}
+
+      - name: Notify Slack log collection complete
+        if: always() && inputs.send_slack_notification != false
+        shell: bash
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          SLACK_WF_NAME: "K8s Native Add Node"
+          RUN_BASE_DIR: ${{ env.RUN_BASE_DIR }}
+        run: |
+          if [ -z "${SLACK_WEBHOOK_URL:-}" ]; then exit 0; fi
+          MSG=":white_check_mark: *Log collection complete* for *SimplyBlock ${SLACK_WF_NAME}*\n:file_folder: \`${RUN_BASE_DIR:-N/A}/graylog_collected/\`\n:link: <${SLACK_RUN_URL}|View Run>"
+          curl -s -X POST "${SLACK_WEBHOOK_URL}" \
+            -H 'Content-Type: application/json' \
+            -d "{\"text\":\"${MSG}\"}" || true
+
       - name: Stop MinIO trace logging and save
         if: always()
         run: |

--- a/.github/workflows/k8s-native-e2e-node-migration.yaml
+++ b/.github/workflows/k8s-native-e2e-node-migration.yaml
@@ -1600,6 +1600,8 @@ jobs:
         shell: bash
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
           JOB_STATUS: ${{ job.status }}
           SLACK_RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           GITHUB_REF_NAME: ${{ github.ref_name }}
@@ -1613,9 +1615,11 @@ jobs:
         run: |
           python3 - <<'PYEOF'
           import json, os, re, sys, urllib.request, urllib.error
-          webhook = os.environ.get("SLACK_WEBHOOK_URL", "")
-          if not webhook:
-              print("No SLACK_WEBHOOK_URL set, skipping.")
+          bot_token = os.environ.get("SLACK_BOT_TOKEN", "")
+          channel   = os.environ.get("SLACK_CHANNEL_ID", "")
+          webhook   = os.environ.get("SLACK_WEBHOOK_URL", "")
+          if not bot_token and not webhook:
+              print("No SLACK_BOT_TOKEN or SLACK_WEBHOOK_URL set, skipping.")
               sys.exit(0)
           out_log = os.path.join(os.environ.get("GITHUB_WORKSPACE", "."), "e2e", "output.log")
           total = passed = failed = skipped = 0
@@ -1695,17 +1699,46 @@ jobs:
               f":link: *Run:* <{run_url}|View on GitHub>",
               f":hourglass_flowing_sand: _Logs are being collected and will be available shortly._",
           ]
-          payload = {"text": "\n".join(lines)}
-          req = urllib.request.Request(
-              webhook,
-              data=json.dumps(payload).encode(),
-              headers={"Content-Type": "application/json"},
-          )
-          try:
-              urllib.request.urlopen(req, timeout=15)
-              print("Slack notification sent.")
-          except Exception as exc:
-              print(f"WARN: Slack notification failed: {exc}", file=sys.stderr)
+          # --- Send ---
+          gh_env = os.environ.get("GITHUB_ENV", "")
+          text   = "\n".join(lines)
+
+          if bot_token and channel:
+              api_payload = json.dumps({"channel": channel, "text": text}).encode()
+              req = urllib.request.Request(
+                  "https://slack.com/api/chat.postMessage",
+                  data=api_payload,
+                  headers={
+                      "Content-Type": "application/json; charset=utf-8",
+                      "Authorization": f"Bearer {bot_token}",
+                  },
+              )
+              try:
+                  resp = urllib.request.urlopen(req, timeout=15)
+                  body = json.loads(resp.read().decode())
+                  if body.get("ok"):
+                      ts = body.get("ts", "")
+                      print(f"Slack notification sent via Bot API (ts={ts}).")
+                      if gh_env and ts:
+                          with open(gh_env, "a") as f:
+                              f.write(f"SLACK_MSG_TS={ts}\n")
+                  else:
+                      print(f"WARN: Slack API error: {body.get('error')}", file=sys.stderr)
+              except Exception as exc:
+                  print(f"WARN: Slack Bot API failed: {exc}", file=sys.stderr)
+          elif webhook:
+              req = urllib.request.Request(
+                  webhook,
+                  data=json.dumps({"text": text}).encode(),
+                  headers={"Content-Type": "application/json"},
+              )
+              try:
+                  urllib.request.urlopen(req, timeout=15)
+                  print("Slack notification sent via webhook (no thread support).")
+              except Exception as exc:
+                  print(f"WARN: Slack webhook failed: {exc}", file=sys.stderr)
+          else:
+              print("No SLACK_BOT_TOKEN or SLACK_WEBHOOK_URL set, skipping.")
           PYEOF
 
 
@@ -1954,16 +1987,25 @@ jobs:
         if: always() && inputs.send_slack_notification != false
         shell: bash
         env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
+          SLACK_MSG_TS: ${{ env.SLACK_MSG_TS }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           SLACK_WF_NAME: "K8s Native Node Migration"
           RUN_BASE_DIR: ${{ env.RUN_BASE_DIR }}
         run: |
-          if [ -z "${SLACK_WEBHOOK_URL:-}" ]; then exit 0; fi
           MSG=":white_check_mark: *Log collection complete* for *SimplyBlock ${SLACK_WF_NAME}*\n:file_folder: \`${RUN_BASE_DIR:-N/A}/graylog_collected/\`\n:link: <${SLACK_RUN_URL}|View Run>"
-          curl -s -X POST "${SLACK_WEBHOOK_URL}" \
-            -H 'Content-Type: application/json' \
-            -d "{\"text\":\"${MSG}\"}" || true
+          if [ -n "${SLACK_BOT_TOKEN:-}" ] && [ -n "${SLACK_CHANNEL_ID:-}" ] && [ -n "${SLACK_MSG_TS:-}" ]; then
+            curl -s -X POST "https://slack.com/api/chat.postMessage" \
+              -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
+              -H "Content-Type: application/json; charset=utf-8" \
+              -d "{\"channel\":\"${SLACK_CHANNEL_ID}\",\"thread_ts\":\"${SLACK_MSG_TS}\",\"text\":\"${MSG}\"}" || true
+          elif [ -n "${SLACK_WEBHOOK_URL:-}" ]; then
+            curl -s -X POST "${SLACK_WEBHOOK_URL}" \
+              -H "Content-Type: application/json" \
+              -d "{\"text\":\"${MSG}\"}" || true
+          fi
 
       - name: Stop MinIO trace logging and save
         if: always()

--- a/.github/workflows/k8s-native-e2e-node-migration.yaml
+++ b/.github/workflows/k8s-native-e2e-node-migration.yaml
@@ -679,13 +679,9 @@ jobs:
           set -euxo pipefail
 
           # 1. Install mc (MinIO Client)
-          if curl -fsSL https://dl.min.io/client/mc/release/linux-amd64/mc -o /usr/local/bin/mc 2>/dev/null; then
-            chmod +x /usr/local/bin/mc
-          else
-            curl -fsSL https://dl.min.io/client/mc/release/linux-amd64/mc -o /tmp/mc
-            chmod +x /tmp/mc
-            export PATH="/tmp:$PATH"
-          fi
+          curl -fsSL https://dl.min.io/client/mc/release/linux-amd64/mc -o /tmp/mc
+          chmod +x /tmp/mc
+          export PATH="/tmp:$PATH"
 
           # 2. Port-forward MinIO service to localhost
           kubectl -n minio port-forward svc/minio 9000:9000 &

--- a/.github/workflows/k8s-native-e2e-node-migration.yaml
+++ b/.github/workflows/k8s-native-e2e-node-migration.yaml
@@ -679,8 +679,13 @@ jobs:
           set -euxo pipefail
 
           # 1. Install mc (MinIO Client)
-          curl -fsSL https://dl.min.io/client/mc/release/linux-amd64/mc -o /usr/local/bin/mc
-          chmod +x /usr/local/bin/mc
+          if curl -fsSL https://dl.min.io/client/mc/release/linux-amd64/mc -o /usr/local/bin/mc 2>/dev/null; then
+            chmod +x /usr/local/bin/mc
+          else
+            curl -fsSL https://dl.min.io/client/mc/release/linux-amd64/mc -o /tmp/mc
+            chmod +x /tmp/mc
+            export PATH="/tmp:$PATH"
+          fi
 
           # 2. Port-forward MinIO service to localhost
           kubectl -n minio port-forward svc/minio 9000:9000 &

--- a/.github/workflows/k8s-native-e2e-node-migration.yaml
+++ b/.github/workflows/k8s-native-e2e-node-migration.yaml
@@ -1949,6 +1949,22 @@ jobs:
         env:
           CLUSTER_ID: ${{ env.CLUSTER_ID }}
           MON_SECRET: ${{ secrets.MON_SECRET }}
+
+      - name: Notify Slack log collection complete
+        if: always() && inputs.send_slack_notification != false
+        shell: bash
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          SLACK_WF_NAME: "K8s Native Node Migration"
+          RUN_BASE_DIR: ${{ env.RUN_BASE_DIR }}
+        run: |
+          if [ -z "${SLACK_WEBHOOK_URL:-}" ]; then exit 0; fi
+          MSG=":white_check_mark: *Log collection complete* for *SimplyBlock ${SLACK_WF_NAME}*\n:file_folder: \`${RUN_BASE_DIR:-N/A}/graylog_collected/\`\n:link: <${SLACK_RUN_URL}|View Run>"
+          curl -s -X POST "${SLACK_WEBHOOK_URL}" \
+            -H 'Content-Type: application/json' \
+            -d "{\"text\":\"${MSG}\"}" || true
+
       - name: Stop MinIO trace logging and save
         if: always()
         run: |

--- a/.github/workflows/k8s-native-e2e-node-migration.yaml
+++ b/.github/workflows/k8s-native-e2e-node-migration.yaml
@@ -2027,6 +2027,9 @@ jobs:
           else
             echo "No MinIO trace log found (backup tests may not have run)"
           fi
+          # Cleanup: delete trace logs and kill any orphaned mc trace processes
+          rm -f /tmp/minio-trace-*.log 2>/dev/null || true
+          pkill -f "mc admin trace" 2>/dev/null || true
 
       - name: Upload MinIO trace log
         if: always()

--- a/.github/workflows/k8s-native-e2e.yaml
+++ b/.github/workflows/k8s-native-e2e.yaml
@@ -2058,6 +2058,9 @@ jobs:
           else
             echo "No MinIO trace log found (backup tests may not have run)"
           fi
+          # Cleanup: delete trace logs and kill any orphaned mc trace processes
+          rm -f /tmp/minio-trace-*.log 2>/dev/null || true
+          pkill -f "mc admin trace" 2>/dev/null || true
 
       - name: Upload MinIO trace log
         if: always()

--- a/.github/workflows/k8s-native-e2e.yaml
+++ b/.github/workflows/k8s-native-e2e.yaml
@@ -1585,6 +1585,8 @@ jobs:
         shell: bash
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
           JOB_STATUS: ${{ job.status }}
           SLACK_RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           GITHUB_REF_NAME: ${{ github.ref_name }}
@@ -1598,9 +1600,11 @@ jobs:
         run: |
           python3 - <<'PYEOF'
           import json, os, re, sys, urllib.request, urllib.error
-          webhook = os.environ.get("SLACK_WEBHOOK_URL", "")
-          if not webhook:
-              print("No SLACK_WEBHOOK_URL set, skipping.")
+          bot_token = os.environ.get("SLACK_BOT_TOKEN", "")
+          channel   = os.environ.get("SLACK_CHANNEL_ID", "")
+          webhook   = os.environ.get("SLACK_WEBHOOK_URL", "")
+          if not bot_token and not webhook:
+              print("No SLACK_BOT_TOKEN or SLACK_WEBHOOK_URL set, skipping.")
               sys.exit(0)
           out_log = os.path.join(os.environ.get("GITHUB_WORKSPACE", "."), "e2e", "output.log")
           total = passed = failed = skipped = 0
@@ -1688,17 +1692,46 @@ jobs:
               f":link: *Run:* <{run_url}|View on GitHub>",
               f":hourglass_flowing_sand: _Logs are being collected and will be available shortly._",
           ]
-          payload = {"text": "\n".join(lines)}
-          req = urllib.request.Request(
-              webhook,
-              data=json.dumps(payload).encode(),
-              headers={"Content-Type": "application/json"},
-          )
-          try:
-              urllib.request.urlopen(req, timeout=15)
-              print("Slack notification sent.")
-          except Exception as exc:
-              print(f"WARN: Slack notification failed: {exc}", file=sys.stderr)
+          # --- Send ---
+          gh_env = os.environ.get("GITHUB_ENV", "")
+          text   = "\n".join(lines)
+
+          if bot_token and channel:
+              api_payload = json.dumps({"channel": channel, "text": text}).encode()
+              req = urllib.request.Request(
+                  "https://slack.com/api/chat.postMessage",
+                  data=api_payload,
+                  headers={
+                      "Content-Type": "application/json; charset=utf-8",
+                      "Authorization": f"Bearer {bot_token}",
+                  },
+              )
+              try:
+                  resp = urllib.request.urlopen(req, timeout=15)
+                  body = json.loads(resp.read().decode())
+                  if body.get("ok"):
+                      ts = body.get("ts", "")
+                      print(f"Slack notification sent via Bot API (ts={ts}).")
+                      if gh_env and ts:
+                          with open(gh_env, "a") as f:
+                              f.write(f"SLACK_MSG_TS={ts}\n")
+                  else:
+                      print(f"WARN: Slack API error: {body.get('error')}", file=sys.stderr)
+              except Exception as exc:
+                  print(f"WARN: Slack Bot API failed: {exc}", file=sys.stderr)
+          elif webhook:
+              req = urllib.request.Request(
+                  webhook,
+                  data=json.dumps({"text": text}).encode(),
+                  headers={"Content-Type": "application/json"},
+              )
+              try:
+                  urllib.request.urlopen(req, timeout=15)
+                  print("Slack notification sent via webhook (no thread support).")
+              except Exception as exc:
+                  print(f"WARN: Slack webhook failed: {exc}", file=sys.stderr)
+          else:
+              print("No SLACK_BOT_TOKEN or SLACK_WEBHOOK_URL set, skipping.")
           PYEOF
 
 
@@ -1975,16 +2008,25 @@ jobs:
         if: always() && (github.event.inputs.send_slack_notification || 'true') == 'true'
         shell: bash
         env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
+          SLACK_MSG_TS: ${{ env.SLACK_MSG_TS }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           SLACK_WF_NAME: "K8s Native E2E"
           RUN_BASE_DIR: ${{ env.RUN_BASE_DIR }}
         run: |
-          if [ -z "${SLACK_WEBHOOK_URL:-}" ]; then exit 0; fi
           MSG=":white_check_mark: *Log collection complete* for *SimplyBlock ${SLACK_WF_NAME}*\n:file_folder: \`${RUN_BASE_DIR:-N/A}/graylog_collected/\`\n:link: <${SLACK_RUN_URL}|View Run>"
-          curl -s -X POST "${SLACK_WEBHOOK_URL}" \
-            -H 'Content-Type: application/json' \
-            -d "{\"text\":\"${MSG}\"}" || true
+          if [ -n "${SLACK_BOT_TOKEN:-}" ] && [ -n "${SLACK_CHANNEL_ID:-}" ] && [ -n "${SLACK_MSG_TS:-}" ]; then
+            curl -s -X POST "https://slack.com/api/chat.postMessage" \
+              -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
+              -H "Content-Type: application/json; charset=utf-8" \
+              -d "{\"channel\":\"${SLACK_CHANNEL_ID}\",\"thread_ts\":\"${SLACK_MSG_TS}\",\"text\":\"${MSG}\"}" || true
+          elif [ -n "${SLACK_WEBHOOK_URL:-}" ]; then
+            curl -s -X POST "${SLACK_WEBHOOK_URL}" \
+              -H "Content-Type: application/json" \
+              -d "{\"text\":\"${MSG}\"}" || true
+          fi
 
       - name: Upload logs (always)
         if: always()

--- a/.github/workflows/k8s-native-e2e.yaml
+++ b/.github/workflows/k8s-native-e2e.yaml
@@ -1970,6 +1970,22 @@ jobs:
         env:
           CLUSTER_ID: ${{ env.CLUSTER_ID }}
           MON_SECRET: ${{ secrets.MON_SECRET }}
+
+      - name: Notify Slack log collection complete
+        if: always() && (github.event.inputs.send_slack_notification || 'true') == 'true'
+        shell: bash
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          SLACK_WF_NAME: "K8s Native E2E"
+          RUN_BASE_DIR: ${{ env.RUN_BASE_DIR }}
+        run: |
+          if [ -z "${SLACK_WEBHOOK_URL:-}" ]; then exit 0; fi
+          MSG=":white_check_mark: *Log collection complete* for *SimplyBlock ${SLACK_WF_NAME}*\n:file_folder: \`${RUN_BASE_DIR:-N/A}/graylog_collected/\`\n:link: <${SLACK_RUN_URL}|View Run>"
+          curl -s -X POST "${SLACK_WEBHOOK_URL}" \
+            -H 'Content-Type: application/json' \
+            -d "{\"text\":\"${MSG}\"}" || true
+
       - name: Upload logs (always)
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/k8s-native-e2e.yaml
+++ b/.github/workflows/k8s-native-e2e.yaml
@@ -588,13 +588,9 @@ jobs:
           set -euxo pipefail
 
           # 1. Install mc (MinIO Client)
-          if curl -fsSL https://dl.min.io/client/mc/release/linux-amd64/mc -o /usr/local/bin/mc 2>/dev/null; then
-            chmod +x /usr/local/bin/mc
-          else
-            curl -fsSL https://dl.min.io/client/mc/release/linux-amd64/mc -o /tmp/mc
-            chmod +x /tmp/mc
-            export PATH="/tmp:$PATH"
-          fi
+          curl -fsSL https://dl.min.io/client/mc/release/linux-amd64/mc -o /tmp/mc
+          chmod +x /tmp/mc
+          export PATH="/tmp:$PATH"
 
           # 2. Port-forward MinIO service to localhost
           kubectl -n minio port-forward svc/minio 9000:9000 &

--- a/.github/workflows/k8s-native-e2e.yaml
+++ b/.github/workflows/k8s-native-e2e.yaml
@@ -588,8 +588,13 @@ jobs:
           set -euxo pipefail
 
           # 1. Install mc (MinIO Client)
-          curl -fsSL https://dl.min.io/client/mc/release/linux-amd64/mc -o /usr/local/bin/mc
-          chmod +x /usr/local/bin/mc
+          if curl -fsSL https://dl.min.io/client/mc/release/linux-amd64/mc -o /usr/local/bin/mc 2>/dev/null; then
+            chmod +x /usr/local/bin/mc
+          else
+            curl -fsSL https://dl.min.io/client/mc/release/linux-amd64/mc -o /tmp/mc
+            chmod +x /tmp/mc
+            export PATH="/tmp:$PATH"
+          fi
 
           # 2. Port-forward MinIO service to localhost
           kubectl -n minio port-forward svc/minio 9000:9000 &

--- a/.github/workflows/k8s-native-stress.yaml
+++ b/.github/workflows/k8s-native-stress.yaml
@@ -1401,6 +1401,8 @@ jobs:
         shell: bash
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
           JOB_STATUS: ${{ job.status }}
           SLACK_RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           GITHUB_REF_NAME: ${{ github.ref_name }}
@@ -1414,9 +1416,11 @@ jobs:
         run: |
           python3 - <<'PYEOF'
           import json, os, re, sys, urllib.request, urllib.error
-          webhook = os.environ.get("SLACK_WEBHOOK_URL", "")
-          if not webhook:
-              print("No SLACK_WEBHOOK_URL set, skipping.")
+          bot_token = os.environ.get("SLACK_BOT_TOKEN", "")
+          channel   = os.environ.get("SLACK_CHANNEL_ID", "")
+          webhook   = os.environ.get("SLACK_WEBHOOK_URL", "")
+          if not bot_token and not webhook:
+              print("No SLACK_BOT_TOKEN or SLACK_WEBHOOK_URL set, skipping.")
               sys.exit(0)
           out_log = os.path.join(os.environ.get("GITHUB_WORKSPACE", "."), "e2e", "output.log")
           total = passed = failed = skipped = 0
@@ -1496,17 +1500,46 @@ jobs:
               f":link: *Run:* <{run_url}|View on GitHub>",
               f":hourglass_flowing_sand: _Logs are being collected and will be available shortly._",
           ]
-          payload = {"text": "\n".join(lines)}
-          req = urllib.request.Request(
-              webhook,
-              data=json.dumps(payload).encode(),
-              headers={"Content-Type": "application/json"},
-          )
-          try:
-              urllib.request.urlopen(req, timeout=15)
-              print("Slack notification sent.")
-          except Exception as exc:
-              print(f"WARN: Slack notification failed: {exc}", file=sys.stderr)
+          # --- Send ---
+          gh_env = os.environ.get("GITHUB_ENV", "")
+          text   = "\n".join(lines)
+
+          if bot_token and channel:
+              api_payload = json.dumps({"channel": channel, "text": text}).encode()
+              req = urllib.request.Request(
+                  "https://slack.com/api/chat.postMessage",
+                  data=api_payload,
+                  headers={
+                      "Content-Type": "application/json; charset=utf-8",
+                      "Authorization": f"Bearer {bot_token}",
+                  },
+              )
+              try:
+                  resp = urllib.request.urlopen(req, timeout=15)
+                  body = json.loads(resp.read().decode())
+                  if body.get("ok"):
+                      ts = body.get("ts", "")
+                      print(f"Slack notification sent via Bot API (ts={ts}).")
+                      if gh_env and ts:
+                          with open(gh_env, "a") as f:
+                              f.write(f"SLACK_MSG_TS={ts}\n")
+                  else:
+                      print(f"WARN: Slack API error: {body.get('error')}", file=sys.stderr)
+              except Exception as exc:
+                  print(f"WARN: Slack Bot API failed: {exc}", file=sys.stderr)
+          elif webhook:
+              req = urllib.request.Request(
+                  webhook,
+                  data=json.dumps({"text": text}).encode(),
+                  headers={"Content-Type": "application/json"},
+              )
+              try:
+                  urllib.request.urlopen(req, timeout=15)
+                  print("Slack notification sent via webhook (no thread support).")
+              except Exception as exc:
+                  print(f"WARN: Slack webhook failed: {exc}", file=sys.stderr)
+          else:
+              print("No SLACK_BOT_TOKEN or SLACK_WEBHOOK_URL set, skipping.")
           PYEOF
 
 
@@ -1755,16 +1788,25 @@ jobs:
         if: always() && (github.event.inputs.send_slack_notification || 'true') == 'true'
         shell: bash
         env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
+          SLACK_MSG_TS: ${{ env.SLACK_MSG_TS }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           SLACK_WF_NAME: "K8s Native Stress"
           RUN_BASE_DIR: ${{ env.RUN_BASE_DIR }}
         run: |
-          if [ -z "${SLACK_WEBHOOK_URL:-}" ]; then exit 0; fi
           MSG=":white_check_mark: *Log collection complete* for *SimplyBlock ${SLACK_WF_NAME}*\n:file_folder: \`${RUN_BASE_DIR:-N/A}/graylog_collected/\`\n:link: <${SLACK_RUN_URL}|View Run>"
-          curl -s -X POST "${SLACK_WEBHOOK_URL}" \
-            -H 'Content-Type: application/json' \
-            -d "{\"text\":\"${MSG}\"}" || true
+          if [ -n "${SLACK_BOT_TOKEN:-}" ] && [ -n "${SLACK_CHANNEL_ID:-}" ] && [ -n "${SLACK_MSG_TS:-}" ]; then
+            curl -s -X POST "https://slack.com/api/chat.postMessage" \
+              -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
+              -H "Content-Type: application/json; charset=utf-8" \
+              -d "{\"channel\":\"${SLACK_CHANNEL_ID}\",\"thread_ts\":\"${SLACK_MSG_TS}\",\"text\":\"${MSG}\"}" || true
+          elif [ -n "${SLACK_WEBHOOK_URL:-}" ]; then
+            curl -s -X POST "${SLACK_WEBHOOK_URL}" \
+              -H "Content-Type: application/json" \
+              -d "{\"text\":\"${MSG}\"}" || true
+          fi
 
       - name: Cleanup build folder
         if: always()

--- a/.github/workflows/k8s-native-stress.yaml
+++ b/.github/workflows/k8s-native-stress.yaml
@@ -1750,6 +1750,22 @@ jobs:
         env:
           CLUSTER_ID: ${{ env.CLUSTER_ID }}
           MON_SECRET: ${{ secrets.MON_SECRET }}
+
+      - name: Notify Slack log collection complete
+        if: always() && (github.event.inputs.send_slack_notification || 'true') == 'true'
+        shell: bash
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          SLACK_WF_NAME: "K8s Native Stress"
+          RUN_BASE_DIR: ${{ env.RUN_BASE_DIR }}
+        run: |
+          if [ -z "${SLACK_WEBHOOK_URL:-}" ]; then exit 0; fi
+          MSG=":white_check_mark: *Log collection complete* for *SimplyBlock ${SLACK_WF_NAME}*\n:file_folder: \`${RUN_BASE_DIR:-N/A}/graylog_collected/\`\n:link: <${SLACK_RUN_URL}|View Run>"
+          curl -s -X POST "${SLACK_WEBHOOK_URL}" \
+            -H 'Content-Type: application/json' \
+            -d "{\"text\":\"${MSG}\"}" || true
+
       - name: Cleanup build folder
         if: always()
         run: |

--- a/.github/workflows/k8s-native-upgrade.yaml
+++ b/.github/workflows/k8s-native-upgrade.yaml
@@ -712,6 +712,7 @@ jobs:
             --create-namespace \
             --timeout 10m \
             --set ingress-nginx.controller.admissionWebhooks.enabled=false \
+            --set ports.lvolNvmfPortStart=9110 \
             ./
           echo "sbcli control plane chart installed"
 
@@ -800,7 +801,9 @@ jobs:
             sbcli-dev -d --dev cluster create \
               --mgmt-ip "$MGMT_IP" \
               --mode kubernetes \
-              --disable-monitoring 2>&1) || true
+              --disable-monitoring \
+              --data-chunks-per-stripe "${NDCS}" \
+              --parity-chunks-per-stripe "${NPCS}" 2>&1) || true
           echo "Cluster create output: $CREATE_OUTPUT"
 
           # Parse cluster ID and secret from output
@@ -895,7 +898,8 @@ jobs:
             --set logicalVolume.encryption=false \
             --set storagenode.ifname="${MGMT_IFC}" \
             --set storagenode.create=true \
-            --set storagenode.numPartitions=1 \
+            --set storagenode.numPartitions="${PARTITIONS}" \
+            --set storagenode.haJMCount="${JM_COUNT}" \
             --set storagenode.coresPercentage=50 \
             --set image.storageNode.tag="${STORAGENODE_TAG}"
 
@@ -911,6 +915,7 @@ jobs:
           NDCS: ${{ env.NDCS }}
           NPCS: ${{ env.NPCS }}
           PARTITIONS: ${{ env.PARTITIONS }}
+          JM_COUNT: ${{ env.JM_COUNT }}
           MGMT_IFC: ${{ env.MGMT_IFC }}
 
       - name: Wait for R25 storage nodes and cluster active

--- a/.github/workflows/k8s-native-upgrade.yaml
+++ b/.github/workflows/k8s-native-upgrade.yaml
@@ -981,7 +981,7 @@ jobs:
           for i in $(seq 1 60); do
             ONLINE_COUNT=$(kubectl -n $NAMESPACE exec "$ADMIN_POD" -- \
               sbcli-dev sn list --json 2>/dev/null \
-              | jq '[.[] | select(.status == "online")] | length' 2>/dev/null || echo "0")
+              | jq '[.[] | select(.Status == "online")] | length' 2>/dev/null || echo "0")
             echo "Storage nodes online: $ONLINE_COUNT/$EXPECTED_SNODES ($i/60)"
             if [ "$ONLINE_COUNT" -ge "$EXPECTED_SNODES" ]; then
               echo "All storage nodes are online"

--- a/.github/workflows/k8s-native-upgrade.yaml
+++ b/.github/workflows/k8s-native-upgrade.yaml
@@ -1310,43 +1310,270 @@ jobs:
         if: always()
         shell: bash
         run: |
-          set +e
+          set -euxo pipefail
+
           out_log="$GITHUB_WORKSPACE/e2e/output.log"
           dur_fmt="${TEST_TIME_HOURS:-0}h ${TEST_TIME_MINS:-0}m ${TEST_TIME_SECS:-0}s"
 
-          total_cases="$(grep -E 'Total Cases:|Total Test Cases:' "${out_log}" 2>/dev/null | tail -n 1 | grep -oE '[0-9]+' | tail -1 || echo '?')"
-          passed_cnt="$(grep -E 'Passed:' "${out_log}" 2>/dev/null | tail -n 1 | grep -oE '[0-9]+' | tail -1 || echo '?')"
-          failed_cnt="$(grep -E 'Failed:' "${out_log}" 2>/dev/null | tail -n 1 | grep -oE '[0-9]+' | tail -1 || echo '?')"
+          # --- Parse test counts from output.log (upgrade_e2e.py format) ---
+          total_cases=0; passed_cases=0; failed_cases=0; skipped_cases=0
+          if [[ -f "${out_log}" ]]; then
+            v="$(grep -m1 'Total Cases:'  "${out_log}" | grep -oE '[0-9]+$' 2>/dev/null || true)"; [[ "${v}" =~ ^[0-9]+$ ]] && total_cases="${v}"
+            v="$(grep -m1 'Passed:'       "${out_log}" | grep -oE '[0-9]+$' 2>/dev/null || true)"; [[ "${v}" =~ ^[0-9]+$ ]] && passed_cases="${v}"
+            v="$(grep -m1 'Failed:'       "${out_log}" | grep -oE '[0-9]+$' 2>/dev/null || true)"; [[ "${v}" =~ ^[0-9]+$ ]] && failed_cases="${v}"
+            v="$(grep -m1 'Skipped:'      "${out_log}" | grep -oE '[0-9]+$' 2>/dev/null || true)"; [[ "${v}" =~ ^[0-9]+$ ]] && skipped_cases="${v}"
+          fi
+
+          pass_pct=0; fail_pct=0; skip_pct=0
+          if [[ "${total_cases}" -gt 0 ]]; then
+            pass_pct=$(( (passed_cases  * 100) / total_cases ))
+            fail_pct=$(( (failed_cases  * 100) / total_cases ))
+            skip_pct=$(( (skipped_cases * 100) / total_cases ))
+          fi
+
+          # --- Parse per-test status ---
+          test_details_table=""
+          if [[ -f "${out_log}" ]]; then
+            while IFS= read -r line; do
+              clean="$(printf '%s' "${line}" | sed 's/\x1b\[[0-9;]*m//g')"
+              test_name="$(printf '%s' "${clean}" | grep -oE 'Test[A-Za-z0-9_]+' | head -n1 || true)"
+              [[ -z "${test_name}" ]] && continue
+              if   printf '%s' "${clean}" | grep -qi 'PASSED';  then icon="✅"; status="PASSED"
+              elif printf '%s' "${clean}" | grep -qi 'FAILED';  then icon="❌"; status="FAILED"
+              elif printf '%s' "${clean}" | grep -qi 'SKIPPED'; then icon="⏭"; status="SKIPPED"
+              else continue
+              fi
+              test_details_table+="| \`${test_name}\` | ${icon} ${status} |"$'\n'
+            done < <(grep -iE 'PASSED|FAILED|SKIPPED' "${out_log}" 2>/dev/null || true)
+          fi
+
+          # --- Failure reason ---
+          failure_reason=""
+          if [[ -f "${out_log}" ]]; then
+            multi="$(grep 'MultipleExceptions:' "${out_log}" | sed 's/\x1b\[[0-9;]*m//g' || true)"
+            if [[ -n "${multi}" ]]; then
+              failure_reason="${multi}"
+            elif grep -Eqi 'Traceback \(most recent call last\)|Exception:|AssertionError|Input/output error' "${out_log}"; then
+              failure_reason="$(grep -Ei 'Traceback \(most recent call last\)|Exception:|AssertionError|Input/output error' "${out_log}" | tail -n 3 | sed 's/\x1b\[[0-9;]*m//g' || true)"
+            fi
+          fi
+
+          # --- Overall result ---
+          conclusion="✅ SUCCESS"
+          if [[ "${{ job.status }}" != "success" ]]; then
+            conclusion="❌ FAILED"
+          fi
 
           {
-            echo "## K8s Native Upgrade Test Results"
+            echo "## SimplyBlock K8s Upgrade E2E Run Summary"
             echo ""
-            echo "| Metric | Value |"
-            echo "|--------|-------|"
-            echo "| Base Version | \`${{ github.event.inputs.base_simplyblock_image }}\` |"
-            echo "| Target Version | \`${{ github.event.inputs.target_simplyblock_image }}\` |"
-            echo "| Duration | ${dur_fmt} |"
-            echo "| Total | ${total_cases} |"
-            echo "| Passed | ${passed_cnt} |"
-            echo "| Failed | ${failed_cnt} |"
+            echo "**Result:** ${conclusion} &nbsp;|&nbsp; **Duration:** ${dur_fmt}"
             echo ""
-            if [ -n "${RUN_BASE_DIR:-}" ]; then
-              echo "**Logs:** \`${RUN_BASE_DIR}\`"
+
+            echo "### Upgrade"
+            echo "| | Image | SPDK Image |"
+            echo "|---|---|---|"
+            echo "| **Base**   | \`${BASE_IMAGE}\`   | \`${BASE_SPDK}\` |"
+            echo "| **Target** | \`${TARGET_IMAGE}\` | \`${TARGET_SPDK}\` |"
+            echo ""
+
+            echo "### Test Results"
+            echo "| | Count | % |"
+            echo "|---|---|---|"
+            echo "| ✅ Passed  | ${passed_cases}  | ${pass_pct}% |"
+            echo "| ❌ Failed  | ${failed_cases}  | ${fail_pct}% |"
+            echo "| ⏭ Skipped | ${skipped_cases} | ${skip_pct}% |"
+            echo "| **Total**  | **${total_cases}** | |"
+            echo ""
+
+            if [[ -n "${test_details_table}" ]]; then
+              echo "### Test Case Details"
+              echo "| Test | Result |"
+              echo "|---|---|"
+              printf '%s' "${test_details_table}"
+              echo ""
             fi
+
+            echo "### Run Info"
+            echo "- **Upgrade type:** \`${UPGRADE_TYPE}\`"
+            echo "- **Test class:** \`${TESTNAME:-all}\`"
+            echo "- **Cluster ID:** \`${CLUSTER_ID}\`"
+            echo "- **Environment:** \`${CLUSTER_ENV}\`"
+            echo "- **Branch:** \`${{ github.ref_name }}\`"
+            echo "- **NDCS/NPCS:** \`${NDCS:-?}/${NPCS:-?}\`"
             echo ""
+
+            if [[ -n "${failure_reason}" ]]; then
+              echo "### Failure Reason"
+              echo '```'
+              printf '%s\n' "${failure_reason}"
+              echo '```'
+              echo ""
+            fi
+
+            if [[ -n "${RUN_BASE_DIR:-}" ]]; then
+              echo "<details><summary>Run Artifacts (NFS)</summary>"
+              echo ""
+              echo "- **Run dir:** \`${RUN_BASE_DIR}/\`"
+              echo "- Graylog logs: \`${RUN_BASE_DIR}/graylog_collected/\`"
+              echo "- K8s pod logs: \`${RUN_BASE_DIR}/k8s_pod_logs/\`"
+              echo ""
+              echo "</details>"
+              echo ""
+            fi
+
             echo "> **Note:** Graylog/OpenSearch logs are currently being collected and will be available in the NFS log directory shortly."
           } >> "$GITHUB_STEP_SUMMARY"
+        env:
+          TESTNAME: ${{ github.event.inputs.testname || 'K8sNativeMajorUpgrade' }}
+          CLUSTER_ID: ${{ env.CLUSTER_ID }}
+          NDCS: ${{ env.NDCS }}
+          NPCS: ${{ env.NPCS }}
+          RUN_BASE_DIR: ${{ env.RUN_BASE_DIR }}
+          BASE_IMAGE: ${{ github.event.inputs.base_simplyblock_image }}
+          TARGET_IMAGE: ${{ github.event.inputs.target_simplyblock_image }}
+          BASE_SPDK: ${{ github.event.inputs.base_spdk_image }}
+          TARGET_SPDK: ${{ github.event.inputs.target_spdk_image }}
+          UPGRADE_TYPE: ${{ github.event.inputs.upgrade_type || 'rolling' }}
+          CLUSTER_ENV: ${{ github.event.inputs.cluster_environment || 'local' }}
 
-      - name: Send Slack notification
-        if: ${{ always() && github.event.inputs.send_slack_notification == 'true' }}
-        uses: slackapi/slack-github-action@v1.26.0
-        with:
-          payload: |
-            {
-              "text": "K8s Upgrade Test: ${{ job.status }} | ${{ github.event.inputs.base_simplyblock_image }} -> ${{ github.event.inputs.target_simplyblock_image }} | ${{ github.event.inputs.cluster_environment }} | Duration: ${{ env.TEST_TIME_HOURS }}h ${{ env.TEST_TIME_MINS }}m | <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Run>\n:hourglass_flowing_sand: _Logs are being collected and will be available shortly._"
-            }
+      - name: Send Slack Notification
+        if: always() && (github.event.inputs.send_slack_notification == 'true')
+        shell: bash
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          JOB_STATUS: ${{ job.status }}
+          SLACK_RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          GITHUB_REF_NAME: ${{ github.ref_name }}
+          SLACK_WF_NAME: "K8s Upgrade (${{ github.event.inputs.upgrade_type || 'rolling' }})"
+          TESTNAME: ${{ github.event.inputs.testname || 'K8sNativeMajorUpgrade' }}
+          RUN_BASE_DIR: ${{ env.RUN_BASE_DIR }}
+          NDCS: ${{ env.NDCS }}
+          NPCS: ${{ env.NPCS }}
+          TEST_START_TIME: ${{ env.TEST_START_TIME }}
+          TEST_END_TIME: ${{ env.TEST_END_TIME }}
+          BASE_IMAGE: ${{ github.event.inputs.base_simplyblock_image }}
+          TARGET_IMAGE: ${{ github.event.inputs.target_simplyblock_image }}
+          BASE_SPDK: ${{ github.event.inputs.base_spdk_image }}
+          TARGET_SPDK: ${{ github.event.inputs.target_spdk_image }}
+          CLUSTER_ENV: ${{ github.event.inputs.cluster_environment || 'local' }}
+        run: |
+          python3 - <<'PYEOF'
+          import json, os, re, sys, urllib.request, urllib.error
+
+          webhook = os.environ.get("SLACK_WEBHOOK_URL", "")
+          if not webhook:
+              print("No SLACK_WEBHOOK_URL set, skipping.")
+              sys.exit(0)
+
+          out_log = os.path.join(os.environ.get("GITHUB_WORKSPACE", "."), "e2e", "output.log")
+          content = open(out_log).read() if os.path.isfile(out_log) else ""
+
+          # --- Counts (upgrade_e2e.py format) ---
+          def px(pat):
+              m = re.search(pat, content)
+              return int(m.group(1)) if m else 0
+          total   = px(r'Total Cases:\s*(\d+)')
+          passed  = px(r'Passed:\s*(\d+)')
+          failed  = px(r'Failed:\s*(\d+)')
+          skipped = px(r'Skipped:\s*(\d+)')
+          pass_pct = (passed * 100 // total) if total > 0 else 0
+
+          # --- Per-test results ---
+          ansi = re.compile(r'\x1b\[[0-9;]*m')
+          test_results = []
+          for line in content.splitlines():
+              clean = ansi.sub('', line)
+              m = re.search(r'Test[A-Za-z0-9_]+', clean)
+              if not m:
+                  continue
+              name = m.group(0)
+              if   'PASSED'  in clean: test_results.append(('PASSED',  name))
+              elif 'FAILED'  in clean: test_results.append(('FAILED',  name))
+              elif 'SKIPPED' in clean: test_results.append(('SKIPPED', name))
+
+          # --- Failure reason ---
+          failure_reason = ""
+          multi = [ansi.sub('', l) for l in content.splitlines() if 'MultipleExceptions:' in l]
+          if multi:
+              failure_reason = multi[0][:2000]
+          elif content:
+              exc_lines = [ansi.sub('', l) for l in content.splitlines()
+                           if re.search(r'(Exception:|AssertionError|Input/output error)', l)]
+              if exc_lines:
+                  failure_reason = '\n'.join(exc_lines[-5:])[:2000]
+
+          # --- Env ---
+          s    = int(os.environ.get("TEST_START_TIME", "0") or "0")
+          e    = int(os.environ.get("TEST_END_TIME",   "0") or "0")
+          secs = max(0, e - s) if e >= s > 0 else 0
+          dur  = f"{secs//3600}h {(secs%3600)//60}m {secs%60}s"
+          run_url       = os.environ.get("SLACK_RUN_URL",   "")
+          log_dir       = os.environ.get("RUN_BASE_DIR",    "N/A")
+          base_img      = os.environ.get("BASE_IMAGE",      "?")
+          base_spdk     = os.environ.get("BASE_SPDK",       "") or "default"
+          target_img    = os.environ.get("TARGET_IMAGE",     "?")
+          target_spdk   = os.environ.get("TARGET_SPDK",      "") or "default"
+          test_cls      = os.environ.get("TESTNAME",         "") or "all"
+          branch        = os.environ.get("GITHUB_REF_NAME",  "?")
+          ndcs          = os.environ.get("NDCS",             "?")
+          npcs          = os.environ.get("NPCS",             "?")
+          cluster_env   = os.environ.get("CLUSTER_ENV",      "?")
+          wf_name       = os.environ.get("SLACK_WF_NAME",    "Run")
+          ok            = os.environ.get("JOB_STATUS",       "") == "success"
+
+          icon    = ":white_check_mark:" if ok else ":x:"
+          status  = "SUCCESS" if ok else "FAILURE"
+          mention = "" if ok else " <!channel>"
+
+          lines = [
+              f"{icon} *SimplyBlock {wf_name}*{mention}",
+              f"*Status:* {status}  |  *Duration:* {dur}",
+              f"*Branch:* `{branch}`  |  *Test class:* `{test_cls}`",
+              f"*Upgrade:* `{base_img}` \u2192 `{target_img}`",
+              f"*Base SPDK:* `{base_spdk}`  |  *Target SPDK:* `{target_spdk}`",
+              f"*Environment:* `{cluster_env}`  |  *NDCS/NPCS:* `{ndcs}/{npcs}`",
+              "",
+          ]
+
+          if total > 0:
+              lines += [
+                  f":white_check_mark: *Passed:*  {passed}/{total}  ({pass_pct}%)",
+                  f":x: *Failed:*  {failed}",
+                  f":fast_forward: *Skipped:*  {skipped}",
+              ]
+          else:
+              lines.append("_(test counts not found in log)_")
+
+          if test_results:
+              lines.append("")
+              lines.append("*Test Results:*")
+              icons = {'PASSED': ':white_check_mark:', 'FAILED': ':x:', 'SKIPPED': ':fast_forward:'}
+              for st, nm in test_results:
+                  lines.append(f"{icons.get(st, ':grey_question:')} `{nm}`")
+
+          if failure_reason:
+              lines += ["", "*Failure:*", f"```{failure_reason}```"]
+
+          lines += [
+              "",
+              f":link: *Run:* <{run_url}|View on GitHub>",
+              f":file_folder: *Final Logs:* `{log_dir}`",
+              f":hourglass_flowing_sand: _Logs are being collected and will be available shortly._",
+          ]
+
+          payload = {"text": "\n".join(lines)}
+          req = urllib.request.Request(
+              webhook,
+              data=json.dumps(payload).encode(),
+              headers={"Content-Type": "application/json"},
+          )
+          try:
+              urllib.request.urlopen(req, timeout=15)
+              print("Slack notification sent.")
+          except Exception as exc:
+              print(f"WARN: Slack notification failed: {exc}", file=sys.stderr)
+          PYEOF
 
 
       - name: Collect Graylog/OpenSearch logs
@@ -1580,6 +1807,21 @@ jobs:
         env:
           CLUSTER_ID: ${{ env.CLUSTER_ID }}
           MON_SECRET: ${{ secrets.MON_SECRET }}
+
+      - name: Notify Slack log collection complete
+        if: always() && (github.event.inputs.send_slack_notification == 'true')
+        shell: bash
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          SLACK_WF_NAME: "K8s Upgrade (${{ github.event.inputs.upgrade_type || 'rolling' }})"
+          RUN_BASE_DIR: ${{ env.RUN_BASE_DIR }}
+        run: |
+          if [ -z "${SLACK_WEBHOOK_URL:-}" ]; then exit 0; fi
+          MSG=":white_check_mark: *Log collection complete* for *SimplyBlock ${SLACK_WF_NAME}*\n:file_folder: \`${RUN_BASE_DIR:-N/A}/graylog_collected/\`\n:link: <${SLACK_RUN_URL}|View Run>"
+          curl -s -X POST "${SLACK_WEBHOOK_URL}" \
+            -H 'Content-Type: application/json' \
+            -d "{\"text\":\"${MSG}\"}" || true
 
       - name: Cleanup build folder
         if: always()

--- a/.github/workflows/k8s-native-upgrade.yaml
+++ b/.github/workflows/k8s-native-upgrade.yaml
@@ -1442,6 +1442,8 @@ jobs:
         shell: bash
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
           JOB_STATUS: ${{ job.status }}
           SLACK_RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           GITHUB_REF_NAME: ${{ github.ref_name }}
@@ -1461,9 +1463,11 @@ jobs:
           python3 - <<'PYEOF'
           import json, os, re, sys, urllib.request, urllib.error
 
-          webhook = os.environ.get("SLACK_WEBHOOK_URL", "")
-          if not webhook:
-              print("No SLACK_WEBHOOK_URL set, skipping.")
+          bot_token = os.environ.get("SLACK_BOT_TOKEN", "")
+          channel   = os.environ.get("SLACK_CHANNEL_ID", "")
+          webhook   = os.environ.get("SLACK_WEBHOOK_URL", "")
+          if not bot_token and not webhook:
+              print("No SLACK_BOT_TOKEN or SLACK_WEBHOOK_URL set, skipping.")
               sys.exit(0)
 
           out_log = os.path.join(os.environ.get("GITHUB_WORKSPACE", "."), "e2e", "output.log")
@@ -1562,17 +1566,46 @@ jobs:
               f":hourglass_flowing_sand: _Logs are being collected and will be available shortly._",
           ]
 
-          payload = {"text": "\n".join(lines)}
-          req = urllib.request.Request(
-              webhook,
-              data=json.dumps(payload).encode(),
-              headers={"Content-Type": "application/json"},
-          )
-          try:
-              urllib.request.urlopen(req, timeout=15)
-              print("Slack notification sent.")
-          except Exception as exc:
-              print(f"WARN: Slack notification failed: {exc}", file=sys.stderr)
+          # --- Send ---
+          gh_env = os.environ.get("GITHUB_ENV", "")
+          text   = "\n".join(lines)
+
+          if bot_token and channel:
+              api_payload = json.dumps({"channel": channel, "text": text}).encode()
+              req = urllib.request.Request(
+                  "https://slack.com/api/chat.postMessage",
+                  data=api_payload,
+                  headers={
+                      "Content-Type": "application/json; charset=utf-8",
+                      "Authorization": f"Bearer {bot_token}",
+                  },
+              )
+              try:
+                  resp = urllib.request.urlopen(req, timeout=15)
+                  body = json.loads(resp.read().decode())
+                  if body.get("ok"):
+                      ts = body.get("ts", "")
+                      print(f"Slack notification sent via Bot API (ts={ts}).")
+                      if gh_env and ts:
+                          with open(gh_env, "a") as f:
+                              f.write(f"SLACK_MSG_TS={ts}\n")
+                  else:
+                      print(f"WARN: Slack API error: {body.get('error')}", file=sys.stderr)
+              except Exception as exc:
+                  print(f"WARN: Slack Bot API failed: {exc}", file=sys.stderr)
+          elif webhook:
+              req = urllib.request.Request(
+                  webhook,
+                  data=json.dumps({"text": text}).encode(),
+                  headers={"Content-Type": "application/json"},
+              )
+              try:
+                  urllib.request.urlopen(req, timeout=15)
+                  print("Slack notification sent via webhook (no thread support).")
+              except Exception as exc:
+                  print(f"WARN: Slack webhook failed: {exc}", file=sys.stderr)
+          else:
+              print("No SLACK_BOT_TOKEN or SLACK_WEBHOOK_URL set, skipping.")
           PYEOF
 
 
@@ -1812,16 +1845,25 @@ jobs:
         if: always() && (github.event.inputs.send_slack_notification == 'true')
         shell: bash
         env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
+          SLACK_MSG_TS: ${{ env.SLACK_MSG_TS }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           SLACK_WF_NAME: "K8s Upgrade (${{ github.event.inputs.upgrade_type || 'rolling' }})"
           RUN_BASE_DIR: ${{ env.RUN_BASE_DIR }}
         run: |
-          if [ -z "${SLACK_WEBHOOK_URL:-}" ]; then exit 0; fi
           MSG=":white_check_mark: *Log collection complete* for *SimplyBlock ${SLACK_WF_NAME}*\n:file_folder: \`${RUN_BASE_DIR:-N/A}/graylog_collected/\`\n:link: <${SLACK_RUN_URL}|View Run>"
-          curl -s -X POST "${SLACK_WEBHOOK_URL}" \
-            -H 'Content-Type: application/json' \
-            -d "{\"text\":\"${MSG}\"}" || true
+          if [ -n "${SLACK_BOT_TOKEN:-}" ] && [ -n "${SLACK_CHANNEL_ID:-}" ] && [ -n "${SLACK_MSG_TS:-}" ]; then
+            curl -s -X POST "https://slack.com/api/chat.postMessage" \
+              -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
+              -H "Content-Type: application/json; charset=utf-8" \
+              -d "{\"channel\":\"${SLACK_CHANNEL_ID}\",\"thread_ts\":\"${SLACK_MSG_TS}\",\"text\":\"${MSG}\"}" || true
+          elif [ -n "${SLACK_WEBHOOK_URL:-}" ]; then
+            curl -s -X POST "${SLACK_WEBHOOK_URL}" \
+              -H "Content-Type: application/json" \
+              -d "{\"text\":\"${MSG}\"}" || true
+          fi
 
       - name: Cleanup build folder
         if: always()

--- a/.github/workflows/monitoring-suite-docker.yaml
+++ b/.github/workflows/monitoring-suite-docker.yaml
@@ -955,6 +955,21 @@ jobs:
           done
           echo "=== Graylog collection complete (${CHUNK} chunks): ${OUTPUT_DIR} ==="
 
+      - name: Notify Slack log collection complete
+        if: always()
+        shell: bash
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          SLACK_WF_NAME: "Monitoring Suite Docker"
+          RUN_BASE_DIR: ${{ env.RUN_BASE_DIR }}
+        run: |
+          if [ -z "${SLACK_WEBHOOK_URL:-}" ]; then exit 0; fi
+          MSG=":white_check_mark: *Log collection complete* for *SimplyBlock ${SLACK_WF_NAME}*\n:file_folder: \`${RUN_BASE_DIR:-N/A}/graylog_collected/\`\n:link: <${SLACK_RUN_URL}|View Run>"
+          curl -s -X POST "${SLACK_WEBHOOK_URL}" \
+            -H 'Content-Type: application/json' \
+            -d "{\"text\":\"${MSG}\"}" || true
+
       # ============================================================
       # COLLECT TIMING ARTIFACTS
       # ============================================================

--- a/.github/workflows/monitoring-suite-docker.yaml
+++ b/.github/workflows/monitoring-suite-docker.yaml
@@ -619,16 +619,10 @@ jobs:
           set -euxo pipefail
 
           # 1. Install mc (MinIO Client)
-          if ! command -v mc &>/dev/null; then
-            if curl -fsSL https://dl.min.io/client/mc/release/linux-amd64/mc -o /usr/local/bin/mc 2>/dev/null; then
-              chmod +x /usr/local/bin/mc
-            else
-              curl -fsSL https://dl.min.io/client/mc/release/linux-amd64/mc -o /tmp/mc
-              chmod +x /tmp/mc
-              export PATH="/tmp:$PATH"
-              echo "/tmp" >> "$GITHUB_PATH"
-            fi
-          fi
+          curl -fsSL https://dl.min.io/client/mc/release/linux-amd64/mc -o /tmp/mc
+          chmod +x /tmp/mc
+          export PATH="/tmp:$PATH"
+          echo "/tmp" >> "$GITHUB_PATH"
 
           # 2. Configure mc alias to external MinIO
           mc alias set myminio http://192.168.10.164:9000 "${MINIO_ACCESS_KEY}" "${MINIO_SECRET_KEY}"

--- a/.github/workflows/monitoring-suite-docker.yaml
+++ b/.github/workflows/monitoring-suite-docker.yaml
@@ -1036,6 +1036,9 @@ jobs:
           else
             echo "No MinIO trace log found (backup tests may not have run)"
           fi
+          # Cleanup: delete trace logs and kill any orphaned mc trace processes
+          rm -f /tmp/minio-trace-*.log 2>/dev/null || true
+          pkill -f "mc admin trace" 2>/dev/null || true
 
       - name: Upload bootstrap + test logs
         if: always()

--- a/.github/workflows/monitoring-suite-docker.yaml
+++ b/.github/workflows/monitoring-suite-docker.yaml
@@ -959,16 +959,25 @@ jobs:
         if: always()
         shell: bash
         env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
+          SLACK_MSG_TS: ${{ env.SLACK_MSG_TS }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           SLACK_WF_NAME: "Monitoring Suite Docker"
           RUN_BASE_DIR: ${{ env.RUN_BASE_DIR }}
         run: |
-          if [ -z "${SLACK_WEBHOOK_URL:-}" ]; then exit 0; fi
           MSG=":white_check_mark: *Log collection complete* for *SimplyBlock ${SLACK_WF_NAME}*\n:file_folder: \`${RUN_BASE_DIR:-N/A}/graylog_collected/\`\n:link: <${SLACK_RUN_URL}|View Run>"
-          curl -s -X POST "${SLACK_WEBHOOK_URL}" \
-            -H 'Content-Type: application/json' \
-            -d "{\"text\":\"${MSG}\"}" || true
+          if [ -n "${SLACK_BOT_TOKEN:-}" ] && [ -n "${SLACK_CHANNEL_ID:-}" ] && [ -n "${SLACK_MSG_TS:-}" ]; then
+            curl -s -X POST "https://slack.com/api/chat.postMessage" \
+              -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
+              -H "Content-Type: application/json; charset=utf-8" \
+              -d "{\"channel\":\"${SLACK_CHANNEL_ID}\",\"thread_ts\":\"${SLACK_MSG_TS}\",\"text\":\"${MSG}\"}" || true
+          elif [ -n "${SLACK_WEBHOOK_URL:-}" ]; then
+            curl -s -X POST "${SLACK_WEBHOOK_URL}" \
+              -H "Content-Type: application/json" \
+              -d "{\"text\":\"${MSG}\"}" || true
+          fi
 
       # ============================================================
       # COLLECT TIMING ARTIFACTS
@@ -1327,14 +1336,18 @@ jobs:
         shell: bash
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
           JOB_STATUS: ${{ needs.run-tests.result }}
           SLACK_RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           GITHUB_REF_NAME: ${{ github.ref_name }}
         run: |
           python3 - <<'PYEOF'
           import json, os, sys, urllib.request
-          webhook = os.environ.get("SLACK_WEBHOOK_URL", "")
-          if not webhook: sys.exit(0)
+          bot_token = os.environ.get("SLACK_BOT_TOKEN", "")
+          channel   = os.environ.get("SLACK_CHANNEL_ID", "")
+          webhook   = os.environ.get("SLACK_WEBHOOK_URL", "")
+          if not bot_token and not webhook: sys.exit(0)
           ok = os.environ.get("JOB_STATUS", "") == "success"
           icon = ":white_check_mark:" if ok else ":x:"
           status = "SUCCESS" if ok else "FAILURE"
@@ -1345,9 +1358,44 @@ jobs:
               f"*Branch:* `{os.environ.get('GITHUB_REF_NAME','?')}`  |  *Tests:* `${{ inputs.TEST_CLASSES }}`",
               f":link: *Run:* <{os.environ.get('SLACK_RUN_URL','')}|View on GitHub>",
           ]
-          payload = {"text": "\n".join(lines)}
-          req = urllib.request.Request(webhook, data=json.dumps(payload).encode(),
-                                      headers={"Content-Type": "application/json"})
-          try: urllib.request.urlopen(req, timeout=15)
-          except Exception as exc: print(f"WARN: Slack failed: {exc}", file=sys.stderr)
+          # --- Send ---
+          gh_env = os.environ.get("GITHUB_ENV", "")
+          text   = "\n".join(lines)
+
+          if bot_token and channel:
+              api_payload = json.dumps({"channel": channel, "text": text}).encode()
+              req = urllib.request.Request(
+                  "https://slack.com/api/chat.postMessage",
+                  data=api_payload,
+                  headers={
+                      "Content-Type": "application/json; charset=utf-8",
+                      "Authorization": f"Bearer {bot_token}",
+                  },
+              )
+              try:
+                  resp = urllib.request.urlopen(req, timeout=15)
+                  body = json.loads(resp.read().decode())
+                  if body.get("ok"):
+                      ts = body.get("ts", "")
+                      print(f"Slack notification sent via Bot API (ts={ts}).")
+                      if gh_env and ts:
+                          with open(gh_env, "a") as f:
+                              f.write(f"SLACK_MSG_TS={ts}\n")
+                  else:
+                      print(f"WARN: Slack API error: {body.get('error')}", file=sys.stderr)
+              except Exception as exc:
+                  print(f"WARN: Slack Bot API failed: {exc}", file=sys.stderr)
+          elif webhook:
+              req = urllib.request.Request(
+                  webhook,
+                  data=json.dumps({"text": text}).encode(),
+                  headers={"Content-Type": "application/json"},
+              )
+              try:
+                  urllib.request.urlopen(req, timeout=15)
+                  print("Slack notification sent via webhook (no thread support).")
+              except Exception as exc:
+                  print(f"WARN: Slack webhook failed: {exc}", file=sys.stderr)
+          else:
+              print("No SLACK_BOT_TOKEN or SLACK_WEBHOOK_URL set, skipping.")
           PYEOF

--- a/.github/workflows/monitoring-suite-k8s-native.yaml
+++ b/.github/workflows/monitoring-suite-k8s-native.yaml
@@ -1267,16 +1267,25 @@ jobs:
         if: always() && (github.event.inputs.send_slack_notification || 'true') == 'true'
         shell: bash
         env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
+          SLACK_MSG_TS: ${{ env.SLACK_MSG_TS }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           SLACK_WF_NAME: "Monitoring Suite K8s"
           RUN_BASE_DIR: ${{ env.RUN_BASE_DIR }}
         run: |
-          if [ -z "${SLACK_WEBHOOK_URL:-}" ]; then exit 0; fi
           MSG=":white_check_mark: *Log collection complete* for *SimplyBlock ${SLACK_WF_NAME}*\n:file_folder: \`${RUN_BASE_DIR:-N/A}/graylog_collected/\`\n:link: <${SLACK_RUN_URL}|View Run>"
-          curl -s -X POST "${SLACK_WEBHOOK_URL}" \
-            -H 'Content-Type: application/json' \
-            -d "{\"text\":\"${MSG}\"}" || true
+          if [ -n "${SLACK_BOT_TOKEN:-}" ] && [ -n "${SLACK_CHANNEL_ID:-}" ] && [ -n "${SLACK_MSG_TS:-}" ]; then
+            curl -s -X POST "https://slack.com/api/chat.postMessage" \
+              -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
+              -H "Content-Type: application/json; charset=utf-8" \
+              -d "{\"channel\":\"${SLACK_CHANNEL_ID}\",\"thread_ts\":\"${SLACK_MSG_TS}\",\"text\":\"${MSG}\"}" || true
+          elif [ -n "${SLACK_WEBHOOK_URL:-}" ]; then
+            curl -s -X POST "${SLACK_WEBHOOK_URL}" \
+              -H "Content-Type: application/json" \
+              -d "{\"text\":\"${MSG}\"}" || true
+          fi
 
       # ============================================================
       # COLLECT TIMING ARTIFACTS
@@ -1612,6 +1621,8 @@ jobs:
         shell: bash
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
           JOB_STATUS: ${{ needs.run-tests.result }}
           SLACK_RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           GITHUB_REF_NAME: ${{ github.ref_name }}
@@ -1620,8 +1631,10 @@ jobs:
           import json, os, sys, urllib.request
           from pathlib import Path
 
-          webhook = os.environ.get("SLACK_WEBHOOK_URL", "")
-          if not webhook: sys.exit(0)
+          bot_token = os.environ.get("SLACK_BOT_TOKEN", "")
+          channel   = os.environ.get("SLACK_CHANNEL_ID", "")
+          webhook   = os.environ.get("SLACK_WEBHOOK_URL", "")
+          if not bot_token and not webhook: sys.exit(0)
 
           ok = os.environ.get("JOB_STATUS", "") == "success"
           icon = ":white_check_mark:" if ok else ":x:"
@@ -1671,12 +1684,44 @@ jobs:
               f":hourglass_flowing_sand: _Logs are being collected and will be available shortly._",
           ]
 
-          payload = {"text": "\n".join(lines)}
-          req = urllib.request.Request(webhook, data=json.dumps(payload).encode(),
-                                      headers={"Content-Type": "application/json"})
-          try:
-              urllib.request.urlopen(req, timeout=15)
-              print("Slack notification sent.")
-          except Exception as exc:
-              print(f"WARN: Slack failed: {exc}", file=sys.stderr)
+          # --- Send ---
+          gh_env = os.environ.get("GITHUB_ENV", "")
+          text   = "\n".join(lines)
+
+          if bot_token and channel:
+              api_payload = json.dumps({"channel": channel, "text": text}).encode()
+              req = urllib.request.Request(
+                  "https://slack.com/api/chat.postMessage",
+                  data=api_payload,
+                  headers={
+                      "Content-Type": "application/json; charset=utf-8",
+                      "Authorization": f"Bearer {bot_token}",
+                  },
+              )
+              try:
+                  resp = urllib.request.urlopen(req, timeout=15)
+                  body = json.loads(resp.read().decode())
+                  if body.get("ok"):
+                      ts = body.get("ts", "")
+                      print(f"Slack notification sent via Bot API (ts={ts}).")
+                      if gh_env and ts:
+                          with open(gh_env, "a") as f:
+                              f.write(f"SLACK_MSG_TS={ts}\n")
+                  else:
+                      print(f"WARN: Slack API error: {body.get('error')}", file=sys.stderr)
+              except Exception as exc:
+                  print(f"WARN: Slack Bot API failed: {exc}", file=sys.stderr)
+          elif webhook:
+              req = urllib.request.Request(
+                  webhook,
+                  data=json.dumps({"text": text}).encode(),
+                  headers={"Content-Type": "application/json"},
+              )
+              try:
+                  urllib.request.urlopen(req, timeout=15)
+                  print("Slack notification sent via webhook (no thread support).")
+              except Exception as exc:
+                  print(f"WARN: Slack webhook failed: {exc}", file=sys.stderr)
+          else:
+              print("No SLACK_BOT_TOKEN or SLACK_WEBHOOK_URL set, skipping.")
           PYEOF

--- a/.github/workflows/monitoring-suite-k8s-native.yaml
+++ b/.github/workflows/monitoring-suite-k8s-native.yaml
@@ -1263,6 +1263,21 @@ jobs:
           CLUSTER_ID: ${{ env.CLUSTER_ID }}
           MON_SECRET: ${{ secrets.MON_SECRET }}
 
+      - name: Notify Slack log collection complete
+        if: always() && (github.event.inputs.send_slack_notification || 'true') == 'true'
+        shell: bash
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          SLACK_WF_NAME: "Monitoring Suite K8s"
+          RUN_BASE_DIR: ${{ env.RUN_BASE_DIR }}
+        run: |
+          if [ -z "${SLACK_WEBHOOK_URL:-}" ]; then exit 0; fi
+          MSG=":white_check_mark: *Log collection complete* for *SimplyBlock ${SLACK_WF_NAME}*\n:file_folder: \`${RUN_BASE_DIR:-N/A}/graylog_collected/\`\n:link: <${SLACK_RUN_URL}|View Run>"
+          curl -s -X POST "${SLACK_WEBHOOK_URL}" \
+            -H 'Content-Type: application/json' \
+            -d "{\"text\":\"${MSG}\"}" || true
+
       # ============================================================
       # COLLECT TIMING ARTIFACTS
       # ============================================================

--- a/.github/workflows/stress-run-bootstrap-k8s.yml
+++ b/.github/workflows/stress-run-bootstrap-k8s.yml
@@ -1077,6 +1077,21 @@ jobs:
           done
           echo "=== Log collection complete (${CHUNK} chunks, newest-first): ${OUTPUT_DIR} ==="
 
+      - name: Notify Slack log collection complete
+        if: always()
+        shell: bash
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          SLACK_WF_NAME: "Stress Run K8s"
+          RUN_BASE_DIR: ${{ env.RUN_BASE_DIR }}
+        run: |
+          if [ -z "${SLACK_WEBHOOK_URL:-}" ]; then exit 0; fi
+          MSG=":white_check_mark: *Log collection complete* for *SimplyBlock ${SLACK_WF_NAME}*\n:file_folder: \`${RUN_BASE_DIR:-N/A}/graylog_collected/\`\n:link: <${SLACK_RUN_URL}|View Run>"
+          curl -s -X POST "${SLACK_WEBHOOK_URL}" \
+            -H 'Content-Type: application/json' \
+            -d "{\"text\":\"${MSG}\"}" || true
+
       - name: Collect mgmt snapshots (kubectl exec on admin pod)
         if: always()
         shell: bash

--- a/.github/workflows/stress-run-bootstrap-k8s.yml
+++ b/.github/workflows/stress-run-bootstrap-k8s.yml
@@ -848,6 +848,8 @@ jobs:
         shell: bash
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
           JOB_STATUS: ${{ job.status }}
           SLACK_RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           GITHUB_REF_NAME: ${{ github.ref_name }}
@@ -855,9 +857,11 @@ jobs:
         run: |
           python3 - <<'PYEOF'
           import json, os, re, sys, urllib.request, urllib.error
-          webhook = os.environ.get("SLACK_WEBHOOK_URL", "")
-          if not webhook:
-              print("No SLACK_WEBHOOK_URL set, skipping."); sys.exit(0)
+          bot_token = os.environ.get("SLACK_BOT_TOKEN", "")
+          channel   = os.environ.get("SLACK_CHANNEL_ID", "")
+          webhook   = os.environ.get("SLACK_WEBHOOK_URL", "")
+          if not bot_token and not webhook:
+              print("No SLACK_BOT_TOKEN or SLACK_WEBHOOK_URL set, skipping."); sys.exit(0)
           out_log = "sbcli/e2e/output.log"
           total = passed = failed = skipped = 0
           if os.path.isfile(out_log):
@@ -893,13 +897,46 @@ jobs:
                         f":x: *Failed:* {failed}", f":fast_forward: *Skipped:* {skipped}"]
           lines.append(f":link: *Run:* <{run_url}|View on GitHub>")
           lines.append(f":hourglass_flowing_sand: _Logs are being collected and will be available shortly._")
-          payload = {"text": "\n".join(lines)}
-          req = urllib.request.Request(webhook, data=json.dumps(payload).encode(),
-                                        headers={"Content-Type":"application/json"})
-          try:
-              urllib.request.urlopen(req, timeout=15); print("Slack notification sent.")
-          except Exception as exc:
-              print(f"WARN: Slack failed: {exc}", file=sys.stderr)
+          # --- Send ---
+          gh_env = os.environ.get("GITHUB_ENV", "")
+          text   = "\n".join(lines)
+
+          if bot_token and channel:
+              api_payload = json.dumps({"channel": channel, "text": text}).encode()
+              req = urllib.request.Request(
+                  "https://slack.com/api/chat.postMessage",
+                  data=api_payload,
+                  headers={
+                      "Content-Type": "application/json; charset=utf-8",
+                      "Authorization": f"Bearer {bot_token}",
+                  },
+              )
+              try:
+                  resp = urllib.request.urlopen(req, timeout=15)
+                  body = json.loads(resp.read().decode())
+                  if body.get("ok"):
+                      ts = body.get("ts", "")
+                      print(f"Slack notification sent via Bot API (ts={ts}).")
+                      if gh_env and ts:
+                          with open(gh_env, "a") as f:
+                              f.write(f"SLACK_MSG_TS={ts}\n")
+                  else:
+                      print(f"WARN: Slack API error: {body.get('error')}", file=sys.stderr)
+              except Exception as exc:
+                  print(f"WARN: Slack Bot API failed: {exc}", file=sys.stderr)
+          elif webhook:
+              req = urllib.request.Request(
+                  webhook,
+                  data=json.dumps({"text": text}).encode(),
+                  headers={"Content-Type": "application/json"},
+              )
+              try:
+                  urllib.request.urlopen(req, timeout=15)
+                  print("Slack notification sent via webhook (no thread support).")
+              except Exception as exc:
+                  print(f"WARN: Slack webhook failed: {exc}", file=sys.stderr)
+          else:
+              print("No SLACK_BOT_TOKEN or SLACK_WEBHOOK_URL set, skipping.")
           PYEOF
 
 
@@ -1081,16 +1118,25 @@ jobs:
         if: always()
         shell: bash
         env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
+          SLACK_MSG_TS: ${{ env.SLACK_MSG_TS }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           SLACK_WF_NAME: "Stress Run K8s"
           RUN_BASE_DIR: ${{ env.RUN_BASE_DIR }}
         run: |
-          if [ -z "${SLACK_WEBHOOK_URL:-}" ]; then exit 0; fi
           MSG=":white_check_mark: *Log collection complete* for *SimplyBlock ${SLACK_WF_NAME}*\n:file_folder: \`${RUN_BASE_DIR:-N/A}/graylog_collected/\`\n:link: <${SLACK_RUN_URL}|View Run>"
-          curl -s -X POST "${SLACK_WEBHOOK_URL}" \
-            -H 'Content-Type: application/json' \
-            -d "{\"text\":\"${MSG}\"}" || true
+          if [ -n "${SLACK_BOT_TOKEN:-}" ] && [ -n "${SLACK_CHANNEL_ID:-}" ] && [ -n "${SLACK_MSG_TS:-}" ]; then
+            curl -s -X POST "https://slack.com/api/chat.postMessage" \
+              -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
+              -H "Content-Type: application/json; charset=utf-8" \
+              -d "{\"channel\":\"${SLACK_CHANNEL_ID}\",\"thread_ts\":\"${SLACK_MSG_TS}\",\"text\":\"${MSG}\"}" || true
+          elif [ -n "${SLACK_WEBHOOK_URL:-}" ]; then
+            curl -s -X POST "${SLACK_WEBHOOK_URL}" \
+              -H "Content-Type: application/json" \
+              -d "{\"text\":\"${MSG}\"}" || true
+          fi
 
       - name: Collect mgmt snapshots (kubectl exec on admin pod)
         if: always()

--- a/.github/workflows/stress-run-bootstrap.yml
+++ b/.github/workflows/stress-run-bootstrap.yml
@@ -1265,6 +1265,21 @@ jobs:
           done
           echo "=== Log collection complete (${CHUNK} chunks, newest-first): ${OUTPUT_DIR} ==="
 
+      - name: Notify Slack log collection complete
+        if: always()
+        shell: bash
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          SLACK_WF_NAME: "Stress Run Bootstrap"
+          RUN_BASE_DIR: ${{ env.RUN_BASE_DIR }}
+        run: |
+          if [ -z "${SLACK_WEBHOOK_URL:-}" ]; then exit 0; fi
+          MSG=":white_check_mark: *Log collection complete* for *SimplyBlock ${SLACK_WF_NAME}*\n:file_folder: \`${RUN_BASE_DIR:-N/A}/graylog_collected/\`\n:link: <${SLACK_RUN_URL}|View Run>"
+          curl -s -X POST "${SLACK_WEBHOOK_URL}" \
+            -H 'Content-Type: application/json' \
+            -d "{\"text\":\"${MSG}\"}" || true
+
       - name: Collect mgmt snapshots into RUN_BASE_DIR (on failure)
         id: collect-mgmt
         if: always()

--- a/.github/workflows/stress-run-bootstrap.yml
+++ b/.github/workflows/stress-run-bootstrap.yml
@@ -743,16 +743,10 @@ jobs:
           set -euxo pipefail
 
           # 1. Install mc (MinIO Client)
-          if ! command -v mc &>/dev/null; then
-            if curl -fsSL https://dl.min.io/client/mc/release/linux-amd64/mc -o /usr/local/bin/mc 2>/dev/null; then
-              chmod +x /usr/local/bin/mc
-            else
-              curl -fsSL https://dl.min.io/client/mc/release/linux-amd64/mc -o /tmp/mc
-              chmod +x /tmp/mc
-              export PATH="/tmp:$PATH"
-              echo "/tmp" >> "$GITHUB_PATH"
-            fi
-          fi
+          curl -fsSL https://dl.min.io/client/mc/release/linux-amd64/mc -o /tmp/mc
+          chmod +x /tmp/mc
+          export PATH="/tmp:$PATH"
+          echo "/tmp" >> "$GITHUB_PATH"
 
           # 2. Configure mc alias to external MinIO
           mc alias set myminio http://192.168.10.164:9000 "${MINIO_ACCESS_KEY}" "${MINIO_SECRET_KEY}"

--- a/.github/workflows/stress-run-bootstrap.yml
+++ b/.github/workflows/stress-run-bootstrap.yml
@@ -1649,6 +1649,9 @@ jobs:
           else
             echo "No MinIO trace log found (backup tests may not have run)"
           fi
+          # Cleanup: delete trace logs and kill any orphaned mc trace processes
+          rm -f /tmp/minio-trace-*.log 2>/dev/null || true
+          pkill -f "mc admin trace" 2>/dev/null || true
 
       - name: Upload logs (always)
         if: always()

--- a/.github/workflows/stress-run-bootstrap.yml
+++ b/.github/workflows/stress-run-bootstrap.yml
@@ -1039,6 +1039,8 @@ jobs:
         shell: bash
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
           JOB_STATUS: ${{ job.status }}
           SLACK_RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           GITHUB_REF_NAME: ${{ github.ref_name }}
@@ -1046,9 +1048,11 @@ jobs:
         run: |
           python3 - <<'PYEOF'
           import json, os, re, sys, urllib.request, urllib.error
-          webhook = os.environ.get("SLACK_WEBHOOK_URL", "")
-          if not webhook:
-              print("No SLACK_WEBHOOK_URL set, skipping.")
+          bot_token = os.environ.get("SLACK_BOT_TOKEN", "")
+          channel   = os.environ.get("SLACK_CHANNEL_ID", "")
+          webhook   = os.environ.get("SLACK_WEBHOOK_URL", "")
+          if not bot_token and not webhook:
+              print("No SLACK_BOT_TOKEN or SLACK_WEBHOOK_URL set, skipping.")
               sys.exit(0)
           out_log = "sbcli/e2e/output.log"
           total = passed = failed = skipped = 0
@@ -1109,17 +1113,46 @@ jobs:
               f":file_folder: *Final Logs:* `{log_dir}`",
               f":hourglass_flowing_sand: _Logs are being collected and will be available shortly._",
           ]
-          payload = {"text": "\n".join(lines)}
-          req = urllib.request.Request(
-              webhook,
-              data=json.dumps(payload).encode(),
-              headers={"Content-Type": "application/json"},
-          )
-          try:
-              urllib.request.urlopen(req, timeout=15)
-              print("Slack notification sent.")
-          except Exception as exc:
-              print(f"WARN: Slack notification failed: {exc}", file=sys.stderr)
+          # --- Send ---
+          gh_env = os.environ.get("GITHUB_ENV", "")
+          text   = "\n".join(lines)
+
+          if bot_token and channel:
+              api_payload = json.dumps({"channel": channel, "text": text}).encode()
+              req = urllib.request.Request(
+                  "https://slack.com/api/chat.postMessage",
+                  data=api_payload,
+                  headers={
+                      "Content-Type": "application/json; charset=utf-8",
+                      "Authorization": f"Bearer {bot_token}",
+                  },
+              )
+              try:
+                  resp = urllib.request.urlopen(req, timeout=15)
+                  body = json.loads(resp.read().decode())
+                  if body.get("ok"):
+                      ts = body.get("ts", "")
+                      print(f"Slack notification sent via Bot API (ts={ts}).")
+                      if gh_env and ts:
+                          with open(gh_env, "a") as f:
+                              f.write(f"SLACK_MSG_TS={ts}\n")
+                  else:
+                      print(f"WARN: Slack API error: {body.get('error')}", file=sys.stderr)
+              except Exception as exc:
+                  print(f"WARN: Slack Bot API failed: {exc}", file=sys.stderr)
+          elif webhook:
+              req = urllib.request.Request(
+                  webhook,
+                  data=json.dumps({"text": text}).encode(),
+                  headers={"Content-Type": "application/json"},
+              )
+              try:
+                  urllib.request.urlopen(req, timeout=15)
+                  print("Slack notification sent via webhook (no thread support).")
+              except Exception as exc:
+                  print(f"WARN: Slack webhook failed: {exc}", file=sys.stderr)
+          else:
+              print("No SLACK_BOT_TOKEN or SLACK_WEBHOOK_URL set, skipping.")
           PYEOF
 
 
@@ -1269,16 +1302,25 @@ jobs:
         if: always()
         shell: bash
         env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
+          SLACK_MSG_TS: ${{ env.SLACK_MSG_TS }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           SLACK_WF_NAME: "Stress Run Bootstrap"
           RUN_BASE_DIR: ${{ env.RUN_BASE_DIR }}
         run: |
-          if [ -z "${SLACK_WEBHOOK_URL:-}" ]; then exit 0; fi
           MSG=":white_check_mark: *Log collection complete* for *SimplyBlock ${SLACK_WF_NAME}*\n:file_folder: \`${RUN_BASE_DIR:-N/A}/graylog_collected/\`\n:link: <${SLACK_RUN_URL}|View Run>"
-          curl -s -X POST "${SLACK_WEBHOOK_URL}" \
-            -H 'Content-Type: application/json' \
-            -d "{\"text\":\"${MSG}\"}" || true
+          if [ -n "${SLACK_BOT_TOKEN:-}" ] && [ -n "${SLACK_CHANNEL_ID:-}" ] && [ -n "${SLACK_MSG_TS:-}" ]; then
+            curl -s -X POST "https://slack.com/api/chat.postMessage" \
+              -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
+              -H "Content-Type: application/json; charset=utf-8" \
+              -d "{\"channel\":\"${SLACK_CHANNEL_ID}\",\"thread_ts\":\"${SLACK_MSG_TS}\",\"text\":\"${MSG}\"}" || true
+          elif [ -n "${SLACK_WEBHOOK_URL:-}" ]; then
+            curl -s -X POST "${SLACK_WEBHOOK_URL}" \
+              -H "Content-Type: application/json" \
+              -d "{\"text\":\"${MSG}\"}" || true
+          fi
 
       - name: Collect mgmt snapshots into RUN_BASE_DIR (on failure)
         id: collect-mgmt

--- a/.github/workflows/stress-run-only.yml
+++ b/.github/workflows/stress-run-only.yml
@@ -881,6 +881,8 @@ jobs:
         shell: bash
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
           JOB_STATUS: ${{ job.status }}
           SLACK_RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           GITHUB_REF_NAME: ${{ github.ref_name }}
@@ -888,9 +890,11 @@ jobs:
         run: |
           python3 - <<'PYEOF'
           import json, os, re, sys, urllib.request, urllib.error
-          webhook = os.environ.get("SLACK_WEBHOOK_URL", "")
-          if not webhook:
-              print("No SLACK_WEBHOOK_URL set, skipping.")
+          bot_token = os.environ.get("SLACK_BOT_TOKEN", "")
+          channel   = os.environ.get("SLACK_CHANNEL_ID", "")
+          webhook   = os.environ.get("SLACK_WEBHOOK_URL", "")
+          if not bot_token and not webhook:
+              print("No SLACK_BOT_TOKEN or SLACK_WEBHOOK_URL set, skipping.")
               sys.exit(0)
           out_log = "sbcli/e2e/output.log"
           total = passed = failed = skipped = 0
@@ -951,17 +955,46 @@ jobs:
               f":file_folder: *Final Logs:* `{log_dir}`",
               f":hourglass_flowing_sand: _Logs are being collected and will be available shortly._",
           ]
-          payload = {"text": "\n".join(lines)}
-          req = urllib.request.Request(
-              webhook,
-              data=json.dumps(payload).encode(),
-              headers={"Content-Type": "application/json"},
-          )
-          try:
-              urllib.request.urlopen(req, timeout=15)
-              print("Slack notification sent.")
-          except Exception as exc:
-              print(f"WARN: Slack notification failed: {exc}", file=sys.stderr)
+          # --- Send ---
+          gh_env = os.environ.get("GITHUB_ENV", "")
+          text   = "\n".join(lines)
+
+          if bot_token and channel:
+              api_payload = json.dumps({"channel": channel, "text": text}).encode()
+              req = urllib.request.Request(
+                  "https://slack.com/api/chat.postMessage",
+                  data=api_payload,
+                  headers={
+                      "Content-Type": "application/json; charset=utf-8",
+                      "Authorization": f"Bearer {bot_token}",
+                  },
+              )
+              try:
+                  resp = urllib.request.urlopen(req, timeout=15)
+                  body = json.loads(resp.read().decode())
+                  if body.get("ok"):
+                      ts = body.get("ts", "")
+                      print(f"Slack notification sent via Bot API (ts={ts}).")
+                      if gh_env and ts:
+                          with open(gh_env, "a") as f:
+                              f.write(f"SLACK_MSG_TS={ts}\n")
+                  else:
+                      print(f"WARN: Slack API error: {body.get('error')}", file=sys.stderr)
+              except Exception as exc:
+                  print(f"WARN: Slack Bot API failed: {exc}", file=sys.stderr)
+          elif webhook:
+              req = urllib.request.Request(
+                  webhook,
+                  data=json.dumps({"text": text}).encode(),
+                  headers={"Content-Type": "application/json"},
+              )
+              try:
+                  urllib.request.urlopen(req, timeout=15)
+                  print("Slack notification sent via webhook (no thread support).")
+              except Exception as exc:
+                  print(f"WARN: Slack webhook failed: {exc}", file=sys.stderr)
+          else:
+              print("No SLACK_BOT_TOKEN or SLACK_WEBHOOK_URL set, skipping.")
           PYEOF
 
       - name: Upload logs (always)

--- a/.github/workflows/topology-suite-docker.yml
+++ b/.github/workflows/topology-suite-docker.yml
@@ -289,6 +289,8 @@ jobs:
         shell: bash
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
           OVERALL_STATUS: ${{ needs.run-tests.result }}
           SLACK_RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           GITHUB_REF_NAME: ${{ github.ref_name }}
@@ -298,9 +300,11 @@ jobs:
           python3 - <<'PYEOF'
           import json, os, re, sys, urllib.request
 
-          webhook = os.environ.get("SLACK_WEBHOOK_URL", "")
-          if not webhook:
-              print("No SLACK_WEBHOOK_URL set, skipping.")
+          bot_token = os.environ.get("SLACK_BOT_TOKEN", "")
+          channel   = os.environ.get("SLACK_CHANNEL_ID", "")
+          webhook   = os.environ.get("SLACK_WEBHOOK_URL", "")
+          if not bot_token and not webhook:
+              print("No SLACK_BOT_TOKEN or SLACK_WEBHOOK_URL set, skipping.")
               sys.exit(0)
 
           overall  = os.environ.get("OVERALL_STATUS", "unknown")
@@ -369,15 +373,44 @@ jobs:
               "",
               f":link: *Run:* <{run_url}|View on GitHub>",
           ]
-          payload = {"text": "\n".join(lines)}
-          req = urllib.request.Request(
-              webhook,
-              data=json.dumps(payload).encode(),
-              headers={"Content-Type": "application/json"},
-          )
-          try:
-              urllib.request.urlopen(req, timeout=15)
-              print("Combined Slack notification sent.")
-          except Exception as exc:
-              print(f"WARN: Slack notification failed: {exc}", file=sys.stderr)
+          # --- Send ---
+          gh_env = os.environ.get("GITHUB_ENV", "")
+          text   = "\n".join(lines)
+
+          if bot_token and channel:
+              api_payload = json.dumps({"channel": channel, "text": text}).encode()
+              req = urllib.request.Request(
+                  "https://slack.com/api/chat.postMessage",
+                  data=api_payload,
+                  headers={
+                      "Content-Type": "application/json; charset=utf-8",
+                      "Authorization": f"Bearer {bot_token}",
+                  },
+              )
+              try:
+                  resp = urllib.request.urlopen(req, timeout=15)
+                  body = json.loads(resp.read().decode())
+                  if body.get("ok"):
+                      ts = body.get("ts", "")
+                      print(f"Slack notification sent via Bot API (ts={ts}).")
+                      if gh_env and ts:
+                          with open(gh_env, "a") as f:
+                              f.write(f"SLACK_MSG_TS={ts}\n")
+                  else:
+                      print(f"WARN: Slack API error: {body.get('error')}", file=sys.stderr)
+              except Exception as exc:
+                  print(f"WARN: Slack Bot API failed: {exc}", file=sys.stderr)
+          elif webhook:
+              req = urllib.request.Request(
+                  webhook,
+                  data=json.dumps({"text": text}).encode(),
+                  headers={"Content-Type": "application/json"},
+              )
+              try:
+                  urllib.request.urlopen(req, timeout=15)
+                  print("Slack notification sent via webhook (no thread support).")
+              except Exception as exc:
+                  print(f"WARN: Slack webhook failed: {exc}", file=sys.stderr)
+          else:
+              print("No SLACK_BOT_TOKEN or SLACK_WEBHOOK_URL set, skipping.")
           PYEOF

--- a/.github/workflows/topology-suite-k8s-add-node.yml
+++ b/.github/workflows/topology-suite-k8s-add-node.yml
@@ -302,6 +302,8 @@ jobs:
         shell: bash
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
           OVERALL_STATUS: ${{ needs.run-tests.result }}
           SLACK_RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           GITHUB_REF_NAME: ${{ github.ref_name }}
@@ -312,9 +314,11 @@ jobs:
           python3 - <<'PYEOF'
           import json, os, re, sys, urllib.request
 
-          webhook = os.environ.get("SLACK_WEBHOOK_URL", "")
-          if not webhook:
-              print("No SLACK_WEBHOOK_URL set, skipping.")
+          bot_token = os.environ.get("SLACK_BOT_TOKEN", "")
+          channel   = os.environ.get("SLACK_CHANNEL_ID", "")
+          webhook   = os.environ.get("SLACK_WEBHOOK_URL", "")
+          if not bot_token and not webhook:
+              print("No SLACK_BOT_TOKEN or SLACK_WEBHOOK_URL set, skipping.")
               sys.exit(0)
 
           overall  = os.environ.get("OVERALL_STATUS", "unknown")
@@ -385,15 +389,42 @@ jobs:
               "",
               f":link: *Run:* <{run_url}|View on GitHub>",
           ]
-          payload = {"text": "\n".join(lines)}
-          req = urllib.request.Request(
-              webhook,
-              data=json.dumps(payload).encode(),
-              headers={"Content-Type": "application/json"},
-          )
-          try:
-              urllib.request.urlopen(req, timeout=15)
-              print("Combined Slack notification sent.")
+          # --- Send ---
+          gh_env = os.environ.get("GITHUB_ENV", "")
+          text   = "\n".join(lines)
+
+          if bot_token and channel:
+              api_payload = json.dumps({"channel": channel, "text": text}).encode()
+              req = urllib.request.Request(
+                  "https://slack.com/api/chat.postMessage",
+                  data=api_payload,
+                  headers={
+                      "Content-Type": "application/json; charset=utf-8",
+                      "Authorization": f"Bearer {bot_token}",
+                  },
+              )
+              try:
+                  resp = urllib.request.urlopen(req, timeout=15)
+                  body = json.loads(resp.read().decode())
+                  if body.get("ok"):
+                      ts = body.get("ts", "")
+                      print(f"Slack notification sent via Bot API (ts={ts}).")
+                      if gh_env and ts:
+                          with open(gh_env, "a") as f:
+                              f.write(f"SLACK_MSG_TS={ts}\n")
+                  else:
+                      print(f"WARN: Slack API error: {body.get('error')}", file=sys.stderr)
+              except Exception as exc:
+                  print(f"WARN: Slack Bot API failed: {exc}", file=sys.stderr)
+          elif webhook:
+              req = urllib.request.Request(
+                  webhook,
+                  data=json.dumps({"text": text}).encode(),
+                  headers={"Content-Type": "application/json"},
+              )
+              try:
+                  urllib.request.urlopen(req, timeout=15)
+                  print("Slack notification sent via webhook (no thread support).")
           except Exception as exc:
               print(f"WARN: Slack notification failed: {exc}", file=sys.stderr)
           PYEOF

--- a/.github/workflows/topology-suite-k8s-migration.yml
+++ b/.github/workflows/topology-suite-k8s-migration.yml
@@ -304,6 +304,8 @@ jobs:
         shell: bash
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
           OVERALL_STATUS: ${{ needs.run-tests.result }}
           SLACK_RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           GITHUB_REF_NAME: ${{ github.ref_name }}
@@ -314,9 +316,11 @@ jobs:
           python3 - <<'PYEOF'
           import json, os, re, sys, urllib.request
 
-          webhook = os.environ.get("SLACK_WEBHOOK_URL", "")
-          if not webhook:
-              print("No SLACK_WEBHOOK_URL set, skipping.")
+          bot_token = os.environ.get("SLACK_BOT_TOKEN", "")
+          channel   = os.environ.get("SLACK_CHANNEL_ID", "")
+          webhook   = os.environ.get("SLACK_WEBHOOK_URL", "")
+          if not bot_token and not webhook:
+              print("No SLACK_BOT_TOKEN or SLACK_WEBHOOK_URL set, skipping.")
               sys.exit(0)
 
           overall  = os.environ.get("OVERALL_STATUS", "unknown")
@@ -387,15 +391,42 @@ jobs:
               "",
               f":link: *Run:* <{run_url}|View on GitHub>",
           ]
-          payload = {"text": "\n".join(lines)}
-          req = urllib.request.Request(
-              webhook,
-              data=json.dumps(payload).encode(),
-              headers={"Content-Type": "application/json"},
-          )
-          try:
-              urllib.request.urlopen(req, timeout=15)
-              print("Combined Slack notification sent.")
+          # --- Send ---
+          gh_env = os.environ.get("GITHUB_ENV", "")
+          text   = "\n".join(lines)
+
+          if bot_token and channel:
+              api_payload = json.dumps({"channel": channel, "text": text}).encode()
+              req = urllib.request.Request(
+                  "https://slack.com/api/chat.postMessage",
+                  data=api_payload,
+                  headers={
+                      "Content-Type": "application/json; charset=utf-8",
+                      "Authorization": f"Bearer {bot_token}",
+                  },
+              )
+              try:
+                  resp = urllib.request.urlopen(req, timeout=15)
+                  body = json.loads(resp.read().decode())
+                  if body.get("ok"):
+                      ts = body.get("ts", "")
+                      print(f"Slack notification sent via Bot API (ts={ts}).")
+                      if gh_env and ts:
+                          with open(gh_env, "a") as f:
+                              f.write(f"SLACK_MSG_TS={ts}\n")
+                  else:
+                      print(f"WARN: Slack API error: {body.get('error')}", file=sys.stderr)
+              except Exception as exc:
+                  print(f"WARN: Slack Bot API failed: {exc}", file=sys.stderr)
+          elif webhook:
+              req = urllib.request.Request(
+                  webhook,
+                  data=json.dumps({"text": text}).encode(),
+                  headers={"Content-Type": "application/json"},
+              )
+              try:
+                  urllib.request.urlopen(req, timeout=15)
+                  print("Slack notification sent via webhook (no thread support).")
           except Exception as exc:
               print(f"WARN: Slack notification failed: {exc}", file=sys.stderr)
           PYEOF

--- a/.github/workflows/upgrade-bootstrap-single-v2.yml
+++ b/.github/workflows/upgrade-bootstrap-single-v2.yml
@@ -1204,6 +1204,21 @@ jobs:
           done
           echo "=== Log collection complete (${CHUNK} chunks, newest-first): ${OUTPUT_DIR} ==="
 
+      - name: Notify Slack log collection complete
+        if: always()
+        shell: bash
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          SLACK_WF_NAME: "E2E (Upgrade Single Node v2)"
+          RUN_BASE_DIR: ${{ env.RUN_BASE_DIR }}
+        run: |
+          if [ -z "${SLACK_WEBHOOK_URL:-}" ]; then exit 0; fi
+          MSG=":white_check_mark: *Log collection complete* for *SimplyBlock ${SLACK_WF_NAME}*\n:file_folder: \`${RUN_BASE_DIR:-N/A}/graylog_collected/\`\n:link: <${SLACK_RUN_URL}|View Run>"
+          curl -s -X POST "${SLACK_WEBHOOK_URL}" \
+            -H 'Content-Type: application/json' \
+            -d "{\"text\":\"${MSG}\"}" || true
+
       # =========================
       # SUMMARY (always)
       # =========================

--- a/.github/workflows/upgrade-bootstrap-single-v2.yml
+++ b/.github/workflows/upgrade-bootstrap-single-v2.yml
@@ -1208,16 +1208,25 @@ jobs:
         if: always()
         shell: bash
         env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
+          SLACK_MSG_TS: ${{ env.SLACK_MSG_TS }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           SLACK_WF_NAME: "E2E (Upgrade Single Node v2)"
           RUN_BASE_DIR: ${{ env.RUN_BASE_DIR }}
         run: |
-          if [ -z "${SLACK_WEBHOOK_URL:-}" ]; then exit 0; fi
           MSG=":white_check_mark: *Log collection complete* for *SimplyBlock ${SLACK_WF_NAME}*\n:file_folder: \`${RUN_BASE_DIR:-N/A}/graylog_collected/\`\n:link: <${SLACK_RUN_URL}|View Run>"
-          curl -s -X POST "${SLACK_WEBHOOK_URL}" \
-            -H 'Content-Type: application/json' \
-            -d "{\"text\":\"${MSG}\"}" || true
+          if [ -n "${SLACK_BOT_TOKEN:-}" ] && [ -n "${SLACK_CHANNEL_ID:-}" ] && [ -n "${SLACK_MSG_TS:-}" ]; then
+            curl -s -X POST "https://slack.com/api/chat.postMessage" \
+              -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
+              -H "Content-Type: application/json; charset=utf-8" \
+              -d "{\"channel\":\"${SLACK_CHANNEL_ID}\",\"thread_ts\":\"${SLACK_MSG_TS}\",\"text\":\"${MSG}\"}" || true
+          elif [ -n "${SLACK_WEBHOOK_URL:-}" ]; then
+            curl -s -X POST "${SLACK_WEBHOOK_URL}" \
+              -H "Content-Type: application/json" \
+              -d "{\"text\":\"${MSG}\"}" || true
+          fi
 
       # =========================
       # SUMMARY (always)
@@ -1370,6 +1379,8 @@ jobs:
         shell: bash
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
           JOB_STATUS: ${{ job.status }}
           SLACK_RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           GITHUB_REF_NAME: ${{ github.ref_name }}
@@ -1378,9 +1389,11 @@ jobs:
           python3 - <<'PYEOF'
           import json, os, re, sys, urllib.request, urllib.error
 
-          webhook = os.environ.get("SLACK_WEBHOOK_URL", "")
-          if not webhook:
-              print("No SLACK_WEBHOOK_URL set, skipping.")
+          bot_token = os.environ.get("SLACK_BOT_TOKEN", "")
+          channel   = os.environ.get("SLACK_CHANNEL_ID", "")
+          webhook   = os.environ.get("SLACK_WEBHOOK_URL", "")
+          if not bot_token and not webhook:
+              print("No SLACK_BOT_TOKEN or SLACK_WEBHOOK_URL set, skipping.")
               sys.exit(0)
 
           out_log = "sbcli/e2e/output.log"
@@ -1471,17 +1484,46 @@ jobs:
               f":hourglass_flowing_sand: _Logs are being collected and will be available shortly._",
           ]
 
-          payload = {"text": "\n".join(lines)}
-          req = urllib.request.Request(
-              webhook,
-              data=json.dumps(payload).encode(),
-              headers={"Content-Type": "application/json"},
-          )
-          try:
-              urllib.request.urlopen(req, timeout=15)
-              print("Slack notification sent.")
-          except Exception as exc:
-              print(f"WARN: Slack notification failed: {exc}", file=sys.stderr)
+          # --- Send ---
+          gh_env = os.environ.get("GITHUB_ENV", "")
+          text   = "\n".join(lines)
+
+          if bot_token and channel:
+              api_payload = json.dumps({"channel": channel, "text": text}).encode()
+              req = urllib.request.Request(
+                  "https://slack.com/api/chat.postMessage",
+                  data=api_payload,
+                  headers={
+                      "Content-Type": "application/json; charset=utf-8",
+                      "Authorization": f"Bearer {bot_token}",
+                  },
+              )
+              try:
+                  resp = urllib.request.urlopen(req, timeout=15)
+                  body = json.loads(resp.read().decode())
+                  if body.get("ok"):
+                      ts = body.get("ts", "")
+                      print(f"Slack notification sent via Bot API (ts={ts}).")
+                      if gh_env and ts:
+                          with open(gh_env, "a") as f:
+                              f.write(f"SLACK_MSG_TS={ts}\n")
+                  else:
+                      print(f"WARN: Slack API error: {body.get('error')}", file=sys.stderr)
+              except Exception as exc:
+                  print(f"WARN: Slack Bot API failed: {exc}", file=sys.stderr)
+          elif webhook:
+              req = urllib.request.Request(
+                  webhook,
+                  data=json.dumps({"text": text}).encode(),
+                  headers={"Content-Type": "application/json"},
+              )
+              try:
+                  urllib.request.urlopen(req, timeout=15)
+                  print("Slack notification sent via webhook (no thread support).")
+              except Exception as exc:
+                  print(f"WARN: Slack webhook failed: {exc}", file=sys.stderr)
+          else:
+              print("No SLACK_BOT_TOKEN or SLACK_WEBHOOK_URL set, skipping.")
           PYEOF
 
       - name: Upload logs (always)

--- a/.github/workflows/upgrade-bootstrap-single.yml
+++ b/.github/workflows/upgrade-bootstrap-single.yml
@@ -1231,6 +1231,21 @@ jobs:
           done
           echo "=== Log collection complete (${CHUNK} chunks, newest-first): ${OUTPUT_DIR} ==="
 
+      - name: Notify Slack log collection complete
+        if: always()
+        shell: bash
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          SLACK_WF_NAME: "E2E (Upgrade Single Node)"
+          RUN_BASE_DIR: ${{ env.RUN_BASE_DIR }}
+        run: |
+          if [ -z "${SLACK_WEBHOOK_URL:-}" ]; then exit 0; fi
+          MSG=":white_check_mark: *Log collection complete* for *SimplyBlock ${SLACK_WF_NAME}*\n:file_folder: \`${RUN_BASE_DIR:-N/A}/graylog_collected/\`\n:link: <${SLACK_RUN_URL}|View Run>"
+          curl -s -X POST "${SLACK_WEBHOOK_URL}" \
+            -H 'Content-Type: application/json' \
+            -d "{\"text\":\"${MSG}\"}" || true
+
       # =========================
       # SUMMARY (always)
       # =========================

--- a/.github/workflows/upgrade-bootstrap-single.yml
+++ b/.github/workflows/upgrade-bootstrap-single.yml
@@ -1571,6 +1571,9 @@ jobs:
           else
             echo "No MinIO trace log found (backup tests may not have run)"
           fi
+          # Cleanup: delete trace logs and kill any orphaned mc trace processes
+          rm -f /tmp/minio-trace-*.log 2>/dev/null || true
+          pkill -f "mc admin trace" 2>/dev/null || true
 
       - name: Upload logs (always)
         if: always()

--- a/.github/workflows/upgrade-bootstrap-single.yml
+++ b/.github/workflows/upgrade-bootstrap-single.yml
@@ -1235,16 +1235,25 @@ jobs:
         if: always()
         shell: bash
         env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
+          SLACK_MSG_TS: ${{ env.SLACK_MSG_TS }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           SLACK_WF_NAME: "E2E (Upgrade Single Node)"
           RUN_BASE_DIR: ${{ env.RUN_BASE_DIR }}
         run: |
-          if [ -z "${SLACK_WEBHOOK_URL:-}" ]; then exit 0; fi
           MSG=":white_check_mark: *Log collection complete* for *SimplyBlock ${SLACK_WF_NAME}*\n:file_folder: \`${RUN_BASE_DIR:-N/A}/graylog_collected/\`\n:link: <${SLACK_RUN_URL}|View Run>"
-          curl -s -X POST "${SLACK_WEBHOOK_URL}" \
-            -H 'Content-Type: application/json' \
-            -d "{\"text\":\"${MSG}\"}" || true
+          if [ -n "${SLACK_BOT_TOKEN:-}" ] && [ -n "${SLACK_CHANNEL_ID:-}" ] && [ -n "${SLACK_MSG_TS:-}" ]; then
+            curl -s -X POST "https://slack.com/api/chat.postMessage" \
+              -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
+              -H "Content-Type: application/json; charset=utf-8" \
+              -d "{\"channel\":\"${SLACK_CHANNEL_ID}\",\"thread_ts\":\"${SLACK_MSG_TS}\",\"text\":\"${MSG}\"}" || true
+          elif [ -n "${SLACK_WEBHOOK_URL:-}" ]; then
+            curl -s -X POST "${SLACK_WEBHOOK_URL}" \
+              -H "Content-Type: application/json" \
+              -d "{\"text\":\"${MSG}\"}" || true
+          fi
 
       # =========================
       # SUMMARY (always)
@@ -1397,6 +1406,8 @@ jobs:
         shell: bash
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
           JOB_STATUS: ${{ job.status }}
           SLACK_RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           GITHUB_REF_NAME: ${{ github.ref_name }}
@@ -1405,9 +1416,11 @@ jobs:
           python3 - <<'PYEOF'
           import json, os, re, sys, urllib.request, urllib.error
 
-          webhook = os.environ.get("SLACK_WEBHOOK_URL", "")
-          if not webhook:
-              print("No SLACK_WEBHOOK_URL set, skipping.")
+          bot_token = os.environ.get("SLACK_BOT_TOKEN", "")
+          channel   = os.environ.get("SLACK_CHANNEL_ID", "")
+          webhook   = os.environ.get("SLACK_WEBHOOK_URL", "")
+          if not bot_token and not webhook:
+              print("No SLACK_BOT_TOKEN or SLACK_WEBHOOK_URL set, skipping.")
               sys.exit(0)
 
           out_log = "sbcli/e2e/output.log"
@@ -1498,17 +1511,46 @@ jobs:
               f":hourglass_flowing_sand: _Logs are being collected and will be available shortly._",
           ]
 
-          payload = {"text": "\n".join(lines)}
-          req = urllib.request.Request(
-              webhook,
-              data=json.dumps(payload).encode(),
-              headers={"Content-Type": "application/json"},
-          )
-          try:
-              urllib.request.urlopen(req, timeout=15)
-              print("Slack notification sent.")
-          except Exception as exc:
-              print(f"WARN: Slack notification failed: {exc}", file=sys.stderr)
+          # --- Send ---
+          gh_env = os.environ.get("GITHUB_ENV", "")
+          text   = "\n".join(lines)
+
+          if bot_token and channel:
+              api_payload = json.dumps({"channel": channel, "text": text}).encode()
+              req = urllib.request.Request(
+                  "https://slack.com/api/chat.postMessage",
+                  data=api_payload,
+                  headers={
+                      "Content-Type": "application/json; charset=utf-8",
+                      "Authorization": f"Bearer {bot_token}",
+                  },
+              )
+              try:
+                  resp = urllib.request.urlopen(req, timeout=15)
+                  body = json.loads(resp.read().decode())
+                  if body.get("ok"):
+                      ts = body.get("ts", "")
+                      print(f"Slack notification sent via Bot API (ts={ts}).")
+                      if gh_env and ts:
+                          with open(gh_env, "a") as f:
+                              f.write(f"SLACK_MSG_TS={ts}\n")
+                  else:
+                      print(f"WARN: Slack API error: {body.get('error')}", file=sys.stderr)
+              except Exception as exc:
+                  print(f"WARN: Slack Bot API failed: {exc}", file=sys.stderr)
+          elif webhook:
+              req = urllib.request.Request(
+                  webhook,
+                  data=json.dumps({"text": text}).encode(),
+                  headers={"Content-Type": "application/json"},
+              )
+              try:
+                  urllib.request.urlopen(req, timeout=15)
+                  print("Slack notification sent via webhook (no thread support).")
+              except Exception as exc:
+                  print(f"WARN: Slack webhook failed: {exc}", file=sys.stderr)
+          else:
+              print("No SLACK_BOT_TOKEN or SLACK_WEBHOOK_URL set, skipping.")
           PYEOF
 
       - name: Stop MinIO trace logging and save

--- a/.github/workflows/upgrade-bootstrap-single.yml
+++ b/.github/workflows/upgrade-bootstrap-single.yml
@@ -747,16 +747,10 @@ jobs:
           set -euxo pipefail
 
           # 1. Install mc (MinIO Client)
-          if ! command -v mc &>/dev/null; then
-            if curl -fsSL https://dl.min.io/client/mc/release/linux-amd64/mc -o /usr/local/bin/mc 2>/dev/null; then
-              chmod +x /usr/local/bin/mc
-            else
-              curl -fsSL https://dl.min.io/client/mc/release/linux-amd64/mc -o /tmp/mc
-              chmod +x /tmp/mc
-              export PATH="/tmp:$PATH"
-              echo "/tmp" >> "$GITHUB_PATH"
-            fi
-          fi
+          curl -fsSL https://dl.min.io/client/mc/release/linux-amd64/mc -o /tmp/mc
+          chmod +x /tmp/mc
+          export PATH="/tmp:$PATH"
+          echo "/tmp" >> "$GITHUB_PATH"
 
           # 2. Configure mc alias to external MinIO
           mc alias set myminio http://192.168.10.164:9000 "${MINIO_ACCESS_KEY}" "${MINIO_SECRET_KEY}"

--- a/.github/workflows/upgrade-bootstrap.yml
+++ b/.github/workflows/upgrade-bootstrap.yml
@@ -1245,16 +1245,25 @@ jobs:
         if: always()
         shell: bash
         env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
+          SLACK_MSG_TS: ${{ env.SLACK_MSG_TS }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           SLACK_WF_NAME: "E2E (Upgrade Bootstrap)"
           RUN_BASE_DIR: ${{ env.RUN_BASE_DIR }}
         run: |
-          if [ -z "${SLACK_WEBHOOK_URL:-}" ]; then exit 0; fi
           MSG=":white_check_mark: *Log collection complete* for *SimplyBlock ${SLACK_WF_NAME}*\n:file_folder: \`${RUN_BASE_DIR:-N/A}/graylog_collected/\`\n:link: <${SLACK_RUN_URL}|View Run>"
-          curl -s -X POST "${SLACK_WEBHOOK_URL}" \
-            -H 'Content-Type: application/json' \
-            -d "{\"text\":\"${MSG}\"}" || true
+          if [ -n "${SLACK_BOT_TOKEN:-}" ] && [ -n "${SLACK_CHANNEL_ID:-}" ] && [ -n "${SLACK_MSG_TS:-}" ]; then
+            curl -s -X POST "https://slack.com/api/chat.postMessage" \
+              -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
+              -H "Content-Type: application/json; charset=utf-8" \
+              -d "{\"channel\":\"${SLACK_CHANNEL_ID}\",\"thread_ts\":\"${SLACK_MSG_TS}\",\"text\":\"${MSG}\"}" || true
+          elif [ -n "${SLACK_WEBHOOK_URL:-}" ]; then
+            curl -s -X POST "${SLACK_WEBHOOK_URL}" \
+              -H "Content-Type: application/json" \
+              -d "{\"text\":\"${MSG}\"}" || true
+          fi
 
       # =========================
       # SUMMARY (always)
@@ -1411,6 +1420,8 @@ jobs:
         shell: bash
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
           JOB_STATUS: ${{ job.status }}
           SLACK_RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           GITHUB_REF_NAME: ${{ github.ref_name }}
@@ -1419,9 +1430,11 @@ jobs:
           python3 - <<'PYEOF'
           import json, os, re, sys, urllib.request, urllib.error
 
-          webhook = os.environ.get("SLACK_WEBHOOK_URL", "")
-          if not webhook:
-              print("No SLACK_WEBHOOK_URL set, skipping.")
+          bot_token = os.environ.get("SLACK_BOT_TOKEN", "")
+          channel   = os.environ.get("SLACK_CHANNEL_ID", "")
+          webhook   = os.environ.get("SLACK_WEBHOOK_URL", "")
+          if not bot_token and not webhook:
+              print("No SLACK_BOT_TOKEN or SLACK_WEBHOOK_URL set, skipping.")
               sys.exit(0)
 
           out_log = "sbcli/e2e/output.log"
@@ -1516,17 +1529,46 @@ jobs:
               f":hourglass_flowing_sand: _Logs are being collected and will be available shortly._",
           ]
 
-          payload = {"text": "\n".join(lines)}
-          req = urllib.request.Request(
-              webhook,
-              data=json.dumps(payload).encode(),
-              headers={"Content-Type": "application/json"},
-          )
-          try:
-              urllib.request.urlopen(req, timeout=15)
-              print("Slack notification sent.")
-          except Exception as exc:
-              print(f"WARN: Slack notification failed: {exc}", file=sys.stderr)
+          # --- Send ---
+          gh_env = os.environ.get("GITHUB_ENV", "")
+          text   = "\n".join(lines)
+
+          if bot_token and channel:
+              api_payload = json.dumps({"channel": channel, "text": text}).encode()
+              req = urllib.request.Request(
+                  "https://slack.com/api/chat.postMessage",
+                  data=api_payload,
+                  headers={
+                      "Content-Type": "application/json; charset=utf-8",
+                      "Authorization": f"Bearer {bot_token}",
+                  },
+              )
+              try:
+                  resp = urllib.request.urlopen(req, timeout=15)
+                  body = json.loads(resp.read().decode())
+                  if body.get("ok"):
+                      ts = body.get("ts", "")
+                      print(f"Slack notification sent via Bot API (ts={ts}).")
+                      if gh_env and ts:
+                          with open(gh_env, "a") as f:
+                              f.write(f"SLACK_MSG_TS={ts}\n")
+                  else:
+                      print(f"WARN: Slack API error: {body.get('error')}", file=sys.stderr)
+              except Exception as exc:
+                  print(f"WARN: Slack Bot API failed: {exc}", file=sys.stderr)
+          elif webhook:
+              req = urllib.request.Request(
+                  webhook,
+                  data=json.dumps({"text": text}).encode(),
+                  headers={"Content-Type": "application/json"},
+              )
+              try:
+                  urllib.request.urlopen(req, timeout=15)
+                  print("Slack notification sent via webhook (no thread support).")
+              except Exception as exc:
+                  print(f"WARN: Slack webhook failed: {exc}", file=sys.stderr)
+          else:
+              print("No SLACK_BOT_TOKEN or SLACK_WEBHOOK_URL set, skipping.")
           PYEOF
 
       - name: Stop MinIO trace logging and save

--- a/.github/workflows/upgrade-bootstrap.yml
+++ b/.github/workflows/upgrade-bootstrap.yml
@@ -1241,6 +1241,21 @@ jobs:
           done
           echo "=== Log collection complete (${CHUNK} chunks, newest-first): ${OUTPUT_DIR} ==="
 
+      - name: Notify Slack log collection complete
+        if: always()
+        shell: bash
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          SLACK_WF_NAME: "E2E (Upgrade Bootstrap)"
+          RUN_BASE_DIR: ${{ env.RUN_BASE_DIR }}
+        run: |
+          if [ -z "${SLACK_WEBHOOK_URL:-}" ]; then exit 0; fi
+          MSG=":white_check_mark: *Log collection complete* for *SimplyBlock ${SLACK_WF_NAME}*\n:file_folder: \`${RUN_BASE_DIR:-N/A}/graylog_collected/\`\n:link: <${SLACK_RUN_URL}|View Run>"
+          curl -s -X POST "${SLACK_WEBHOOK_URL}" \
+            -H 'Content-Type: application/json' \
+            -d "{\"text\":\"${MSG}\"}" || true
+
       # =========================
       # SUMMARY (always)
       # =========================

--- a/.github/workflows/upgrade-bootstrap.yml
+++ b/.github/workflows/upgrade-bootstrap.yml
@@ -756,16 +756,10 @@ jobs:
           set -euxo pipefail
 
           # 1. Install mc (MinIO Client)
-          if ! command -v mc &>/dev/null; then
-            if curl -fsSL https://dl.min.io/client/mc/release/linux-amd64/mc -o /usr/local/bin/mc 2>/dev/null; then
-              chmod +x /usr/local/bin/mc
-            else
-              curl -fsSL https://dl.min.io/client/mc/release/linux-amd64/mc -o /tmp/mc
-              chmod +x /tmp/mc
-              export PATH="/tmp:$PATH"
-              echo "/tmp" >> "$GITHUB_PATH"
-            fi
-          fi
+          curl -fsSL https://dl.min.io/client/mc/release/linux-amd64/mc -o /tmp/mc
+          chmod +x /tmp/mc
+          export PATH="/tmp:$PATH"
+          echo "/tmp" >> "$GITHUB_PATH"
 
           # 2. Configure mc alias to external MinIO
           mc alias set myminio http://192.168.10.164:9000 "${MINIO_ACCESS_KEY}" "${MINIO_SECRET_KEY}"

--- a/.github/workflows/upgrade-bootstrap.yml
+++ b/.github/workflows/upgrade-bootstrap.yml
@@ -1589,6 +1589,9 @@ jobs:
           else
             echo "No MinIO trace log found (backup tests may not have run)"
           fi
+          # Cleanup: delete trace logs and kill any orphaned mc trace processes
+          rm -f /tmp/minio-trace-*.log 2>/dev/null || true
+          pkill -f "mc admin trace" 2>/dev/null || true
 
       - name: Upload logs (always)
         if: always()

--- a/e2e/e2e.py
+++ b/e2e/e2e.py
@@ -218,7 +218,7 @@ def main():
         seen = set()
         for needle in needles:
             for cls in ALL_TESTS:
-                if needle in cls.__name__.lower().replace("_", "") and cls not in seen:
+                if needle == cls.__name__.lower().replace("_", "") and cls not in seen:
                     if cls.__name__ == "TestAddNodesDuringFioRun" and len(new_nodes) == 0:
                         raise ValueError("TestAddNodesDuringFioRun requires --new-nodes with at least 1 IP.")
                     if cls.__name__ == "TestAddNodesDualNodePerHost" and len(new_nodes) == 0:

--- a/e2e/e2e_tests/backup/test_backup_restore.py
+++ b/e2e/e2e_tests/backup/test_backup_restore.py
@@ -3770,38 +3770,65 @@ class TestBackupCrossClusterRestore(BackupTestBase):
                 f"TC-BCK-075: restore triggered: {out3.strip()}")
             self._c2_lvols.append(restored_name)
 
-            # Wait for restore to complete on Cluster-2
+            # Wait for restore task to complete on Cluster-2, then wait
+            # for the lvol to reach 'online' status before connect/mount.
             self.logger.info(
-                "TC-BCK-075: waiting for Cluster-2 restore to complete…")
-            restored_id = None
-            deadline = time.time() + _RESTORE_COMPLETE_TIMEOUT
-            while time.time() < deadline:
-                lvol_out, _ = self._sbcli_c2("lvol list")
-                if restored_name in lvol_out:
-                    # Extract lvol ID from the table row containing the name
-                    import re as _re
-                    for line in lvol_out.split("\n"):
-                        if restored_name in line:
-                            id_match = _re.search(
-                                r"([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-"
-                                r"[0-9a-f]{4}-[0-9a-f]{12})", line)
-                            if id_match:
-                                restored_id = id_match.group(1)
+                "TC-BCK-075: waiting for Cluster-2 restore task to "
+                "complete…")
+
+            # Phase 1: wait for restore task to reach 'done'
+            import re as _re
+            task_deadline = time.time() + _RESTORE_COMPLETE_TIMEOUT
+            while time.time() < task_deadline:
+                try:
+                    task_out, _ = self._sbcli_c2(
+                        f"cluster list-tasks {self._cluster2_id}"
+                        f" --limit 0")
+                    for line in (task_out or "").splitlines():
+                        if "s3_backup_restore" in line and "done" in line:
+                            self.logger.info(
+                                "TC-BCK-075: restore task reached 'done'")
                             break
-                    self.logger.info(
-                        f"TC-BCK-075: restored lvol appeared on Cluster-2"
-                        f" (id={restored_id})")
-                    break
-                sleep_n_sec(_POLL_INTERVAL)
+                    else:
+                        sleep_n_sec(_POLL_INTERVAL)
+                        continue
+                    break  # task done
+                except Exception as e:
+                    self.logger.warning(
+                        f"TC-BCK-075: could not check task status: {e}")
+                    sleep_n_sec(_POLL_INTERVAL)
             else:
-                raise TimeoutError(
-                    f"TC-BCK-075: restored lvol {restored_name} did not "
-                    f"appear on Cluster-2 within "
-                    f"{_RESTORE_COMPLETE_TIMEOUT}s")
+                self.logger.warning(
+                    "TC-BCK-075: restore task did not reach 'done' "
+                    f"within {_RESTORE_COMPLETE_TIMEOUT}s — proceeding")
+
+            # Stabilisation wait after restore task completes
+            self.logger.info(
+                "TC-BCK-075: waiting 60s for restore to stabilise…")
+            sleep_n_sec(60)
+
+            # Phase 2: verify lvol is online and extract its ID
+            restored_id = None
+            lvol_out, _ = self._sbcli_c2("lvol list")
+            for line in lvol_out.split("\n"):
+                if restored_name in line:
+                    id_match = _re.search(
+                        r"([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-"
+                        r"[0-9a-f]{4}-[0-9a-f]{12})", line)
+                    if id_match:
+                        restored_id = id_match.group(1)
+                    if "online" not in line.lower():
+                        self.logger.warning(
+                            f"TC-BCK-075: lvol {restored_name} not "
+                            f"online yet: {line.strip()}")
+                    break
+            self.logger.info(
+                f"TC-BCK-075: restored lvol on Cluster-2"
+                f" (id={restored_id})")
 
             assert restored_id, (
-                f"TC-BCK-075: could not extract lvol ID for "
-                f"{restored_name} from lvol list output")
+                f"TC-BCK-075: could not find restored lvol "
+                f"{restored_name} in lvol list:\n{lvol_out}")
 
             # TC-BCK-076: data integrity — connect via Cluster-2
             self.logger.info(

--- a/e2e/e2e_tests/backup/test_backup_restore.py
+++ b/e2e/e2e_tests/backup/test_backup_restore.py
@@ -3754,6 +3754,26 @@ class TestBackupCrossClusterRestore(BackupTestBase):
             f"{out_sw.strip()}")
 
         try:
+            import re as _re
+
+            # Pick a C2 storage node for restore (backup.node_id is from C1)
+            sn_out, _ = self._sbcli_c2(
+                f"sn list --cluster-id {self._cluster2_id}")
+            c2_node_id = None
+            for line in (sn_out or "").splitlines():
+                if "online" not in line.lower():
+                    continue
+                m = _re.search(
+                    r"([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-"
+                    r"[0-9a-f]{4}-[0-9a-f]{12})", line)
+                if m:
+                    c2_node_id = m.group(0)
+                    break
+            assert c2_node_id, (
+                f"TC-BCK-075: no online C2 storage node found in:\n{sn_out}")
+            self.logger.info(
+                f"TC-BCK-075: using C2 storage node {c2_node_id}")
+
             # TC-BCK-075: restore on Cluster-2
             restored_name = f"cc_rest_{_rand_suffix()}"
             self.logger.info(
@@ -3763,6 +3783,7 @@ class TestBackupCrossClusterRestore(BackupTestBase):
                 f"backup restore {backup_id} "
                 f"--lvol {restored_name} "
                 f"--pool {self._cluster2_pool_name} "
+                f"--node {c2_node_id} "
                 f"--cluster-id {self._cluster2_id}")
             assert not (err3 and "error" in err3.lower()), \
                 f"TC-BCK-075: restore on Cluster-2 failed: {err3}"
@@ -3777,7 +3798,6 @@ class TestBackupCrossClusterRestore(BackupTestBase):
                 "complete…")
 
             # Phase 1: wait for restore task to reach 'done'
-            import re as _re
             task_deadline = time.time() + _RESTORE_COMPLETE_TIMEOUT
             while time.time() < task_deadline:
                 try:

--- a/e2e/e2e_tests/backup/test_backup_restore.py
+++ b/e2e/e2e_tests/backup/test_backup_restore.py
@@ -3773,12 +3773,24 @@ class TestBackupCrossClusterRestore(BackupTestBase):
             # Wait for restore to complete on Cluster-2
             self.logger.info(
                 "TC-BCK-075: waiting for Cluster-2 restore to complete…")
+            restored_id = None
             deadline = time.time() + _RESTORE_COMPLETE_TIMEOUT
             while time.time() < deadline:
                 lvol_out, _ = self._sbcli_c2("lvol list")
                 if restored_name in lvol_out:
+                    # Extract lvol ID from the table row containing the name
+                    import re as _re
+                    for line in lvol_out.split("\n"):
+                        if restored_name in line:
+                            id_match = _re.search(
+                                r"([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-"
+                                r"[0-9a-f]{4}-[0-9a-f]{12})", line)
+                            if id_match:
+                                restored_id = id_match.group(1)
+                            break
                     self.logger.info(
-                        "TC-BCK-075: restored lvol appeared on Cluster-2")
+                        f"TC-BCK-075: restored lvol appeared on Cluster-2"
+                        f" (id={restored_id})")
                     break
                 sleep_n_sec(_POLL_INTERVAL)
             else:
@@ -3787,11 +3799,15 @@ class TestBackupCrossClusterRestore(BackupTestBase):
                     f"appear on Cluster-2 within "
                     f"{_RESTORE_COMPLETE_TIMEOUT}s")
 
+            assert restored_id, (
+                f"TC-BCK-075: could not extract lvol ID for "
+                f"{restored_name} from lvol list output")
+
             # TC-BCK-076: data integrity — connect via Cluster-2
             self.logger.info(
                 "TC-BCK-076: connecting restored lvol from Cluster-2")
             c2_connect_out, c2_connect_err = self._sbcli_c2(
-                f"volume connect {restored_name}")
+                f"volume connect {restored_id}")
             connect_lines = [
                 line.strip()
                 for line in c2_connect_out.strip().split("\n")

--- a/e2e/e2e_tests/backup/test_backup_restore.py
+++ b/e2e/e2e_tests/backup/test_backup_restore.py
@@ -3099,6 +3099,84 @@ class TestBackupCrossClusterRestore(BackupTestBase):
             f"TC-BCK-070: Cluster-2 discovered — ID={self._cluster2_id}, "
             f"namespace={self._cluster2_namespace}")
 
+    # ── CLI overrides (Docker mode) ─────────────────────────────────────────
+    # In multi-cluster Docker setups the REST API helpers in sbcli_utils
+    # hit issues that won't be fixed until v2.  Override the base-class
+    # methods to use sbctl CLI commands instead.
+
+    def _ensure_pool_and_sc(self, pool_name=None, retries=3):
+        if self.k8s_test:
+            return super()._ensure_pool_and_sc(
+                pool_name=pool_name, retries=retries)
+        target = pool_name or self.pool_name
+        self.logger.info(f"[CLI] Creating pool '{target}' via sbctl")
+        out, err = self._sbcli(
+            f"pool add {target} {self.cluster_id}")
+        # Tolerate "already exists" — reuse the pool
+        if err and "error" in err.lower():
+            if "already exists" not in (err or "").lower():
+                raise RuntimeError(f"pool add failed: {err}")
+            self.logger.info(f"[CLI] Pool '{target}' already exists, reusing")
+        else:
+            self.logger.info(
+                f"[CLI] Pool '{target}' created: {(out or '').strip()}")
+        return self.pool_name
+
+    def _create_lvol(self, name=None, size=None,
+                     crypto=False, ndcs=None, npcs=None):
+        if self.k8s_test:
+            return super()._create_lvol(
+                name=name, size=size, crypto=crypto,
+                ndcs=ndcs, npcs=npcs)
+        name = name or f"bck_{_rand_suffix()}"
+        size = size or self.lvol_size
+        cmd = f"lvol add {name} {size} {self.pool_name}"
+        if crypto:
+            cmd += " --crypto"
+        out, err = self._sbcli(cmd)
+        assert not (err and "error" in err.lower()), \
+            f"lvol add failed: {err}"
+        # sbctl lvol add prints the lvol UUID
+        lvol_id = (out or "").strip().split()[-1] if out and out.strip() else name
+        self.created_lvols.append(name)
+        self.logger.info(
+            f"[CLI] Created lvol '{name}' (id={lvol_id})")
+        return name, lvol_id
+
+    def _connect_and_mount(self, lvol_name, lvol_id,
+                           mount=None, format_disk=True):
+        if self.k8s_test:
+            return super()._connect_and_mount(
+                lvol_name, lvol_id, mount=mount, format_disk=format_disk)
+        mount = mount or f"{self.mount_path}/{lvol_name}"
+        # Get NVMe connect strings via CLI
+        out, err = self._sbcli(f"volume connect {lvol_name}")
+        connect_lines = [
+            ln.strip() for ln in (out or "").split("\n")
+            if ln.strip() and "nvme connect" in ln
+        ]
+        assert connect_lines, (
+            f"No nvme connect strings for {lvol_name}: {out}")
+
+        initial = self.ssh_obj.get_devices(node=self.fio_node)
+        for cmd in connect_lines:
+            self.ssh_obj.exec_command(node=self.fio_node, command=cmd)
+        sleep_n_sec(3)
+        final = self.ssh_obj.get_devices(node=self.fio_node)
+        new_devs = [d for d in final if d not in initial]
+        assert new_devs, (
+            f"No new block device after connecting {lvol_name}")
+        device = f"/dev/{new_devs[0]}"
+        if format_disk:
+            self.ssh_obj.format_disk(
+                node=self.fio_node, device=device, fs_type="ext4")
+        self.ssh_obj.exec_command(self.fio_node, f"mkdir -p {mount}")
+        self.ssh_obj.mount_path(
+            node=self.fio_node, device=device, mount_path=mount)
+        self.mounted.append((self.fio_node, mount))
+        self.connected.append(lvol_id)
+        return device, mount
+
     # ── self-bootstrap second cluster ────────────────────────────────────────
 
     def _bootstrap_second_cluster(self):

--- a/e2e/e2e_tests/backup/test_backup_restore.py
+++ b/e2e/e2e_tests/backup/test_backup_restore.py
@@ -3633,7 +3633,8 @@ class TestBackupCrossClusterRestore(BackupTestBase):
             c2_pool = os.environ.get("CLUSTER2_POOL", self.pool_name)
             out3, err3 = self._sbcli_c2(
                 f"backup restore {backup_id} "
-                f"--lvol {restored_name} --pool {c2_pool}")
+                f"--lvol {restored_name} --pool {c2_pool} "
+                f"--cluster-id {self._cluster2_id}")
             assert not (err3 and "error" in err3.lower()), \
                 f"TC-BCK-075: restore on Cluster-2 failed: {err3}"
             self.logger.info(

--- a/e2e/e2e_tests/backup/test_backup_restore.py
+++ b/e2e/e2e_tests/backup/test_backup_restore.py
@@ -3205,17 +3205,16 @@ class TestBackupCrossClusterRestore(BackupTestBase):
             self.ssh_obj.exec_command(node=ip, command=deploy_cmd)
 
         # Wait for SPDK containers to start
-        self.logger.info("  [C2] Waiting for SPDK containers to start...")
+        self.logger.info("  [C2] art...")
         sleep_n_sec(30)
 
         # Step 2: create Cluster-2 on mgmt node
         self.logger.info("  [C2] Creating second cluster on mgmt node")
         create_cmd = (
-            f"{sbcli_cmd} --dev -d cluster create"
+            f"{sbcli_cmd} --dev -d cluster add"
             f" --ha-type {ha_type}"
             f" --data-chunks-per-stripe {ndcs}"
             f" --parity-chunks-per-stripe {npcs}"
-            f" --ifname {ifname}"
         )
         if extra_cluster_args:
             create_cmd += f" {extra_cluster_args}"

--- a/e2e/e2e_tests/backup/test_backup_restore.py
+++ b/e2e/e2e_tests/backup/test_backup_restore.py
@@ -3702,7 +3702,8 @@ class TestBackupCrossClusterRestore(BackupTestBase):
             f"TC-BCK-074b: Cluster-2 — backup source-switch to "
             f"Cluster-1 ({self.cluster_id})")
         out_sw, err_sw = self._sbcli_c2(
-            f"backup source-switch {self.cluster_id}")
+            f"backup source-switch {self.cluster_id}"
+            f" --cluster-id {self._cluster2_id}")
         assert not (err_sw and "error" in err_sw.lower()), \
             f"TC-BCK-074b: source-switch to Cluster-1 failed: {err_sw}"
         self.logger.info(
@@ -3788,7 +3789,8 @@ class TestBackupCrossClusterRestore(BackupTestBase):
                 "TC-BCK-076b: Cluster-2 — backup source-switch "
                 "back to local")
             out_back, err_back = self._sbcli_c2(
-                "backup source-switch local")
+                f"backup source-switch local"
+                f" --cluster-id {self._cluster2_id}")
             if err_back and "error" in err_back.lower():
                 self.logger.warning(
                     f"TC-BCK-076b: source-switch-back warning: "
@@ -3857,7 +3859,9 @@ class TestBackupCrossClusterRestore(BackupTestBase):
         # (CLI mode only — K8s-native mode uses CRDs, no manual source-switch)
         if not self.k8s_test:
             try:
-                self._sbcli_c2("backup source-switch local")
+                self._sbcli_c2(
+                    f"backup source-switch local"
+                    f" --cluster-id {self._cluster2_id}")
             except Exception as e:
                 self.logger.warning(
                     f"source-switch-back in teardown warning: {e}")

--- a/e2e/e2e_tests/backup/test_backup_restore.py
+++ b/e2e/e2e_tests/backup/test_backup_restore.py
@@ -3326,45 +3326,62 @@ class TestBackupCrossClusterRestore(BackupTestBase):
         for ip in c2_ips:
             self.logger.info(f"  [C2] Adding storage node {ip} to Cluster-2")
             add_cmd = f"{add_base} {c2_id} {ip}:5000 {ifname}"
-            out, _ = self.ssh_obj.exec_command(node=mgmt_ip, command=add_cmd)
-            if out and "Error:" in out:
-                raise RuntimeError(
-                    f"TC-BCK-070: failed to add node {ip} to Cluster-2: {out}")
+            self.ssh_obj.exec_command(node=mgmt_ip, command=add_cmd)
             sleep_n_sec(3)
 
-        # Verify nodes were added
+        # Verify nodes were added to Cluster-2
         sn_out, _ = self.ssh_obj.exec_command(
-            node=mgmt_ip, command=f"{sbcli_cmd} sn list")
-        self.logger.info(f"  [C2] Storage node list after add:\n{sn_out}")
+            node=mgmt_ip,
+            command=f"{sbcli_cmd} sn list --cluster-id {c2_id}")
+        self.logger.info(f"  [C2] Storage nodes for Cluster-2:\n{sn_out}")
+        sn_count = sum(
+            1 for line in sn_out.split("\n")
+            if c2_id in line or "online" in line.lower())
+        if sn_count < len(c2_ips):
+            raise RuntimeError(
+                f"TC-BCK-070: expected {len(c2_ips)} storage nodes in "
+                f"Cluster-2 but found {sn_count}:\n{sn_out}")
 
         # Step 4: activate Cluster-2
         self.logger.info("  [C2] Activating Cluster-2")
-        out, _ = self.ssh_obj.exec_command(
+        self.ssh_obj.exec_command(
             node=mgmt_ip,
-            command=f"{sbcli_cmd} -d cluster activate {c2_id}"
-        )
-        if out and "Error:" in out:
-            raise RuntimeError(
-                f"TC-BCK-070: failed to activate Cluster-2: {out}")
+            command=f"{sbcli_cmd} -d cluster activate {c2_id}")
 
-        # Verify cluster is ACTIVE
+        # Verify cluster is ACTIVE and nodes are online+healthy
         cl_out, _ = self.ssh_obj.exec_command(
             node=mgmt_ip, command=f"{sbcli_cmd} cluster list")
-        if "ACTIVE" not in cl_out or c2_id not in cl_out:
+        self.logger.info(f"  [C2] Cluster list after activate:\n{cl_out}")
+        # Find C2's row and check it says ACTIVE
+        c2_active = False
+        for line in cl_out.split("\n"):
+            if c2_id in line and "ACTIVE" in line:
+                c2_active = True
+                break
+        if not c2_active:
             raise RuntimeError(
                 f"TC-BCK-070: Cluster-2 {c2_id} not ACTIVE after "
                 f"activate:\n{cl_out}")
-        self.logger.info(f"  [C2] Cluster list after activate:\n{cl_out}")
+
+        sn_out2, _ = self.ssh_obj.exec_command(
+            node=mgmt_ip,
+            command=f"{sbcli_cmd} sn list --cluster-id {c2_id}")
+        self.logger.info(
+            f"  [C2] Storage nodes after activate:\n{sn_out2}")
+        unhealthy = [
+            line for line in sn_out2.split("\n")
+            if "|" in line and c2_id not in line
+            and "online" in line.lower() and "false" in line.lower()]
+        if unhealthy:
+            self.logger.warning(
+                f"  [C2] Unhealthy nodes detected: {unhealthy}")
 
         # Step 5: create pool on Cluster-2
         self.logger.info("  [C2] Creating pool on Cluster-2")
-        out, _ = self.ssh_obj.exec_command(
+        self.ssh_obj.exec_command(
             node=mgmt_ip,
             command=f"{sbcli_cmd} pool add {self._cluster2_pool_name} {c2_id}"
         )
-        if out and "Error:" in out:
-            raise RuntimeError(
-                f"TC-BCK-070: failed to create pool on Cluster-2: {out}")
 
         # Step 6: extract Cluster-2 secret
         out, _ = self.ssh_obj.exec_command(

--- a/e2e/e2e_tests/backup/test_backup_restore.py
+++ b/e2e/e2e_tests/backup/test_backup_restore.py
@@ -3154,7 +3154,7 @@ class TestBackupCrossClusterRestore(BackupTestBase):
                 lvol_name, lvol_id, mount=mount, format_disk=format_disk)
         mount = mount or f"{self.mount_path}/{lvol_name}"
         # Get NVMe connect strings via CLI
-        out, err = self._sbcli(f"volume connect {lvol_name}")
+        out, err = self._sbcli(f"volume connect {lvol_id}")
         connect_lines = [
             ln.strip() for ln in (out or "").split("\n")
             if ln.strip() and "nvme connect" in ln

--- a/e2e/e2e_tests/backup/test_backup_restore.py
+++ b/e2e/e2e_tests/backup/test_backup_restore.py
@@ -3422,7 +3422,8 @@ class TestBackupCrossClusterRestore(BackupTestBase):
         Returns the path of the metadata file on the mgmt node (or inside
         the admin pod in K8s mode).
         """
-        out, err = self._sbcli(f"backup export -o {self._meta_file}")
+        out, err = self._sbcli(
+            f"backup export --cluster {self.cluster_id} -o {self._meta_file}")
         assert not (err and "error" in err.lower()), \
             f"TC-BCK-072: backup export failed: {err}"
         self.logger.info(f"TC-BCK-072: backup export result: {(out or '').strip()}")
@@ -3596,7 +3597,8 @@ class TestBackupCrossClusterRestore(BackupTestBase):
 
         # TC-BCK-073: import metadata on Cluster-2
         self.logger.info(f"TC-BCK-073: Cluster-2 — backup import {meta_file}")
-        out, err = self._sbcli_c2(f"backup import {meta_file}")
+        out, err = self._sbcli_c2(
+            f"backup import {meta_file} --cluster-id {self._cluster2_id}")
         assert not (err and "error" in err.lower()), \
             f"TC-BCK-073: backup import on Cluster-2 failed: {err}"
         self.logger.info(f"TC-BCK-073: import result: {out.strip()}")
@@ -3604,7 +3606,8 @@ class TestBackupCrossClusterRestore(BackupTestBase):
         # TC-BCK-074: verify backup is visible on Cluster-2
         self.logger.info(
             "TC-BCK-074: Cluster-2 — backup list should show imported backup")
-        out2, err2 = self._sbcli_c2("backup list")
+        out2, err2 = self._sbcli_c2(
+            f"backup list --cluster {self._cluster2_id}")
         assert not (err2 and "error" in err2.lower()), \
             f"TC-BCK-074: backup list on Cluster-2 failed: {err2}"
         assert backup_id in out2 or out2.strip(), \

--- a/e2e/e2e_tests/backup/test_backup_restore.py
+++ b/e2e/e2e_tests/backup/test_backup_restore.py
@@ -3326,11 +3326,8 @@ class TestBackupCrossClusterRestore(BackupTestBase):
         for ip in c2_ips:
             self.logger.info(f"  [C2] Adding storage node {ip} to Cluster-2")
             add_cmd = f"{add_base} {c2_id} {ip}:5000 {ifname}"
-            out, err = self.ssh_obj.exec_command(node=mgmt_ip, command=add_cmd)
-            if err and "error" in err.lower():
-                raise RuntimeError(
-                    f"TC-BCK-070: failed to add node {ip} to Cluster-2: {err}")
-            if out and "Error" in out:
+            out, _ = self.ssh_obj.exec_command(node=mgmt_ip, command=add_cmd)
+            if out and "Error:" in out:
                 raise RuntimeError(
                     f"TC-BCK-070: failed to add node {ip} to Cluster-2: {out}")
             sleep_n_sec(3)
@@ -3342,14 +3339,11 @@ class TestBackupCrossClusterRestore(BackupTestBase):
 
         # Step 4: activate Cluster-2
         self.logger.info("  [C2] Activating Cluster-2")
-        out, err = self.ssh_obj.exec_command(
+        out, _ = self.ssh_obj.exec_command(
             node=mgmt_ip,
             command=f"{sbcli_cmd} -d cluster activate {c2_id}"
         )
-        if err and "error" in err.lower():
-            raise RuntimeError(
-                f"TC-BCK-070: failed to activate Cluster-2: {err}")
-        if out and "Error" in out:
+        if out and "Error:" in out:
             raise RuntimeError(
                 f"TC-BCK-070: failed to activate Cluster-2: {out}")
 
@@ -3364,14 +3358,11 @@ class TestBackupCrossClusterRestore(BackupTestBase):
 
         # Step 5: create pool on Cluster-2
         self.logger.info("  [C2] Creating pool on Cluster-2")
-        out, err = self.ssh_obj.exec_command(
+        out, _ = self.ssh_obj.exec_command(
             node=mgmt_ip,
             command=f"{sbcli_cmd} pool add {self._cluster2_pool_name} {c2_id}"
         )
-        if err and "error" in err.lower():
-            raise RuntimeError(
-                f"TC-BCK-070: failed to create pool on Cluster-2: {err}")
-        if out and "Error" in out:
+        if out and "Error:" in out:
             raise RuntimeError(
                 f"TC-BCK-070: failed to create pool on Cluster-2: {out}")
 

--- a/e2e/e2e_tests/backup/test_backup_restore.py
+++ b/e2e/e2e_tests/backup/test_backup_restore.py
@@ -3326,22 +3326,54 @@ class TestBackupCrossClusterRestore(BackupTestBase):
         for ip in c2_ips:
             self.logger.info(f"  [C2] Adding storage node {ip} to Cluster-2")
             add_cmd = f"{add_base} {c2_id} {ip}:5000 {ifname}"
-            self.ssh_obj.exec_command(node=mgmt_ip, command=add_cmd)
+            out, err = self.ssh_obj.exec_command(node=mgmt_ip, command=add_cmd)
+            if err and "error" in err.lower():
+                raise RuntimeError(
+                    f"TC-BCK-070: failed to add node {ip} to Cluster-2: {err}")
+            if out and "Error" in out:
+                raise RuntimeError(
+                    f"TC-BCK-070: failed to add node {ip} to Cluster-2: {out}")
             sleep_n_sec(3)
+
+        # Verify nodes were added
+        sn_out, _ = self.ssh_obj.exec_command(
+            node=mgmt_ip, command=f"{sbcli_cmd} sn list")
+        self.logger.info(f"  [C2] Storage node list after add:\n{sn_out}")
 
         # Step 4: activate Cluster-2
         self.logger.info("  [C2] Activating Cluster-2")
-        self.ssh_obj.exec_command(
+        out, err = self.ssh_obj.exec_command(
             node=mgmt_ip,
             command=f"{sbcli_cmd} -d cluster activate {c2_id}"
         )
+        if err and "error" in err.lower():
+            raise RuntimeError(
+                f"TC-BCK-070: failed to activate Cluster-2: {err}")
+        if out and "Error" in out:
+            raise RuntimeError(
+                f"TC-BCK-070: failed to activate Cluster-2: {out}")
+
+        # Verify cluster is ACTIVE
+        cl_out, _ = self.ssh_obj.exec_command(
+            node=mgmt_ip, command=f"{sbcli_cmd} cluster list")
+        if "ACTIVE" not in cl_out or c2_id not in cl_out:
+            raise RuntimeError(
+                f"TC-BCK-070: Cluster-2 {c2_id} not ACTIVE after "
+                f"activate:\n{cl_out}")
+        self.logger.info(f"  [C2] Cluster list after activate:\n{cl_out}")
 
         # Step 5: create pool on Cluster-2
         self.logger.info("  [C2] Creating pool on Cluster-2")
-        self.ssh_obj.exec_command(
+        out, err = self.ssh_obj.exec_command(
             node=mgmt_ip,
             command=f"{sbcli_cmd} pool add {self._cluster2_pool_name} {c2_id}"
         )
+        if err and "error" in err.lower():
+            raise RuntimeError(
+                f"TC-BCK-070: failed to create pool on Cluster-2: {err}")
+        if out and "Error" in out:
+            raise RuntimeError(
+                f"TC-BCK-070: failed to create pool on Cluster-2: {out}")
 
         # Step 6: extract Cluster-2 secret
         out, _ = self.ssh_obj.exec_command(
@@ -3349,6 +3381,9 @@ class TestBackupCrossClusterRestore(BackupTestBase):
             command=f"{sbcli_cmd} cluster get-secret {c2_id}"
         )
         c2_secret = out.strip().split("\n")[0].strip()
+        if not c2_secret:
+            raise RuntimeError(
+                "TC-BCK-070: failed to extract Cluster-2 secret")
         self.logger.info("  [C2] Cluster-2 secret obtained")
 
         # Set instance attributes

--- a/e2e/e2e_tests/backup/test_backup_restore.py
+++ b/e2e/e2e_tests/backup/test_backup_restore.py
@@ -3005,6 +3005,10 @@ class TestBackupCrossClusterRestore(BackupTestBase):
         self._cluster2_api_url = os.environ.get("CLUSTER2_API_BASE_URL", "")
         self._cluster2_namespace = os.environ.get("CLUSTER2_NAMESPACE", "simplyblock-c2")
         self._meta_file = "/tmp/cross_cluster_backup_meta.json"
+        # Distinct pool names per cluster to avoid ambiguity
+        self.pool_name = "bck_pool_c1"
+        self._cluster2_pool_name = os.environ.get(
+            "CLUSTER2_POOL", "bck_pool_c2")
         # Resources created on Cluster-2 (separate tracking for teardown)
         self._c2_lvols: list[str] = []
         # Whether we bootstrapped cluster 2 ourselves (for teardown)
@@ -3336,7 +3340,7 @@ class TestBackupCrossClusterRestore(BackupTestBase):
         self.logger.info("  [C2] Creating pool on Cluster-2")
         self.ssh_obj.exec_command(
             node=mgmt_ip,
-            command=f"{sbcli_cmd} pool add {self.pool_name} {c2_id}"
+            command=f"{sbcli_cmd} pool add {self._cluster2_pool_name} {c2_id}"
         )
 
         # Step 6: extract Cluster-2 secret
@@ -3711,10 +3715,10 @@ class TestBackupCrossClusterRestore(BackupTestBase):
             self.logger.info(
                 f"TC-BCK-075: Cluster-2 — backup restore "
                 f"{backup_id} → {restored_name}")
-            c2_pool = os.environ.get("CLUSTER2_POOL", self.pool_name)
             out3, err3 = self._sbcli_c2(
                 f"backup restore {backup_id} "
-                f"--lvol {restored_name} --pool {c2_pool} "
+                f"--lvol {restored_name} "
+                f"--pool {self._cluster2_pool_name} "
                 f"--cluster-id {self._cluster2_id}")
             assert not (err3 and "error" in err3.lower()), \
                 f"TC-BCK-075: restore on Cluster-2 failed: {err3}"

--- a/e2e/e2e_tests/backup/test_backup_restore.py
+++ b/e2e/e2e_tests/backup/test_backup_restore.py
@@ -3799,28 +3799,42 @@ class TestBackupCrossClusterRestore(BackupTestBase):
 
             # Phase 1: wait for restore task to reach 'done'
             task_deadline = time.time() + _RESTORE_COMPLETE_TIMEOUT
+            restore_task_done = False
             while time.time() < task_deadline:
                 try:
                     task_out, _ = self._sbcli_c2(
                         f"cluster list-tasks {self._cluster2_id}"
                         f" --limit 0")
                     for line in (task_out or "").splitlines():
-                        if "s3_backup_restore" in line and "done" in line:
+                        if "s3_backup_restore" not in line:
+                            continue
+                        if "done" in line:
                             self.logger.info(
                                 "TC-BCK-075: restore task reached 'done'")
+                            restore_task_done = True
                             break
-                    else:
-                        sleep_n_sec(_POLL_INTERVAL)
-                        continue
-                    break  # task done
+                        # Detect fatal task failure: max retries exhausted
+                        retry_match = _re.search(
+                            r"(\d+)/(\d+)", line)
+                        if retry_match:
+                            cur, mx = int(retry_match.group(1)), int(retry_match.group(2))
+                            if cur >= mx:
+                                raise AssertionError(
+                                    f"TC-BCK-075: restore task exhausted "
+                                    f"retries ({cur}/{mx}): {line.strip()}")
+                    if restore_task_done:
+                        break
+                    sleep_n_sec(_POLL_INTERVAL)
+                except AssertionError:
+                    raise
                 except Exception as e:
                     self.logger.warning(
                         f"TC-BCK-075: could not check task status: {e}")
                     sleep_n_sec(_POLL_INTERVAL)
             else:
-                self.logger.warning(
+                raise AssertionError(
                     "TC-BCK-075: restore task did not reach 'done' "
-                    f"within {_RESTORE_COMPLETE_TIMEOUT}s — proceeding")
+                    f"within {_RESTORE_COMPLETE_TIMEOUT}s")
 
             # Stabilisation wait after restore task completes
             self.logger.info(
@@ -3837,6 +3851,10 @@ class TestBackupCrossClusterRestore(BackupTestBase):
                         r"[0-9a-f]{4}-[0-9a-f]{12})", line)
                     if id_match:
                         restored_id = id_match.group(1)
+                    if "restore_failed" in line.lower():
+                        raise AssertionError(
+                            f"TC-BCK-075: lvol {restored_name} has "
+                            f"restore_failed status: {line.strip()}")
                     if "online" not in line.lower():
                         self.logger.warning(
                             f"TC-BCK-075: lvol {restored_name} not "

--- a/e2e/e2e_tests/backup/test_backup_restore.py
+++ b/e2e/e2e_tests/backup/test_backup_restore.py
@@ -3011,6 +3011,7 @@ class TestBackupCrossClusterRestore(BackupTestBase):
             "CLUSTER2_POOL", "bck_pool_c2")
         # Resources created on Cluster-2 (separate tracking for teardown)
         self._c2_lvols: list[str] = []
+        self._c2_node_ips: list[str] = []
         # Whether we bootstrapped cluster 2 ourselves (for teardown)
         self._self_bootstrapped_c2 = False
         # K8s-mode: second K8sUtils instance for Cluster-2 (initialised in _check_prerequisites)
@@ -3409,6 +3410,26 @@ class TestBackupCrossClusterRestore(BackupTestBase):
         self.logger.info(
             f"TC-BCK-070: Cluster-2 bootstrapped — ID={c2_id}, "
             f"API={self._cluster2_api_url}, nodes={c2_ips}")
+
+        # Start log collection on C2 nodes so we capture SPDK/mgmt logs
+        self._c2_node_ips = list(c2_ips)
+        if hasattr(self, 'docker_logs_path') and self.docker_logs_path:
+            for ip in c2_ips:
+                try:
+                    node_log_dir = os.path.join(self.docker_logs_path, ip)
+                    self.ssh_obj.make_directory(node=ip, dir_name=node_log_dir)
+                    containers = self.ssh_obj.get_running_containers(node_ip=ip)
+                    self.ssh_obj.check_tmux_installed(node_ip=ip)
+                    self.ssh_obj.exec_command(
+                        node=ip, command="sudo tmux kill-server")
+                    self.ssh_obj.start_docker_logging(
+                        node_ip=ip, containers=containers,
+                        log_dir=node_log_dir, test_name=self.test_name)
+                    self.logger.info(
+                        f"  [C2] Started log collection on {ip}")
+                except Exception as e:
+                    self.logger.warning(
+                        f"  [C2] Failed to start log collection on {ip}: {e}")
 
     def _remove_nodes_from_cluster1(self, ips_to_remove: list[str]):
         """Remove storage nodes from Cluster-1 so they can join Cluster-2.
@@ -4006,6 +4027,18 @@ class TestBackupCrossClusterRestore(BackupTestBase):
                         self.mgmt_nodes[0], f"rm -f {self._meta_file}")
                 except Exception:
                     pass
+
+        # Collect final logs from C2 nodes before teardown
+        c2_ips = getattr(self, '_c2_node_ips', [])
+        if c2_ips and hasattr(self, 'docker_logs_path') and self.docker_logs_path:
+            try:
+                self.ssh_obj.collect_final_docker_logs_simple(
+                    c2_ips, self.docker_logs_path)
+                self.logger.info(
+                    f"Collected final logs from C2 nodes: {c2_ips}")
+            except Exception as e:
+                self.logger.warning(
+                    f"Failed to collect final C2 logs: {e}")
 
         # Tear down self-bootstrapped Cluster-2 (if we created it)
         self._teardown_second_cluster()

--- a/e2e/e2e_tests/cluster_test_base.py
+++ b/e2e/e2e_tests/cluster_test_base.py
@@ -267,6 +267,9 @@ class TestClusterBase:
                 sleep_n_sec(2)
             self.disconnect_lvols()
             sleep_n_sec(2)
+        # Order: clones → snapshots → parent lvols → pools
+        self.sbcli_utils.delete_all_clones()
+        sleep_n_sec(2)
         if self.k8s_test:
             self.sbcli_utils.delete_all_snapshots()
         elif self.mgmt_nodes:
@@ -1807,11 +1810,14 @@ class TestClusterBase:
                                 sleep_n_sec(2)
                         self.disconnect_lvols()
                         sleep_n_sec(2)
-                self.sbcli_utils.delete_all_lvols()
+                # Order: clones → snapshots → parent lvols → pools
+                self.sbcli_utils.delete_all_clones()
                 sleep_n_sec(2)
                 if not self.k8s_test:
                     self.ssh_obj.delete_all_snapshots(node=self.mgmt_nodes[0])
                     sleep_n_sec(2)
+                self.sbcli_utils.delete_all_lvols()
+                sleep_n_sec(2)
                 self.sbcli_utils.delete_all_storage_pools()
                 sleep_n_sec(2)
                 latest_util = self.get_latest_cluster_util()

--- a/e2e/e2e_tests/upgrade_tests/k8s_major_upgrade.py
+++ b/e2e/e2e_tests/upgrade_tests/k8s_major_upgrade.py
@@ -1945,7 +1945,25 @@ spec:
 
         apply_cmd = f"cat <<'CREOF' | kubectl apply -f -\n{cr_yaml}\nCREOF"
         out, err = self.k8s_utils._exec_kubectl(apply_cmd)
-        self.logger.info(f"CRs applied: {out}")
+        self.logger.info(f"CRs applied (stdout): {out}")
+        if err and err.strip():
+            self.logger.warning(f"CRs apply stderr: {err.strip()}")
+        # Verify critical CRs were actually created — fail early instead
+        # of discovering a missing CR much later during node restart.
+        for cr_kind, cr_name in [
+            ("storagecluster", self.cluster_cr_name),
+            ("storagenodeset", self.node_cr_name),
+        ]:
+            chk_out, _ = self.k8s_utils._exec_kubectl(
+                f"kubectl get {cr_kind} {cr_name} -n {_NAMESPACE} "
+                f"-o jsonpath='{{.metadata.name}}' 2>&1"
+            )
+            if cr_name not in (chk_out or ""):
+                raise RuntimeError(
+                    f"Critical CR {cr_kind}/{cr_name} was not created. "
+                    f"kubectl apply stderr: {err}"
+                )
+            self.logger.info(f"  Verified {cr_kind}/{cr_name} exists")
         sleep_n_sec(10)
 
     def _run_r25_to_r26_migration(self):
@@ -2468,7 +2486,23 @@ spec:
 
         apply_cmd = f"cat <<'CREOF' | kubectl apply -f -\n{cr_yaml}\nCREOF"
         out, err = self.k8s_utils._exec_kubectl(apply_cmd)
-        self.logger.info(f"CRs applied: {out}")
+        self.logger.info(f"CRs applied (stdout): {out}")
+        if err and err.strip():
+            self.logger.warning(f"CRs apply stderr: {err.strip()}")
+        for cr_kind, cr_name in [
+            ("storagecluster", self.cluster_cr_name),
+            ("storagenodeset", self.node_cr_name),
+        ]:
+            chk_out, _ = self.k8s_utils._exec_kubectl(
+                f"kubectl get {cr_kind} {cr_name} -n {_NAMESPACE} "
+                f"-o jsonpath='{{.metadata.name}}' 2>&1"
+            )
+            if cr_name not in (chk_out or ""):
+                raise RuntimeError(
+                    f"Critical CR {cr_kind}/{cr_name} was not created. "
+                    f"kubectl apply stderr: {err}"
+                )
+            self.logger.info(f"  Verified {cr_kind}/{cr_name} exists")
         sleep_n_sec(10)
 
     def _restart_nodes_sequentially(self, storage_node_list):

--- a/e2e/e2e_tests/upgrade_tests/k8s_major_upgrade.py
+++ b/e2e/e2e_tests/upgrade_tests/k8s_major_upgrade.py
@@ -2171,22 +2171,15 @@ spec:
         self.logger.info("Pre-upgrade Step 3: Creating PVCs and running short FIO")
         self._create_pvcs_with_fio(len(storage_node_list), runtime=pre_fio_runtime)
 
-        # Wait for pre-upgrade FIO to complete (max 5 mins).
-        # FIO failure is non-fatal — the goal is to test the upgrade itself,
-        # not the old version's IO path.
+        # Wait for pre-upgrade FIO to complete on ALL PVCs.
+        # This is mandatory — every lvol must have data written before we
+        # create snapshots/clones and proceed with the upgrade.
         self.logger.info(
-            "Pre-upgrade: Waiting up to 5 mins for FIO to complete "
-            "(non-fatal if it fails)"
+            "Pre-upgrade: Waiting for FIO to complete on all PVCs"
         )
-        fio_timeout = 300  # 5 minutes max wait
-        try:
-            self._validate_all_fio(fio_timeout)
-            self.logger.info("Pre-upgrade FIO completed and validated")
-        except Exception as fio_err:
-            self.logger.warning(
-                f"Pre-upgrade FIO did not complete successfully: {fio_err}. "
-                "Continuing with upgrade — this is non-fatal."
-            )
+        fio_timeout = 600  # 10 minutes — enough for 6 PVCs on a busy cluster
+        self._validate_all_fio(fio_timeout)
+        self.logger.info("Pre-upgrade FIO completed and validated on all PVCs")
 
         # Clean up FIO jobs/pods (preserve PVCs for snapshots + checksums)
         self.logger.info("Pre-upgrade: Cleaning up FIO jobs")

--- a/e2e/e2e_tests/upgrade_tests/k8s_major_upgrade.py
+++ b/e2e/e2e_tests/upgrade_tests/k8s_major_upgrade.py
@@ -837,13 +837,10 @@ class K8sNativeMajorUpgrade(TestClusterBase):
             verify_cm = f"fio-verify-cfg-{pvc_name}"
 
             verify_config = self._build_verify_only_fio_config(pvc_name, fio_meta)
-            avoid = self.k8s_utils.get_pvc_primary_k8s_node(
-                pvc_name, self.sbcli_utils,
-            )
             self.k8s_utils.create_fio_job(
                 job_name=verify_job, pvc_name=pvc_name,
                 configmap_name=verify_cm, fio_config=verify_config,
-                image=self.FIO_IMAGE, avoid_node=avoid,
+                image=self.FIO_IMAGE,
             )
             verify_jobs.append((verify_job, pvc_name))
             sleep_n_sec(5)

--- a/e2e/e2e_tests/upgrade_tests/k8s_major_upgrade.py
+++ b/e2e/e2e_tests/upgrade_tests/k8s_major_upgrade.py
@@ -1237,7 +1237,7 @@ class K8sNativeMajorUpgrade(TestClusterBase):
 
             sleep_n_sec(30)
             self.validate_migration_for_node(
-                restart_ts, 1200, node_id, 60, no_task_ok=True
+                restart_ts, 1200, None, 60, no_task_ok=True
             )
             if idx < len(storage_node_list) - 1:
                 sleep_n_sec(30)
@@ -2613,7 +2613,7 @@ spec:
             sleep_n_sec(30)
             for node_id in nids:
                 self.validate_migration_for_node(
-                    restart_ts, 1200, node_id, 60, no_task_ok=True
+                    restart_ts, 1200, None, 60, no_task_ok=True
                 )
 
             if worker_idx < len(unique_ips):

--- a/e2e/e2e_tests/upgrade_tests/k8s_major_upgrade.py
+++ b/e2e/e2e_tests/upgrade_tests/k8s_major_upgrade.py
@@ -618,11 +618,12 @@ class K8sNativeMajorUpgrade(TestClusterBase):
         # Host-level cleanup script:
         # 1) Find and unmount any simplyblock CSI volume mounts
         # 2) Disconnect all NVMe-oF subsystems
+        # Try without sudo first; fall back to sudo if the command fails.
         cleanup_script = (
             "for mp in $(mount | grep 'kubernetes.io~csi' | awk '{print $3}'); do "
-            "  umount -f \"$mp\" 2>/dev/null || true; "
+            "  umount -f \"$mp\" 2>/dev/null || sudo umount -f \"$mp\" 2>/dev/null || true; "
             "done; "
-            "nvme disconnect-all 2>/dev/null || true; "
+            "nvme disconnect-all 2>/dev/null || sudo nvme disconnect-all 2>/dev/null || true; "
             "echo CLEANUP_DONE"
         )
 

--- a/e2e/e2e_tests/upgrade_tests/k8s_major_upgrade.py
+++ b/e2e/e2e_tests/upgrade_tests/k8s_major_upgrade.py
@@ -184,7 +184,7 @@ class K8sNativeMajorUpgrade(TestClusterBase):
         self.pvc_details: dict[str, dict] = {}
         self.snapshot_details: dict[str, dict] = {}
         self.clone_details: dict[str, dict] = {}
-        self.pre_upgrade_checksums: dict[str, dict] = {}
+
 
         self.logger.info(
             f"K8s native upgrade: {self.base_version} -> {self.target_version} "
@@ -539,6 +539,10 @@ class K8sNativeMajorUpgrade(TestClusterBase):
         """Capture MD5 checksums for all files on the given PVCs.
 
         Returns ``{pvc_name: {filepath: md5hash, ...}, ...}``.
+
+        NOTE: Currently unused in the upgrade flow — FIO's built-in
+        ``verify=md5`` + ``verify_only`` mode (Phase 4.1) is used instead.
+        Kept for future use when unmount/remount verification is needed.
         """
         all_checksums = {}
         for pvc_name in pvc_names:
@@ -577,6 +581,10 @@ class K8sNativeMajorUpgrade(TestClusterBase):
         """Verify that current PVC data matches previously captured checksums.
 
         Raises ``AssertionError`` if any checksum mismatch is found.
+
+        NOTE: Currently unused in the upgrade flow — FIO's built-in
+        ``verify=md5`` + ``verify_only`` mode (Phase 4.1) is used instead.
+        Kept for future use when unmount/remount verification is needed.
         """
         mismatches = []
         for pvc_name, expected in pre_checksums.items():
@@ -2208,11 +2216,6 @@ spec:
         self.logger.info("Pre-upgrade Step 4.1: Running FIO on clones")
         self._run_fio_on_clones(runtime=60)
 
-        # Capture MD5 checksums on all PVCs and clones before upgrade
-        self.logger.info("Pre-upgrade Step 5: Capturing MD5 checksums before upgrade")
-        all_volume_names = list(self.pvc_details.keys()) + list(self.clone_details.keys())
-        self.pre_upgrade_checksums = self._capture_pvc_checksums(all_volume_names)
-
         # Phase 2.7: Capture pre-upgrade state
         self._capture_pre_upgrade_state()
 
@@ -2287,17 +2290,6 @@ spec:
             cluster_id=self.cluster_id, status="active", timeout=600,
         )
         self._assert_all_nodes_healthy()
-
-        # Verify MD5 checksums match post-upgrade
-        if hasattr(self, "pre_upgrade_checksums") and self.pre_upgrade_checksums:
-            self.logger.info(
-                "Post-upgrade: Verifying MD5 checksums match pre-upgrade data"
-            )
-            self._verify_pvc_checksums(self.pre_upgrade_checksums, "post-upgrade")
-        else:
-            self.logger.warning(
-                "No pre-upgrade checksums available — skipping MD5 verification"
-            )
 
         # Phase 4.1–4.3: Verify old data survives the upgrade
         self.logger.info("Post-upgrade: Verifying old data integrity")

--- a/e2e/e2e_tests/upgrade_tests/k8s_major_upgrade.py
+++ b/e2e/e2e_tests/upgrade_tests/k8s_major_upgrade.py
@@ -509,12 +509,17 @@ class K8sNativeMajorUpgrade(TestClusterBase):
             self._save_fio_pod_logs(detail["job_name"], clone_name)
             self.k8s_utils.validate_fio_job(detail["job_name"], timeout=timeout)
 
-    def _cleanup_fio_jobs_only(self):
+    def _cleanup_fio_jobs_only(self, wait_for_termination: bool = True,
+                               termination_timeout: int = 120):
         """Delete FIO jobs and configmaps but leave PVCs/snapshots/clones intact.
 
         Unlike ``k8s_utils.cleanup_stale_fio_resources()`` which also removes
         clone PVCs, snapshots, and test PVCs, this only removes the FIO
         workload resources so PVCs are freed for utility pod mounting.
+
+        When *wait_for_termination* is True (default), waits for all FIO
+        pods to fully terminate and gives CSI time to finish unmounting
+        before returning.  This ensures no stale mounts remain.
         """
         ns = self.k8s_utils.namespace
         cmds = [
@@ -533,7 +538,40 @@ class K8sNativeMajorUpgrade(TestClusterBase):
                 self.k8s_utils._exec_kubectl(cmd)
             except Exception as exc:
                 self.logger.warning(f"FIO job cleanup step failed: {exc}")
-        self.logger.info("FIO jobs and configmaps cleaned up (PVCs preserved)")
+        self.logger.info("FIO jobs and configmaps deleted")
+
+        if not wait_for_termination:
+            return
+
+        # Wait for all FIO pods to fully terminate
+        import time
+        deadline = time.time() + termination_timeout
+        self.logger.info(
+            f"Waiting up to {termination_timeout}s for FIO pods to terminate..."
+        )
+        while time.time() < deadline:
+            out, _ = self.k8s_utils._exec_kubectl(
+                f"kubectl get pods -n {ns} -l app=fio-benchmark "
+                f"--no-headers 2>/dev/null || true",
+                supress_logs=True,
+            )
+            pods = [l for l in out.strip().splitlines() if l.strip()]
+            if not pods:
+                self.logger.info("All FIO pods terminated")
+                break
+            self.logger.info(f"  {len(pods)} FIO pod(s) still terminating...")
+            time.sleep(5)
+        else:
+            self.logger.warning(
+                f"FIO pods did not fully terminate within {termination_timeout}s"
+            )
+
+        # Give CSI NodeUnstageVolume / NodeUnpublishVolume time to complete
+        # after pods are gone — ensures no stale mounts remain on worker nodes
+        self.logger.info("Waiting 15s for CSI unmount to complete...")
+        time.sleep(15)
+
+        self.logger.info("FIO jobs and pods cleaned up (PVCs preserved)")
 
     def _capture_pvc_checksums(self, pvc_names: list[str]) -> dict[str, dict]:
         """Capture MD5 checksums for all files on the given PVCs.
@@ -2204,10 +2242,9 @@ spec:
         self._validate_all_fio(fio_timeout)
         self.logger.info("Pre-upgrade FIO completed and validated on all PVCs")
 
-        # Clean up FIO jobs/pods (preserve PVCs for snapshots + checksums)
-        self.logger.info("Pre-upgrade: Cleaning up FIO jobs")
-        self._cleanup_fio_jobs_only()
-        sleep_n_sec(10)
+        # Clean up FIO jobs/pods and wait for full termination + volume detach
+        self.logger.info("Pre-upgrade: Cleaning up FIO jobs and waiting for clean unmount")
+        self._cleanup_fio_jobs_only(wait_for_termination=True)
 
         self.logger.info("Pre-upgrade Step 4: Creating snapshots and clones")
         self._create_snapshots_and_clones(skip_clone_fio=True)

--- a/e2e/e2e_tests/upgrade_tests/k8s_major_upgrade.py
+++ b/e2e/e2e_tests/upgrade_tests/k8s_major_upgrade.py
@@ -656,7 +656,6 @@ class K8sNativeMajorUpgrade(TestClusterBase):
                 )
 
         # --- 2. Delete stale VolumeAttachments for upgrade PVCs ---
-        ns = self.k8s_utils.namespace
         pvc_names = list(self.pvc_details.keys()) + list(self.clone_details.keys())
         if pvc_names:
             self.logger.info("Checking for stale VolumeAttachments...")

--- a/e2e/e2e_tests/upgrade_tests/k8s_major_upgrade.py
+++ b/e2e/e2e_tests/upgrade_tests/k8s_major_upgrade.py
@@ -573,6 +573,124 @@ class K8sNativeMajorUpgrade(TestClusterBase):
 
         self.logger.info("FIO jobs and pods cleaned up (PVCs preserved)")
 
+    def _cleanup_worker_connections(self):
+        """Unmount stale CSI volumes and disconnect NVMe-oF on every worker.
+
+        After FIO pods are deleted and CSI has had time to unmount, there
+        may still be stale mount-points or NVMe-oF connections left on
+        worker nodes (especially if CSI cleanup didn't fully succeed).
+        This method runs host-level cleanup on each worker via
+        ``oc debug node/`` (OpenShift) or ``kubectl debug node/`` (K8s).
+
+        Also deletes any lingering VolumeAttachment objects for upgrade
+        PVCs so Kubernetes doesn't think the volumes are still attached.
+        """
+        import time
+
+        # --- 1. Get worker node names ---
+        worker_nodes_env = os.environ.get("WORKER_NODES", "")
+        worker_names = []
+        if worker_nodes_env:
+            worker_names = [n.strip() for n in worker_nodes_env.split(",")
+                           if n.strip()]
+        else:
+            out, _ = self.k8s_utils._exec_kubectl(
+                "kubectl get nodes -l node-role.kubernetes.io/worker "
+                "-o jsonpath='{.items[*].metadata.name}' 2>/dev/null || "
+                "kubectl get nodes --no-headers "
+                "-o custom-columns=NAME:.metadata.name",
+                supress_logs=True,
+            )
+            worker_names = [n.strip() for n in (out or "").replace("'", "").split()
+                            if n.strip()]
+
+        if not worker_names:
+            self.logger.warning("No worker nodes found, skipping connection cleanup")
+            return
+
+        self.logger.info(
+            f"Cleaning stale mounts and NVMe connections on {len(worker_names)} "
+            f"worker(s): {worker_names}"
+        )
+
+        is_openshift = self.k8s_utils.detect_openshift()
+
+        # Host-level cleanup script:
+        # 1) Find and unmount any simplyblock CSI volume mounts
+        # 2) Disconnect all NVMe-oF subsystems
+        cleanup_script = (
+            "for mp in $(mount | grep 'kubernetes.io~csi' | awk '{print $3}'); do "
+            "  umount -f \"$mp\" 2>/dev/null || true; "
+            "done; "
+            "nvme disconnect-all 2>/dev/null || true; "
+            "echo CLEANUP_DONE"
+        )
+
+        for node_name in worker_names:
+            self.logger.info(f"  Cleaning worker: {node_name}")
+            try:
+                if is_openshift:
+                    cmd = (
+                        f"oc debug node/{node_name} "
+                        f"-- chroot /host bash -c "
+                        f"'{cleanup_script}'"
+                    )
+                else:
+                    cmd = (
+                        f"kubectl debug node/{node_name} -q "
+                        f"--image=busybox:latest -- chroot /host sh -c "
+                        f"'{cleanup_script}'"
+                    )
+                out, _ = self.k8s_utils._exec_kubectl(cmd, timeout=120)
+                if "CLEANUP_DONE" in (out or ""):
+                    self.logger.info(f"  Worker {node_name}: cleanup completed")
+                else:
+                    self.logger.warning(
+                        f"  Worker {node_name}: cleanup may not have completed "
+                        f"(output: {(out or '')[:200]})"
+                    )
+            except Exception as exc:
+                self.logger.warning(
+                    f"  Worker {node_name}: cleanup failed: {exc}"
+                )
+
+        # --- 2. Delete stale VolumeAttachments for upgrade PVCs ---
+        ns = self.k8s_utils.namespace
+        pvc_names = list(self.pvc_details.keys()) + list(self.clone_details.keys())
+        if pvc_names:
+            self.logger.info("Checking for stale VolumeAttachments...")
+            try:
+                out, _ = self.k8s_utils._exec_kubectl(
+                    "kubectl get volumeattachments -o json 2>/dev/null || true",
+                    supress_logs=True,
+                )
+                if out and out.strip():
+                    va_data = json.loads(out)
+                    for va in va_data.get("items", []):
+                        pv_name = va.get("spec", {}).get("source", {}).get(
+                            "persistentVolumeName", ""
+                        )
+                        va_name = va.get("metadata", {}).get("name", "")
+                        # Check if this VA references one of our PVs
+                        # PV names match PVC names in CSI provisioner
+                        for pvc in pvc_names:
+                            if pvc in pv_name:
+                                self.logger.info(
+                                    f"  Deleting stale VolumeAttachment: {va_name} "
+                                    f"(PV: {pv_name})"
+                                )
+                                self.k8s_utils._exec_kubectl(
+                                    f"kubectl delete volumeattachment {va_name} "
+                                    f"--ignore-not-found",
+                                )
+                                break
+            except Exception as exc:
+                self.logger.warning(f"VolumeAttachment cleanup failed: {exc}")
+
+        self.logger.info("Worker connection cleanup complete")
+        # Brief pause for cleanup to propagate
+        time.sleep(10)
+
     def _capture_pvc_checksums(self, pvc_names: list[str]) -> dict[str, dict]:
         """Capture MD5 checksums for all files on the given PVCs.
 
@@ -2255,6 +2373,17 @@ spec:
 
         # Phase 2.7: Capture pre-upgrade state
         self._capture_pre_upgrade_state()
+
+        # Phase 2.8: Clean stale mounts and NVMe connections on worker nodes
+        # After all FIO pods are gone and CSI has unmounted, force-clean any
+        # leftover mount-points and NVMe-oF connections on every worker node.
+        # This prevents stale device references from causing I/O errors when
+        # storage nodes are shut down and restarted during the upgrade.
+        self.logger.info(
+            "Pre-upgrade: Cleaning worker node connections "
+            "(unmount + NVMe disconnect)"
+        )
+        self._cleanup_worker_connections()
 
         # ── Begin maintenance window ──
         self.logger.info("=" * 40 + " MAINTENANCE WINDOW START " + "=" * 40)

--- a/e2e/e2e_tests/upgrade_tests/k8s_major_upgrade.py
+++ b/e2e/e2e_tests/upgrade_tests/k8s_major_upgrade.py
@@ -510,7 +510,7 @@ class K8sNativeMajorUpgrade(TestClusterBase):
             self.k8s_utils.validate_fio_job(detail["job_name"], timeout=timeout)
 
     def _cleanup_fio_jobs_only(self, wait_for_termination: bool = True,
-                               termination_timeout: int = 120):
+                               termination_timeout: int = 300):
         """Delete FIO jobs and configmaps but leave PVCs/snapshots/clones intact.
 
         Unlike ``k8s_utils.cleanup_stale_fio_resources()`` which also removes
@@ -568,8 +568,8 @@ class K8sNativeMajorUpgrade(TestClusterBase):
 
         # Give CSI NodeUnstageVolume / NodeUnpublishVolume time to complete
         # after pods are gone — ensures no stale mounts remain on worker nodes
-        self.logger.info("Waiting 15s for CSI unmount to complete...")
-        time.sleep(15)
+        self.logger.info("Waiting 60s for CSI unmount to complete...")
+        time.sleep(60)
 
         self.logger.info("FIO jobs and pods cleaned up (PVCs preserved)")
 

--- a/e2e/e2e_tests/upgrade_tests/major_upgrade.py
+++ b/e2e/e2e_tests/upgrade_tests/major_upgrade.py
@@ -983,9 +983,9 @@ print("done")
                 if not self.k8s_test:
                     for node in self.storage_nodes:
                         self.ssh_obj.restart_docker_logging(
-                            node_ip=snode,
+                            node_ip=node,
                             containers=self.container_nodes[node],
-                            log_dir=os.path.join(self.docker_logs_path, snode),
+                            log_dir=os.path.join(self.docker_logs_path, node),
                             test_name=self.test_name,
                         )
                 else:

--- a/e2e/e2e_tests/upgrade_tests/major_upgrade.py
+++ b/e2e/e2e_tests/upgrade_tests/major_upgrade.py
@@ -998,7 +998,7 @@ print("done")
             self.validate_migration_for_node(
                 timestamp=migration_ts,
                 timeout=1800,
-                node_id=node_id,
+                node_id=None,
                 check_interval=30,
                 no_task_ok=(not self.fio_during_upgrade),
             )
@@ -1602,7 +1602,7 @@ class TestMajorUpgradeDualNode(TestMajorUpgrade):
                 self.validate_migration_for_node(
                     timestamp=migration_ts,
                     timeout=1800,
-                    node_id=nid,
+                    node_id=None,
                     check_interval=30,
                     no_task_ok=(not self.fio_during_upgrade),
                 )

--- a/e2e/load.py
+++ b/e2e/load.py
@@ -102,7 +102,7 @@ tests = get_load_tests()
 selected_test = None
 
 for cls in tests:
-    if args.testname.lower() in cls.__name__.lower():
+    if args.testname.lower() == cls.__name__.lower():
         selected_test = cls
         break
 

--- a/e2e/stress.py
+++ b/e2e/stress.py
@@ -60,7 +60,7 @@ def main():
         seen = set()
         for needle in needles:
             for cls in tests:
-                if needle in cls.__name__.lower().replace("_", "") and cls not in seen:
+                if needle == cls.__name__.lower().replace("_", "") and cls not in seen:
                     test_class_run.append(cls)
                     seen.add(cls)
 

--- a/e2e/upgrade_e2e.py
+++ b/e2e/upgrade_e2e.py
@@ -82,7 +82,10 @@ def main():
                     f"[cleanup] Test {test.__name__} failed — preserving K8s "
                     "resources for debugging (--preserve_resources_on_failure)"
                 )
-            test_obj.teardown(skip_k8s_cleanup=_skip_k8s)
+            test_obj.teardown(
+                delete_lvols=not _skip_k8s,
+                skip_k8s_cleanup=_skip_k8s,
+            )
         except Exception as _:
             logger.error(f"Error During Teardown for test: {test.__name__}")
             logger.error(traceback.format_exc())

--- a/e2e/upgrade_e2e.py
+++ b/e2e/upgrade_e2e.py
@@ -35,7 +35,7 @@ def main():
     else:
         for cls in upgrade_tests:
             needle = args.testname.lower().replace("_", "")
-            if needle in cls.__name__.lower().replace("_", ""):
+            if needle == cls.__name__.lower().replace("_", ""):
                 test_class_run.append(cls)
     passed_cases = []
     errors = {}

--- a/e2e/utils/k8s_utils.py
+++ b/e2e/utils/k8s_utils.py
@@ -2488,16 +2488,14 @@ class K8sUtils:
         """
         ns = namespace or self.namespace
 
-        # Quick pre-check: if the pod is stuck in PodInitializing or similar,
-        # report that immediately instead of waiting the full timeout.
+        # Quick pre-check: fail fast on image pull errors (unrecoverable).
+        # PodInitializing and ContainerCreating are normal transient states
+        # (e.g. init container running fio-warmup) — let them proceed.
         pod_name_pre = self.get_job_pod_name(job_name, namespace=ns)
         if pod_name_pre:
             detail = self.get_pod_status_detail(pod_name_pre, namespace=ns)
             reason = detail.get("reason", "")
-            if reason in (
-                "PodInitializing", "ContainerCreating",
-                "ErrImagePull", "ImagePullBackOff",
-            ):
+            if reason in ("ErrImagePull", "ImagePullBackOff"):
                 raise RuntimeError(
                     f"FIO Job '{job_name}' pod '{pod_name_pre}' never "
                     f"started: {reason} — {detail.get('message', '')}"


### PR DESCRIPTION
## Summary
- Fix cross-cluster backup restore end-to-end flow in Docker mode (CLI commands, cluster-id flags, bootstrap validation, restore polling)
- Fix K8s upgrade test reliability (R25 bootstrap params, FIO Multi-Attach, CR verification, data integrity via FIO verify_only)
- Standardize CI pipelines: GitHub summary, Slack notifications, and Graylog log collection across all 21 workflows
- Migrate Slack notifications from webhooks to Bot API enabling thread replies for log-collection-complete messages
- Fix teardown, testname matching, FIO validation, and --new_nodes argument quoting

## Cross-cluster backup restore
- Use CLI commands (sbctl) instead of API calls for multi-cluster Docker mode
- Add --cluster-id to all backup CLI commands (export, import, list, restore, source-switch)
- Use distinct pool names per cluster to avoid ambiguity
- Fix volume connect to use lvol ID instead of name
- Validate C2 bootstrap via actual state (sn list, cluster ACTIVE) instead of stderr parsing
- Fail fast when bootstrap steps (add-node, activate, pool) fail
- Poll restore task to completion before attempting volume connect
- Collect SPDK and management logs from C2 nodes

## K8s upgrade tests
- Fix R25 bootstrap: set lvol port offset, pass ndcs/npcs/partitions/jm_count
- Add CR verification to Step 7 of migration
- Fix Multi-Attach error on verify FIO by removing avoid_node scheduling
- Make pre-upgrade FIO mandatory with 600s timeout so all lvols have data before snapshots/clones
- Switch post-upgrade data integrity to FIO verify_only mode (checksum pod methods retained but unused)
- Pass node_id=None to validate_migration_for_node (cluster-wide tasks have no node_id)
- Fix validate_fio_job failing instantly on PodInitializing

## CI pipelines
- Standardize GitHub summary, Slack notifications, and Graylog log collection across all 21 workflows
- Migrate Slack from webhooks to Bot API (chat.postMessage) with webhook fallback
- Log-collection-complete notifications now post as thread replies under the test summary
- Fix teardown deletion order and docker logging target node
- Use exact class name matching for --testname in all test runners
- Quote NEW_NODE_IPS to fix argument splitting for multi-IP values