### PR TITLE
Improve slow integration test timeout behavior

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,4 +72,4 @@ jobs:
       - name: Run slow integration tests
         run: tox run -e integration-slow
         env:
-          PYTEST_ADDOPTS: -v
+          PYTEST_ADDOPTS: -v --durations=0 --durations-min=0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -70,6 +70,6 @@ jobs:
       - name: Install tox
         run: pip install tox
       - name: Run slow integration tests
-        run: tox run -e integration-slow
+        run: tox run -e integration-slow -- tests/integration/ -m slow --durations=0 --durations-min=0
         env:
-          PYTEST_ADDOPTS: -v --durations=0 --durations-min=0
+          PYTEST_ADDOPTS: -v


### PR DESCRIPTION
The global timeout is excessive, and one borked test is enough to reach it. This PR improves this by:
- lowering the global limit to something reasonable
- applying a default timeout to individual tests
- granting exceptions where necessary.