### PR TITLE
Refuse import of present backups

### DIFF
--- a/simplyblock_core/controllers/backup_controller.py
+++ b/simplyblock_core/controllers/backup_controller.py
@@ -643,23 +643,32 @@ def import_backups(s3_metadata_list, cluster_id=None):
         s3_metadata_list: list of dicts with backup metadata.
         cluster_id: Target cluster to import into.  Required for cross-cluster
             restore so the backups are visible in the local cluster's DB.
+
+    Raises:
+        PreconditionError: One of the given backup IDs is already known.  Backup
+            lookups are not scoped by cluster, so a UUID reused across clusters
+            would make either record unaddressable.  All IDs are checked before
+            the first record is written, so nothing is imported in that case.
     """
-    imported = 0
+    pending = {}
     for meta in s3_metadata_list:
         backup_id = meta.get("backup_id")
         if not backup_id:
             continue
 
-        source_cluster = meta.get("cluster_id", "")
-        target_cluster = cluster_id or source_cluster
+        if backup_id in pending:
+            raise PreconditionError(f"Backup {backup_id} is listed more than once")
 
-        # Skip only if already registered for the target cluster
         try:
             existing = db_controller.get_backup_by_id(backup_id)
-            if existing.cluster_id == target_cluster:
-                continue  # already imported for this cluster
         except KeyError:
-            pass
+            pending[backup_id] = meta
+        else:
+            raise PreconditionError(f"Backup {backup_id} already exists in cluster {existing.cluster_id}")
+
+    for backup_id, meta in pending.items():
+        source_cluster = meta.get("cluster_id", "")
+        target_cluster = cluster_id or source_cluster
 
         backup = Backup()
         backup.uuid = backup_id
@@ -678,9 +687,8 @@ def import_backups(s3_metadata_list, cluster_id=None):
         backup.status = Backup.STATUS_COMPLETED
         backup.s3_metadata = meta
         backup.write_to_db()
-        imported += 1
 
-    return imported
+    return len(pending)
 
 
 def get_backup_sources(cluster_id):

--- a/tests/integration/test_backup.py
+++ b/tests/integration/test_backup.py
@@ -25,6 +25,7 @@ import time
 import pytest
 
 from simplyblock_core.db_controller import DBController
+from simplyblock_core.exceptions import PreconditionError
 from simplyblock_core.models.backup import Backup, BackupPolicy, BackupPolicyAttachment
 from simplyblock_core.models.cluster import Cluster
 from simplyblock_core.models.job_schedule import JobSchedule
@@ -1010,18 +1011,34 @@ class TestImportBackups(unittest.TestCase):
 
     @patch.object(Backup, 'write_to_db')
     @patch("simplyblock_core.controllers.backup_controller.db_controller")
-    def test_skip_existing(self, mock_db, _mock_write):
+    def test_existing_fails(self, mock_db, mock_write):
         existing = _backup(uuid="b-1")
         mock_db.get_backup_by_id.side_effect = lambda bid: existing if bid == "b-1" else (_ for _ in ()).throw(KeyError())
         mock_db.get_backups.return_value = [existing]
 
         from simplyblock_core.controllers.backup_controller import import_backups
-        count = import_backups([
-            {"backup_id": "b-1", "lvol_id": "l-1", "cluster_id": "cluster-1"},
-            {"backup_id": "b-2", "lvol_id": "l-1", "cluster_id": "cluster-1"},
-        ])
+        with self.assertRaises(PreconditionError):
+            import_backups([
+                {"backup_id": "b-2", "lvol_id": "l-1", "cluster_id": "cluster-1"},
+                {"backup_id": "b-1", "lvol_id": "l-1", "cluster_id": "cluster-1"},
+            ])
 
-        self.assertEqual(count, 1)
+        mock_write.assert_not_called()
+
+    @patch.object(Backup, 'write_to_db')
+    @patch("simplyblock_core.controllers.backup_controller.db_controller")
+    def test_duplicate_in_metadata_fails(self, mock_db, mock_write):
+        mock_db.get_backup_by_id.side_effect = KeyError("not found")
+        mock_db.get_backups.return_value = []
+
+        from simplyblock_core.controllers.backup_controller import import_backups
+        with self.assertRaises(PreconditionError):
+            import_backups([
+                {"backup_id": "b-1", "lvol_id": "l-1", "cluster_id": "cluster-1"},
+                {"backup_id": "b-1", "lvol_id": "l-1", "cluster_id": "cluster-1"},
+            ])
+
+        mock_write.assert_not_called()
 
     @patch("simplyblock_core.controllers.backup_controller.db_controller")
     def test_skip_no_backup_id(self, mock_db):


### PR DESCRIPTION
This fixes [SFAM-2795](https://simplyblock.atlassian.net/browse/SFAM-2795). The import logic refuses to import backups that are already present.