### PR TITLE
Fix SFAM 2796

### DIFF
--- a/simplyblock_cli/cli-reference.yaml
+++ b/simplyblock_cli/cli-reference.yaml
@@ -2511,11 +2511,6 @@ commands:
             help: "The target storage node id."
             dest: node
             type: str
-          - name: "--cluster-id"
-            help: "The target cluster id."
-            dest: cluster_id
-            type: str
-            required: true
       - name: export
         help: "Export backup metadata to a JSON file for cross-cluster restore."
         arguments:

--- a/simplyblock_cli/cli.py
+++ b/simplyblock_cli/cli.py
@@ -1036,7 +1036,6 @@ class CLIWrapper(CLIWrapperBase):
         subcommand.add_argument('--lvol', help='The new logical volume name.', type=str, dest='lvol_name', required=True)
         subcommand.add_argument('--pool', help='The target pool name or id.', type=str, dest='pool', required=True)
         subcommand.add_argument('--node', help='The target storage node id.', type=str, dest='node')
-        subcommand.add_argument('--cluster-id', help='The target cluster id.', type=str, dest='cluster_id', required=True)
 
     def init_backup__export(self, subparser):
         subcommand = self.add_sub_command(subparser, 'export', 'Export backup metadata to a JSON file for cross-cluster restore.')

--- a/simplyblock_cli/clibase.py
+++ b/simplyblock_cli/clibase.py
@@ -1037,14 +1037,14 @@ class CLIWrapperBase:
         return True
 
     def backup__restore(self, sub_command, args):
-        result, error = backup_controller.restore_backup(
-            args.backup_id, args.lvol_name, args.pool,
-            cluster_id=args.cluster_id,
-            target_node_id=getattr(args, 'node', None))
-        if error:
-            print(f"Error: {error}")
+        try:
+            lvol_id = backup_controller.restore_backup(
+                args.backup_id, args.lvol_name, args.pool,
+                target_node_id=getattr(args, 'node', None))
+        except (PreconditionError, RuntimeError) as e:
+            print(f"Error: {e}")
             return False
-        print(f"Restoring backup {args.backup_id} into new volume {result}")
+        print(f"Restoring backup {args.backup_id} into new volume {lvol_id}")
         return True
 
     def backup__export(self, sub_command, args):

--- a/simplyblock_core/controllers/backup_controller.py
+++ b/simplyblock_core/controllers/backup_controller.py
@@ -389,7 +389,7 @@ def backup_snapshot(snapshot_id, cluster_id=None):
     return final_backup_id, None
 
 
-def restore_backup(backup_id: str, lvol_name: str, pool_id_or_name: str, cluster_id: str,
+def restore_backup(backup_id: str, lvol_name: str, pool_id_or_name: str,
                    target_node_id: Optional[str] = None):
     """Restore a backup chain into a new fully-accessible lvol.
 
@@ -399,22 +399,30 @@ def restore_backup(backup_id: str, lvol_name: str, pool_id_or_name: str, cluster
     until the data transfer completes.
 
     Args:
-        target_node_id: Optional node to restore onto. If not provided,
-            restores to the original backup node. Any node in the cluster
+        target_node_id: Optional node to restore onto. If not provided, a node
+            of the target cluster is auto-selected. Any node in the cluster
             can restore any backup because S3 keys are node-agnostic
             ({s3_id}/{mid_flag}/{extent}) and all nodes share the same
             S3 bucket and credentials.
 
-    Returns (lvol_uuid, error_message).
+    Returns the uuid of the created volume.
     """
     from simplyblock_core.controllers import lvol_controller
     from simplyblock_core.models.lvol_model import LVol
 
     try:
         backup = db_controller.get_backup_by_id(backup_id)
-        cluster = db_controller.get_cluster_by_id(cluster_id)
+        pool = db_controller.get_pool_by_id_or_name(pool_id_or_name)
+        cluster = db_controller.get_cluster_by_id(pool.cluster_id)
+        target_node = db_controller.get_storage_node_by_id(target_node_id) if target_node_id is not None else None
+        chain = db_controller.get_backup_chain(backup_id)
+        if (incomplete := [
+            backup for backup in chain
+            if backup.status != Backup.STATUS_COMPLETED
+        ]):
+            raise PreconditionError("Incomplete backups in chain: " + ", ".join(backup.uuid for backup in incomplete))
     except KeyError as e:
-        return None, str(e)
+        raise PreconditionError(str(e)) from e
 
     # Verify the backup's source matches the active S3 source.
     # If the backup came from an external cluster, the S3 bdev must be
@@ -422,45 +430,38 @@ def restore_backup(backup_id: str, lvol_name: str, pool_id_or_name: str, cluster
     backup_src = backup.source_cluster_id or backup.cluster_id
     active_src = cluster.backup_source or cluster.uuid
     if backup_src != active_src:
-        return None, (
+        raise PreconditionError(
             f"Backup source is {backup_src[:8]} but active S3 source "
             f"is {active_src[:8]}. Use 'sbctl backup source-switch "
             f"{backup_src}' first.")
 
-    # Build the backup chain
-    chain = db_controller.get_backup_chain(backup_id)
-    if not chain:
-        return None, f"Could not build backup chain for {backup_id}"
-
     size = backup.size
     if size <= 0:
-        return None, "Backup has no size information"
+        raise PreconditionError("Backup has no size information")
 
-    # Determine target node: use explicit target, or fall back to backup node
-    restore_node_id = target_node_id or backup.node_id
+    if target_node is not None:
+        if target_node.cluster_id != cluster.uuid:
+            raise PreconditionError(
+                f"Target node {target_node_id} belongs to cluster "
+                f"{target_node.cluster_id[:8]}, not {cluster.uuid[:8]}")
 
-    # Validate target node is online and has an S3 bdev
-    try:
-        target_node = db_controller.get_storage_node_by_id(restore_node_id)
-    except KeyError:
-        return None, f"Target node {restore_node_id} not found"
+        if target_node.status != StorageNode.STATUS_ONLINE:
+            raise PreconditionError(f"Target node {target_node_id} is not online "
+                                    f"(status: {target_node.status})")
 
-    if target_node.status != StorageNode.STATUS_ONLINE:
-        return None, (f"Target node {restore_node_id} is not online "
-                      f"(status: {target_node.status})")
-
-    if not target_node.lvstore:
-        return None, f"Target node {restore_node_id} has no lvstore (S3 bdev requires lvstore)"
+        if not target_node.lvstore:
+            raise PreconditionError(
+                f"Target node {target_node_id} has no lvstore (S3 bdev requires lvstore)")
 
     if backup.encrypted:
         with create_kms_connection(cluster) as kms:
             try:
                 crypto_key = kms.get_data_encryption_keys(
-                    backup_dek_path(cluster_id, backup.uuid),
+                    backup_dek_path(pool.cluster_id, backup.uuid),
                     backup_kek_name(backup.uuid),
                 )
-            except KMSException:
-                return None, "Failed to retrieve backup crypto keys"
+            except KMSException as e:
+                raise RuntimeError("Failed to retrieve backup crypto keys") from e
     else:
         crypto_key = None
 
@@ -475,7 +476,7 @@ def restore_backup(backup_id: str, lvol_name: str, pool_id_or_name: str, cluster
         max_rw_mbytes=0,
         max_r_mbytes=0,
         max_w_mbytes=0,
-        host_id_or_name=restore_node_id,
+        host_id_or_name=target_node_id,
         ha_type="default",
         crypto_key=crypto_key,
         use_comp=False,
@@ -486,13 +487,13 @@ def restore_backup(backup_id: str, lvol_name: str, pool_id_or_name: str, cluster
         fabric="tcp",
     )
     if error or not lvol_id:
-        return None, f"Failed to create restore volume: {error}"
+        raise RuntimeError(f"Failed to create restore volume: {error}")
 
     # Mark volume as restoring
     try:
         lvol = db_controller.get_lvol_by_id(lvol_id)
-    except KeyError:
-        return None, f"Volume created but not found in DB: {lvol_id}"
+    except KeyError as e:
+        raise RuntimeError(f"Volume created but not found in DB: {lvol_id}") from e
 
     lvol.status = LVol.STATUS_RESTORING
     lvol.write_to_db()
@@ -500,22 +501,15 @@ def restore_backup(backup_id: str, lvol_name: str, pool_id_or_name: str, cluster
     # The bdev name the data plane expects (e.g. LVS_7744/LVOL_12345)
     bdev_name = f"{lvol.lvs_name}/{lvol.lvol_bdev}"
 
-    # Only include completed backups — incomplete ones have no metadata in S3
     # Data plane processes s3_ids in array order: the first entry's clusters
     # take priority (skip-if-populated).  Newest-first means the latest
     # incremental data wins, with older backups filling any remaining gaps.
-    completed_chain = [b for b in reversed(chain)
-                       if b.status == Backup.STATUS_COMPLETED]
-    if not completed_chain:
-        return None, "No completed backups in chain"
+    if not tasks_controller.add_backup_restore_task(
+            pool.cluster_id, lvol.node_id, backup_id, bdev_name,
+            [b.s3_id for b in reversed(chain)], lvol_id=lvol_id):
+        raise RuntimeError("Failed to create restore task")
 
-    result = tasks_controller.add_backup_restore_task(
-        cluster_id, lvol.node_id, backup_id, bdev_name,
-        [b.s3_id for b in completed_chain], lvol_id=lvol_id)
-
-    if result:
-        return lvol_id, None
-    return None, "Failed to create restore task"
+    return lvol_id
 
 
 def _cleanup_backup_kms_keys(backups):

--- a/simplyblock_core/db_controller.py
+++ b/simplyblock_core/db_controller.py
@@ -26,7 +26,7 @@ from simplyblock_core.models.stats import DeviceStatObject, NodeStatObject, Clus
     PoolStatObject, CachedLVolStatObject
 from simplyblock_core.models.storage_node import StorageNode, NodeLVolDelLock
 from simplyblock_core.models.lvstore_lock import LVStoreMutationLock
-from simplyblock_core.utils.helpers import single_or_none
+from simplyblock_core.utils.helpers import single, single_or_none
 
 logger = logging.getLogger(__name__)
 
@@ -1371,17 +1371,17 @@ class DBController(metaclass=Singleton):
 
     def get_backup_chain(self, backup_id: str) -> List[Backup]:
         """Return the full backup chain ending at backup_id, oldest first."""
+        backups = self.get_backups()  # Avoid retrieving all backups multiple times
+
+        def find_backup(id_):
+            return single(backup for backup in backups if backup.uuid == id_)
+
+        next_id = backup_id
         chain = []
-        current_id = backup_id
-        visited = set()
-        while current_id and current_id not in visited:
-            visited.add(current_id)
-            try:
-                backup = self.get_backup_by_id(current_id)
-            except KeyError:
-                break
-            chain.append(backup)
-            current_id = backup.prev_backup_id
+        while next_id:
+            chain.append(find_backup(next_id))
+            next_id = chain[-1].prev_backup_id
+
         chain.reverse()
         return chain
 

--- a/simplyblock_web/api/v2/cluster/backup.py
+++ b/simplyblock_web/api/v2/cluster/backup.py
@@ -55,12 +55,8 @@ class _RestoreParams(BaseModel):
 
 @api.post('/restore', name='clusters:backups:restore', status_code=202)
 def restore_backup(cluster: Cluster, parameters: _RestoreParams):
-    result, error = backup_controller.restore_backup(
-        parameters.backup_id, parameters.lvol_name, parameters.pool,
-        cluster_id=cluster.get_id(), target_node_id=parameters.target_node_id)
-    if error:
-        raise HTTPException(400, error)
-    return {"lvol_id": result}
+    return {"lvol_id": backup_controller.restore_backup(
+        parameters.backup_id, parameters.lvol_name, parameters.pool, target_node_id=parameters.target_node_id)}
 
 
 class _ImportParams(BaseModel):

--- a/tests/integration/test_backup.py
+++ b/tests/integration/test_backup.py
@@ -25,6 +25,7 @@ import time
 import pytest
 
 from simplyblock_core.db_controller import DBController
+from simplyblock_core.exceptions import PreconditionError
 from simplyblock_core.models.backup import Backup, BackupPolicy, BackupPolicyAttachment
 from simplyblock_core.models.cluster import Cluster
 from simplyblock_core.models.job_schedule import JobSchedule
@@ -606,16 +607,14 @@ class TestRestoreBackup(unittest.TestCase):
         mock_lvol.lvol_bdev = "LVOL_123"
         mock_lvol.write_to_db = MagicMock()
         mock_db.get_lvol_by_id.return_value = mock_lvol
-        mock_db.get_storage_node_by_id.return_value = _node()
 
         with patch("simplyblock_core.controllers.lvol_controller.add_lvol_ha") as mock_add_ha:
             mock_add_ha.return_value = ("lvol-new", None)
 
             from simplyblock_core.controllers.backup_controller import restore_backup
-            result, error = restore_backup("backup-1", "restored_lvol", "pool-1", cluster_uuid)
+            result = restore_backup("backup-1", "restored_lvol", "pool-1")
 
         self.assertEqual(result, "lvol-new")
-        self.assertIsNone(error)
         # Verify s3_id integers are passed, not UUIDs
         call_args = mock_tasks.add_backup_restore_task.call_args
         self.assertEqual(call_args[0][4], [5])
@@ -625,17 +624,14 @@ class TestRestoreBackup(unittest.TestCase):
         mock_db.get_backup_by_id.side_effect = KeyError("not found")
 
         from simplyblock_core.controllers.backup_controller import restore_backup
-        result, error = restore_backup("missing", "lvol", "pool-1", "cluster-1")
-
-        self.assertIsNone(result)
-        self.assertIsNotNone(error)
+        with self.assertRaises(PreconditionError):
+            restore_backup("missing", "lvol", "pool-1")
 
     @patch("simplyblock_core.controllers.backup_controller.db_controller")
     def test_add_lvol_ha_fails(self, mock_db):
         cluster_uuid = "00000000-0000-0000-0000-000000000001"
         mock_db.get_backup_by_id.return_value = _backup(cluster_id=cluster_uuid)
         mock_db.get_backup_chain.return_value = [_backup(cluster_id=cluster_uuid)]
-        mock_db.get_storage_node_by_id.return_value = _node()
 
         mock_cluster = MagicMock()
         mock_cluster.uuid = cluster_uuid
@@ -646,10 +642,8 @@ class TestRestoreBackup(unittest.TestCase):
             mock_add_ha.return_value = (None, "Pool not found")
 
             from simplyblock_core.controllers.backup_controller import restore_backup
-            result, error = restore_backup("backup-1", "lvol", "bad-pool", cluster_uuid)
-
-        self.assertIsNone(result)
-        self.assertIn("Failed to create restore volume", error)
+            with self.assertRaisesRegex(RuntimeError, "Failed to create restore volume"):
+                restore_backup("backup-1", "lvol", "bad-pool")
 
 
 # ===========================================================================

--- a/tests/unit/test_backup_restore_node_selection.py
+++ b/tests/unit/test_backup_restore_node_selection.py
@@ -1,0 +1,201 @@
+# coding=utf-8
+"""Node selection in ``backup_controller.restore_backup``.
+
+A backup's ``node_id`` records the node the backup was taken from, which for an
+imported backup belongs to the source cluster.  Restore must never place the
+new volume there: without an explicit target node the placement is left to
+``add_lvol_ha``, which picks a node of the cluster owning the pool.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from simplyblock_core.exceptions import PreconditionError
+from simplyblock_core.models.backup import Backup
+from simplyblock_core.models.storage_node import StorageNode
+
+
+TARGET_CLUSTER = "00000000-0000-0000-0000-00000000000c"
+SOURCE_CLUSTER = "00000000-0000-0000-0000-00000000000f"
+
+
+def _backup(node_id, cluster_id=TARGET_CLUSTER, source_cluster_id=""):
+    backup = Backup()
+    backup.uuid = "backup-1"
+    backup.s3_id = 5
+    backup.node_id = node_id
+    backup.cluster_id = cluster_id
+    backup.source_cluster_id = source_cluster_id
+    backup.size = 1024
+    backup.status = Backup.STATUS_COMPLETED
+    return backup
+
+
+def _node(uuid, cluster_id, status=StorageNode.STATUS_ONLINE, lvstore="lvs_test"):
+    node = StorageNode()
+    node.uuid = uuid
+    node.cluster_id = cluster_id
+    node.status = status
+    node.lvstore = lvstore
+    return node
+
+
+@pytest.fixture
+def db():
+    with patch("simplyblock_core.controllers.backup_controller.db_controller") as db:
+        pool = MagicMock()
+        pool.cluster_id = TARGET_CLUSTER
+        db.get_pool_by_id_or_name.return_value = pool
+
+        cluster = MagicMock()
+        cluster.uuid = TARGET_CLUSTER
+        cluster.backup_source = ""
+        db.get_cluster_by_id.return_value = cluster
+
+        lvol = MagicMock()
+        lvol.node_id = "target-node"
+        lvol.lvs_name = "lvs_test"
+        lvol.lvol_bdev = "LVOL_123"
+        db.get_lvol_by_id.return_value = lvol
+        yield db
+
+
+@pytest.fixture
+def add_lvol_ha():
+    with patch("simplyblock_core.controllers.lvol_controller.add_lvol_ha") as add_lvol_ha:
+        add_lvol_ha.return_value = ("lvol-new", None)
+        yield add_lvol_ha
+
+
+@pytest.fixture
+def tasks():
+    with patch("simplyblock_core.controllers.backup_controller.tasks_controller") as tasks:
+        tasks.add_backup_restore_task.return_value = True
+        yield tasks
+
+
+def _restore(**kwargs):
+    from simplyblock_core.controllers.backup_controller import restore_backup
+    return restore_backup("backup-1", "restored_lvol", "pool-1", **kwargs)
+
+
+class TestImplicitNode:
+
+    def test_backup_node_is_not_used_for_placement(self, db, add_lvol_ha, tasks):
+        """An imported backup's node_id points into the source cluster."""
+        backup = _backup(node_id="source-cluster-node", source_cluster_id=SOURCE_CLUSTER)
+        db.get_backup_by_id.return_value = backup
+        db.get_backup_chain.return_value = [backup]
+        db.get_cluster_by_id.return_value.backup_source = SOURCE_CLUSTER
+
+        assert _restore() == "lvol-new"
+        assert not add_lvol_ha.call_args.kwargs["host_id_or_name"]
+
+    def test_no_node_lookup_without_explicit_target(self, db, add_lvol_ha, tasks):
+        backup = _backup(node_id="source-cluster-node", source_cluster_id=SOURCE_CLUSTER)
+        db.get_backup_by_id.return_value = backup
+        db.get_backup_chain.return_value = [backup]
+        db.get_cluster_by_id.return_value.backup_source = SOURCE_CLUSTER
+
+        _restore()
+
+        db.get_storage_node_by_id.assert_not_called()
+
+    def test_restore_task_targets_the_node_the_volume_landed_on(self, db, add_lvol_ha, tasks):
+        backup = _backup(node_id="source-cluster-node", source_cluster_id=SOURCE_CLUSTER)
+        db.get_backup_by_id.return_value = backup
+        db.get_backup_chain.return_value = [backup]
+        db.get_cluster_by_id.return_value.backup_source = SOURCE_CLUSTER
+
+        _restore()
+
+        cluster_id, node_id, *_ = tasks.add_backup_restore_task.call_args.args
+        assert cluster_id == TARGET_CLUSTER
+        assert node_id == "target-node"
+
+
+class TestExplicitNode:
+
+    @pytest.fixture(autouse=True)
+    def _local_backup(self, db):
+        backup = _backup(node_id="target-node")
+        db.get_backup_by_id.return_value = backup
+        db.get_backup_chain.return_value = [backup]
+
+    def test_target_node_is_passed_through(self, db, add_lvol_ha, tasks):
+        db.get_storage_node_by_id.return_value = _node("other-node", TARGET_CLUSTER)
+
+        assert _restore(target_node_id="other-node") == "lvol-new"
+        assert add_lvol_ha.call_args.kwargs["host_id_or_name"] == "other-node"
+
+    def test_node_of_another_cluster_is_rejected(self, db, add_lvol_ha):
+        db.get_storage_node_by_id.return_value = _node("foreign-node", SOURCE_CLUSTER)
+
+        with pytest.raises(PreconditionError, match="belongs to cluster"):
+            _restore(target_node_id="foreign-node")
+
+        add_lvol_ha.assert_not_called()
+
+    def test_offline_node_is_rejected(self, db, add_lvol_ha):
+        db.get_storage_node_by_id.return_value = _node(
+            "other-node", TARGET_CLUSTER, status=StorageNode.STATUS_OFFLINE)
+
+        with pytest.raises(PreconditionError, match="not online"):
+            _restore(target_node_id="other-node")
+
+        add_lvol_ha.assert_not_called()
+
+    def test_node_without_lvstore_is_rejected(self, db, add_lvol_ha):
+        db.get_storage_node_by_id.return_value = _node("other-node", TARGET_CLUSTER, lvstore="")
+
+        with pytest.raises(PreconditionError, match="no lvstore"):
+            _restore(target_node_id="other-node")
+
+        add_lvol_ha.assert_not_called()
+
+    def test_unknown_node_is_rejected(self, db, add_lvol_ha):
+        db.get_storage_node_by_id.side_effect = KeyError("Storage node not found: ghost-node")
+
+        with pytest.raises(PreconditionError, match="not found"):
+            _restore(target_node_id="ghost-node")
+
+        add_lvol_ha.assert_not_called()
+
+
+class TestFailures:
+
+    @pytest.fixture(autouse=True)
+    def _local_backup(self, db):
+        backup = _backup(node_id="target-node")
+        db.get_backup_by_id.return_value = backup
+        db.get_backup_chain.return_value = [backup]
+
+    def test_source_mismatch_is_a_precondition(self, db, add_lvol_ha):
+        db.get_cluster_by_id.return_value.backup_source = SOURCE_CLUSTER
+
+        with pytest.raises(PreconditionError, match="source-switch"):
+            _restore()
+
+        add_lvol_ha.assert_not_called()
+
+    def test_incomplete_chain_is_rejected_before_creating_a_volume(self, db, add_lvol_ha):
+        db.get_backup_chain.return_value = [_backup(node_id="target-node")]
+        db.get_backup_chain.return_value[0].status = Backup.STATUS_PENDING
+
+        with pytest.raises(PreconditionError, match="Incomplete backups in chain"):
+            _restore()
+
+        add_lvol_ha.assert_not_called()
+
+    def test_volume_creation_failure_is_a_runtime_error(self, db, add_lvol_ha):
+        add_lvol_ha.return_value = (None, "Pool not found")
+
+        with pytest.raises(RuntimeError, match="Failed to create restore volume"):
+            _restore()
+
+    def test_task_creation_failure_is_a_runtime_error(self, db, add_lvol_ha, tasks):
+        tasks.add_backup_restore_task.return_value = False
+
+        with pytest.raises(RuntimeError, match="Failed to create restore task"):
+            _restore()

--- a/tests/unit/web/api/v2/test_backup_endpoints.py
+++ b/tests/unit/web/api/v2/test_backup_endpoints.py
@@ -70,7 +70,7 @@ class TestGetBackup:
 class TestRestoreBackup:
 
     def test_restores_backup(self, client, db, cluster, backup_controller):
-        backup_controller.restore_backup.return_value = (VOLUME_ID, None)
+        backup_controller.restore_backup.return_value = VOLUME_ID
 
         response = client.post(f'{BASE}/restore', json={
             'backup_id': BACKUP_ID,
@@ -81,8 +81,7 @@ class TestRestoreBackup:
         assert response.status_code == 202
         assert response.json() == {'lvol_id': VOLUME_ID}
         backup_controller.restore_backup.assert_called_once_with(
-            BACKUP_ID, 'restored-volume', 'pool-1',
-            cluster_id=CLUSTER_ID, target_node_id=None)
+            BACKUP_ID, 'restored-volume', 'pool-1', target_node_id=None)
 
 
 class TestBackupPolicies:


### PR DESCRIPTION
This fixes [SFAM-2796](https://simplyblock.atlassian.net/browse/SFAM-2796). The backup restore semantics were off:
- `target_node_id` was not a hint, but authoritative
- `pool` was deciding the cluster to restore on

Both individually lead to a possible cluster override, both being set to disagreeing clusters would (hopefully) lead to an error somewhere in the creation. This fixes both cases, and introduces a performance optimization where the complete list of backups is not retrieves multiple times in the same restore command.