### PR TITLE
Implemented fdbbackup runner abstraction which can be backed by Docker or Kubernetes

### DIFF
--- a/simplyblock_core/constants.py
+++ b/simplyblock_core/constants.py
@@ -102,6 +102,17 @@ GRAYLOG_CHECK_INTERVAL_SEC = 60
 # (run 2026-07-21).
 FDB_CLEANUP_INTERVAL_SEC = 60 * 60
 
+# Deployment mode of the FDB backup agent. Set to 'kubernetes' to run the
+# fdbbackup/fdbrestore/fdbcli commands in the agent pod through the kubernetes
+# API; anything else falls back to the management node's docker daemon.
+FDB_BACKUP_MODE = os.getenv('FDB_BACKUP_MODE', '')
+
+# Timeout for a single command executed inside the FDB backup agent
+# (fdbbackup/fdbrestore/fdbcli). `fdbbackup start -w` blocks until the backup
+# completed, so this has to cover a full backup run - the docker client's
+# 60s default silently aborted long backups with a read timeout.
+FDB_AGENT_EXEC_TIMEOUT_SEC = int(os.getenv('FDB_AGENT_EXEC_TIMEOUT_SEC', 60 * 60))
+
 # Continuous per-lvol NVMf subsystem verification + auto-repair in the lvol
 # monitor. ON by default since 2026-08-10.
 #

--- a/simplyblock_core/controllers/fdb_backup_controller.py
+++ b/simplyblock_core/controllers/fdb_backup_controller.py
@@ -5,70 +5,82 @@ import re
 import time
 import uuid
 
-import docker
-
 from simplyblock_core import utils, constants
 from simplyblock_core.db_controller import DBController
+from simplyblock_core.fdb_agent_client import (
+    MODE_KUBERNETES,
+    FdbAgent,
+    FdbAgentError,
+    FdbAgentNotFoundError,
+    KubernetesFdbAgent,
+    get_fdb_agent,
+)
 from simplyblock_core.models.job_schedule import JobSchedule
 
 logger = lg.getLogger()
 db_controller = DBController()
 
-def __get_fdb_cont():
-    snode = db_controller.get_mgmt_nodes()[0]
-    if not snode:
-        return
-    node_docker = docker.DockerClient(base_url=f"tcp://{snode.docker_ip_port}", version="auto")
-    for container in node_docker.containers.list():
-        if container.name.startswith("app_fdb-backup-agent"): # type: ignore[union-attr]
-            return container
+def __get_fdb_agent() -> FdbAgent:
+    """Return the agent executing FDB commands for this deployment.
+
+    ``FDB_BACKUP_MODE=kubernetes`` selects the kubernetes API backend
+    outright. Otherwise the management node's own mode decides, which needs
+    the node anyway for the address of its docker daemon.
+
+    :raises FdbAgentNotFoundError: the cluster has no management node
+    """
+    if constants.FDB_BACKUP_MODE == MODE_KUBERNETES:
+        return KubernetesFdbAgent()
+
+    nodes = db_controller.get_mgmt_nodes()
+    if not nodes:
+        raise FdbAgentNotFoundError("No management node found")
+    return get_fdb_agent(nodes[0])
 
 def create_backup(cluster_id):
-    container = __get_fdb_cont()
-    if container:
-        cluster = db_controller.get_cluster_by_id(cluster_id)
-        backup_path = cluster.get_backup_path()
-        if cluster.backup_s3_bucket and cluster.backup_s3_cred:
-            folder = f"backup-{str(datetime.datetime.now())}"
-            folder = folder.replace(" ", "-")
-            folder = folder.replace(":", "-")
-            folder = folder.split(".")[0]
-            backup_path = f"blobstore://{cluster.backup_s3_cred}@s3.{cluster.backup_s3_region}.amazonaws.com/{folder}?bucket={cluster.backup_s3_bucket}&region={cluster.backup_s3_region}&sc=0"
+    cluster = db_controller.get_cluster_by_id(cluster_id)
+    backup_path = cluster.get_backup_path()
+    if cluster.backup_s3_bucket and cluster.backup_s3_cred:
+        folder = f"backup-{str(datetime.datetime.now())}"
+        folder = folder.replace(" ", "-")
+        folder = folder.replace(":", "-")
+        folder = folder.split(".")[0]
+        backup_path = f"blobstore://{cluster.backup_s3_cred}@s3.{cluster.backup_s3_region}.amazonaws.com/{folder}?bucket={cluster.backup_s3_bucket}&region={cluster.backup_s3_region}&sc=0"
 
-        res = container.exec_run(cmd=f"fdbbackup start -d {backup_path} -w")
-        cont = res.output.decode("utf-8")
-        logger.info(cont)
-        return True
-    return False
+    try:
+        logger.info(__get_fdb_agent().exec(f"fdbbackup start -d {backup_path} -w"))
+    except FdbAgentError as e:
+        logger.error(f"Failed to create backup: {e}")
+        return False
+    return True
 
 def list_backups(cluster_id):
-    container = __get_fdb_cont()
+    cluster = db_controller.get_cluster_by_id(cluster_id)
+    backup_path = cluster.get_backup_path()
     data = []
-    if container:
-        cluster = db_controller.get_cluster_by_id(cluster_id)
-        backup_path = cluster.get_backup_path()
-        res = container.exec_run(cmd=f"fdbbackup list -b {backup_path}")
+    try:
+        agent = __get_fdb_agent()
+        output = agent.exec(f"fdbbackup list -b {backup_path}")
         logger.info(f"backup list from : {backup_path}")
-        cont = res.output.decode("utf-8")
-        for line in cont.splitlines():
+        for line in output.splitlines():
             if not line or "backup-" not in line:
                 continue
 
             name = line.split("/")[-1].strip()
             name = name.split("?")[0]
-            size = 0
-            restorable = 0
+            size = "0"
+            restorable = "0"
             date = ""
-            version = 0
-            res = container.exec_run(cmd=f"fdbbackup describe -d {cluster.get_backup_path(name)} --version-timestamps")
-            cont = res.output.decode("utf-8")
-            for line in cont.splitlines():
-                if line and line.startswith("SnapshotBytes"):
-                    size = line.split()[1].strip()
-                if line and line.startswith("Restorable"):
-                    restorable = line.split()[1].strip()
-                if line and line.startswith("Snapshot:"):
-                    for param in line.split():
+            version = "0"
+            description = agent.exec(
+                f"fdbbackup describe -d {cluster.get_backup_path(name)} --version-timestamps")
+            for desc_line in description.splitlines():
+                if desc_line and desc_line.startswith("SnapshotBytes"):
+                    size = desc_line.split()[1].strip()
+                if desc_line and desc_line.startswith("Restorable"):
+                    restorable = desc_line.split()[1].strip()
+                if desc_line and desc_line.startswith("Snapshot:"):
+                    for param in desc_line.split():
                         if param.startswith("startVersion"):
                             version = param.split("=")[1].strip()
                         elif param.startswith("(") and param.endswith(")") and not date:# 2025/12/28.10:10:20+0000
@@ -86,34 +98,36 @@ def list_backups(cluster_id):
                 "Restorable": restorable,
                 "Date": date,
             })
+    except FdbAgentError as e:
+        logger.error(f"Failed to list backups: {e}")
+        return False
 
-        return utils.print_table(data)
-
-    return True
+    return utils.print_table(data)
 
 
 
 def backup_status():
-    container = __get_fdb_cont()
-    if container:
-        res = container.exec_run(cmd="fdbbackup status")
-        cont = res.output.decode("utf-8")
-        logger.info(f"backup status: \n{cont.strip()}")
-        return True
+    try:
+        output = __get_fdb_agent().exec("fdbbackup status")
+    except FdbAgentError as e:
+        logger.error(f"Failed to get backup status: {e}")
+        return False
+    logger.info(f"backup status: \n{output.strip()}")
+    return True
 
 
 def backup_restore(backup_name, cluster_id):
-    container = __get_fdb_cont()
-    if container:
-        cluster = db_controller.get_cluster_by_id(cluster_id)
-        backup_path = cluster.get_backup_path(backup_name)
-        res = container.exec_run(cmd="fdbcli --exec \"writemode on; clearrange \\\"\\\" \\xff\"")
-        cont = res.output.decode("utf-8")
-        logger.info(cont.strip())
-        res = container.exec_run(cmd=f"fdbrestore start -r \"{backup_path}\" --dest-cluster-file {constants.KVD_DB_FILE_PATH}")
-        cont = res.output.decode("utf-8")
-        logger.info(cont.strip())
-        return True
+    cluster = db_controller.get_cluster_by_id(cluster_id)
+    backup_path = cluster.get_backup_path(backup_name)
+    try:
+        agent = __get_fdb_agent()
+        logger.info(agent.exec("fdbcli --exec \"writemode on; clearrange \\\"\\\" \\xff\"").strip())
+        logger.info(agent.exec(
+            f"fdbrestore start -r \"{backup_path}\" --dest-cluster-file {constants.KVD_DB_FILE_PATH}").strip())
+    except FdbAgentError as e:
+        logger.error(f"Failed to restore backup {backup_name}: {e}")
+        return False
+    return True
 
 
 def parse_history_param(history_string):
@@ -155,22 +169,20 @@ def backup_configure(cluster_id, backup_path, backup_frequency, bucket_name, reg
             cluster.write_to_db()
             return True
         else:
-            container = __get_fdb_cont()
-            if container:
-                backup_path = f"blobstore://{backup_credentials}@s3.{region_name}.amazonaws.com/?bucket={bucket_name}&region={region_name}&sc=0"
-                res = container.exec_run(cmd=f"fdbbackup list -b {backup_path}")
-                cont = res.output.decode("utf-8")
-                if res.exit_code == 0:
-                    logger.info(f"backup list from : {backup_path}")
-                    logger.info(cont)
-                    cluster.backup_s3_region = region_name if region_name else ""
-                    cluster.backup_s3_bucket = bucket_name if bucket_name else ""
-                    cluster.backup_s3_cred = backup_credentials if backup_credentials else ""
-                    cluster.write_to_db()
-                else:
-                    logger.error(f"Failed to list backup from s3: {backup_path}")
-                    logger.error(cont)
-                    return False
+            backup_path = f"blobstore://{backup_credentials}@s3.{region_name}.amazonaws.com/?bucket={bucket_name}&region={region_name}&sc=0"
+            try:
+                output = __get_fdb_agent().exec(f"fdbbackup list -b {backup_path}")
+            except FdbAgentError as e:
+                logger.error(f"Failed to list backup from s3: {backup_path}")
+                logger.error(e)
+                return False
+
+            logger.info(f"backup list from : {backup_path}")
+            logger.info(output)
+            cluster.backup_s3_region = region_name if region_name else ""
+            cluster.backup_s3_bucket = bucket_name if bucket_name else ""
+            cluster.backup_s3_cred = backup_credentials if backup_credentials else ""
+            cluster.write_to_db()
         return True
 
 def add_backup_task(cluster_id):

--- a/simplyblock_core/fdb_agent_client.py
+++ b/simplyblock_core/fdb_agent_client.py
@@ -1,0 +1,211 @@
+# coding=utf-8
+"""Command execution inside the FoundationDB backup agent.
+
+``fdbbackup``, ``fdbrestore`` and ``fdbcli`` only exist inside the FDB backup
+agent image, so every backup operation has to be executed there. How that
+agent is reached depends on the deployment mode of the management node:
+
+* ``docker`` — a container on the mgmt node's docker daemon, reached over the
+  docker remote API.
+* ``kubernetes`` — a pod in the cluster namespace, reached through the
+  kubernetes API (``kubectl`` is not available in the control plane image).
+
+:class:`FdbAgent` hides that difference behind a single ``exec()`` that takes a
+command line and returns its combined stdout/stderr as a utf-8 string, or
+raises :class:`FdbCommandError` when the command exits non-zero.
+"""
+
+import abc
+import re
+import shlex
+from typing import List, Sequence, Tuple, Union
+
+import docker
+from kubernetes import client as k8s_client
+from kubernetes.stream import stream as k8s_stream
+from requests.exceptions import ReadTimeout
+
+from simplyblock_core import constants, utils
+from simplyblock_core.models.mgmt_node import MgmtNode
+
+logger = utils.get_logger()
+
+
+MODE_KUBERNETES = "kubernetes"
+
+# Docker (swarm) deployments: the swarm task container of the
+# ``fdb-backup-agent`` service, see scripts/docker-compose-swarm.yml.
+DOCKER_CONTAINER_NAME_PREFIX = "app_fdb-backup-agent"
+
+# Kubernetes deployments: label selectors tried in order. The first selector
+# matching a running pod wins, so a chart that ships a dedicated backup agent
+# takes precedence over the FDB cluster pods (which carry the same binaries).
+K8S_POD_SELECTORS: Tuple[str, ...] = (
+    "app=fdb-backup-agent",
+    f"foundationdb.org/fdb-cluster-name={constants.FDB_SERVICE_NAME}",
+)
+
+Command = Union[str, Sequence[str]]
+
+# Backup paths are blobstore URLs carrying the S3 credentials inline
+# (blobstore://<key>:<secret>@s3...), so a command line must never be logged
+# or put into an error message verbatim.
+_BLOBSTORE_CRED_RE = re.compile(r"(blobstore://)[^@\s]+@", re.IGNORECASE)
+
+
+def redact(command: Sequence[str]) -> str:
+    """Render ``command`` as a single line with any inline credentials masked."""
+    return _BLOBSTORE_CRED_RE.sub(r"\1**********@", " ".join(command))
+
+
+class FdbAgentError(Exception):
+    """Base error for FDB backup agent command execution."""
+
+
+class FdbAgentNotFoundError(FdbAgentError):
+    """No FDB backup agent container/pod could be located."""
+
+
+class FdbCommandError(FdbAgentError):
+    """A command executed inside the FDB backup agent exited non-zero."""
+
+    def __init__(self, command: Sequence[str], exit_code: int, output: str):
+        super().__init__(
+            f"Command '{redact(command)}' failed with exit code {exit_code}: {output.strip()}")
+        self.command = list(command)
+        self.exit_code = exit_code
+        self.output = output
+
+
+class FdbCommandTimeoutError(FdbAgentError):
+    """A command executed inside the FDB backup agent did not finish in time."""
+
+    def __init__(self, command: Sequence[str], timeout: int):
+        super().__init__(f"Command '{redact(command)}' timed out after {timeout}s")
+        self.command = list(command)
+        self.timeout = timeout
+
+
+class FdbAgent(abc.ABC):
+    """Runs commands inside the cluster's FDB backup agent."""
+
+    def __init__(self, timeout: int = constants.FDB_AGENT_EXEC_TIMEOUT_SEC):
+        self._timeout = timeout
+
+    @abc.abstractmethod
+    def exec(self, command: Command) -> str:
+        """Run ``command`` inside the agent and return its combined
+        stdout/stderr, decoded as utf-8.
+
+        ``command`` is either an argument list or a shell-style string, which
+        is split with :func:`shlex.split` (the same splitting the docker API
+        applies to string commands).
+
+        :raises FdbAgentNotFoundError: the agent container/pod does not exist
+        :raises FdbCommandError: the command exited non-zero
+        :raises FdbCommandTimeoutError: the command exceeded the exec timeout
+        """
+
+    @staticmethod
+    def _argv(command: Command) -> List[str]:
+        return shlex.split(command) if isinstance(command, str) else list(command)
+
+
+class DockerFdbAgent(FdbAgent):
+    """Executes in the ``fdb-backup-agent`` container of a docker mgmt node."""
+
+    def __init__(self, docker_ip_port: str, timeout: int = constants.FDB_AGENT_EXEC_TIMEOUT_SEC):
+        super().__init__(timeout)
+        self._docker_ip_port = docker_ip_port
+
+    def _get_container(self):
+        node_docker = docker.DockerClient(
+            base_url=f"tcp://{self._docker_ip_port}", version="auto", timeout=self._timeout)
+        for container in node_docker.containers.list():
+            if (container.name or "").startswith(DOCKER_CONTAINER_NAME_PREFIX):
+                return container
+        raise FdbAgentNotFoundError(
+            f"No '{DOCKER_CONTAINER_NAME_PREFIX}*' container on docker host {self._docker_ip_port}")
+
+    def exec(self, command: Command) -> str:
+        argv = self._argv(command)
+        container = self._get_container()
+        logger.debug(f"Running '{redact(argv)}' in container {container.name}")
+        try:
+            result = container.exec_run(cmd=argv)
+        except ReadTimeout as e:
+            raise FdbCommandTimeoutError(argv, self._timeout) from e
+
+        output = (result.output or b"").decode("utf-8", errors="replace")
+        if result.exit_code != 0:
+            raise FdbCommandError(argv, result.exit_code, output)
+        return output
+
+
+class KubernetesFdbAgent(FdbAgent):
+    """Executes in the FDB backup agent pod through the kubernetes API."""
+
+    def __init__(self, namespace: str = constants.K8S_NAMESPACE,
+                 timeout: int = constants.FDB_AGENT_EXEC_TIMEOUT_SEC):
+        super().__init__(timeout)
+        self._namespace = namespace
+
+    def _get_core_api(self) -> k8s_client.CoreV1Api:
+        utils.load_kube_config_with_fallback()
+        return k8s_client.CoreV1Api()
+
+    def _get_pod_name(self, core_api: k8s_client.CoreV1Api) -> str:
+        for selector in K8S_POD_SELECTORS:
+            for pod in core_api.list_namespaced_pod(
+                    namespace=self._namespace, label_selector=selector).items:
+                if pod.status.phase == "Running":
+                    return pod.metadata.name
+        raise FdbAgentNotFoundError(
+            f"No running FDB backup agent pod in namespace {self._namespace} "
+            f"matching any of {list(K8S_POD_SELECTORS)}")
+
+    @staticmethod
+    def _get_exit_code(response) -> int:
+        """Exit code of a finished exec stream.
+
+        Must be read *before* ``read_all()``, which drops the channel buffers
+        the return code is parsed from. A stream that carries no error channel
+        payload is treated as success, which is what the API server sends for
+        a command that exited zero.
+        """
+        try:
+            return response.returncode or 0
+        except (TypeError, KeyError, ValueError, IndexError) as e:
+            logger.debug(f"Could not read exit code from exec stream, assuming success: {e}")
+            return 0
+
+    def exec(self, command: Command) -> str:
+        argv = self._argv(command)
+        core_api = self._get_core_api()
+        pod_name = self._get_pod_name(core_api)
+        logger.debug(f"Running '{redact(argv)}' in pod {self._namespace}/{pod_name}")
+
+        response = k8s_stream(
+            core_api.connect_get_namespaced_pod_exec,
+            name=pod_name, namespace=self._namespace, command=argv,
+            stderr=True, stdin=False, stdout=True, tty=False,
+            _preload_content=False)
+        try:
+            response.run_forever(timeout=self._timeout)
+            if response.is_open():
+                raise FdbCommandTimeoutError(argv, self._timeout)
+            exit_code = self._get_exit_code(response)
+            output = response.read_all()
+        finally:
+            response.close()
+
+        if exit_code != 0:
+            raise FdbCommandError(argv, exit_code, output)
+        return output
+
+
+def get_fdb_agent(mgmt_node: MgmtNode) -> FdbAgent:
+    """Return the :class:`FdbAgent` matching ``mgmt_node``'s deployment mode."""
+    if mgmt_node.mode == MODE_KUBERNETES:
+        return KubernetesFdbAgent()
+    return DockerFdbAgent(mgmt_node.docker_ip_port)

--- a/tests/unit/test_fdb_agent_client.py
+++ b/tests/unit/test_fdb_agent_client.py
@@ -1,0 +1,266 @@
+"""Tests for the FDB backup agent execution backends.
+
+``fdbbackup``/``fdbrestore``/``fdbcli`` run inside the FDB backup agent, which
+is a docker container on swarm deployments and a pod on kubernetes ones. Both
+backends must behave identically from the caller's point of view:
+
+  * a command line (string or argv) goes in, its combined stdout/stderr comes
+    back as a utf-8 ``str``,
+  * a non-zero exit raises ``FdbCommandError`` instead of being swallowed,
+  * a missing agent raises ``FdbAgentNotFoundError``,
+  * nothing that is logged or put into an exception message carries the S3
+    credentials embedded in a blobstore backup path.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from simplyblock_core import fdb_agent_client
+from simplyblock_core.fdb_agent_client import (
+    DockerFdbAgent,
+    FdbAgentNotFoundError,
+    FdbCommandError,
+    FdbCommandTimeoutError,
+    KubernetesFdbAgent,
+    get_fdb_agent,
+    redact,
+)
+from simplyblock_core.models.mgmt_node import MgmtNode
+
+BLOBSTORE_PATH = "blobstore://AKIAKEY:s3cr3t@s3.eu-west-1.amazonaws.com/backup-1?bucket=b&region=eu-west-1"
+
+
+def _docker_client(container):
+    client = MagicMock()
+    client.containers.list.return_value = [container] if container else []
+    return client
+
+
+def _container(name="app_fdb-backup-agent.1.abc", exit_code=0, output=b"ok"):
+    container = MagicMock()
+    container.name = name
+    container.exec_run.return_value = MagicMock(exit_code=exit_code, output=output)
+    return container
+
+
+def _pod(name="fdb-backup-agent-0", phase="Running"):
+    pod = MagicMock()
+    pod.metadata.name = name
+    pod.status.phase = phase
+    return pod
+
+
+def _core_api(pods_by_selector):
+    api = MagicMock()
+
+    def list_namespaced_pod(namespace, label_selector):
+        return MagicMock(items=pods_by_selector.get(label_selector, []))
+
+    api.list_namespaced_pod.side_effect = list_namespaced_pod
+    return api
+
+
+def _ws_response(output="ok", returncode=0, still_open=False):
+    response = MagicMock()
+    response.is_open.return_value = still_open
+    response.returncode = returncode
+    response.read_all.return_value = output
+    return response
+
+
+# --- docker backend --------------------------------------------------------
+
+def test_docker_exec_returns_decoded_output():
+    container = _container(output="héllo".encode("utf-8"))
+    with patch.object(fdb_agent_client.docker, "DockerClient",
+                      return_value=_docker_client(container)):
+        assert DockerFdbAgent("1.2.3.4:2375").exec("fdbbackup status") == "héllo"
+
+    container.exec_run.assert_called_once_with(cmd=["fdbbackup", "status"])
+
+
+def test_docker_exec_raises_on_non_zero_exit():
+    container = _container(exit_code=1, output=b"backup not found")
+    with patch.object(fdb_agent_client.docker, "DockerClient",
+                      return_value=_docker_client(container)):
+        with pytest.raises(FdbCommandError) as exc_info:
+            DockerFdbAgent("1.2.3.4:2375").exec("fdbbackup list -b file:///backup")
+
+    assert exc_info.value.exit_code == 1
+    assert exc_info.value.output == "backup not found"
+
+
+def test_docker_missing_container_raises():
+    with patch.object(fdb_agent_client.docker, "DockerClient",
+                      return_value=_docker_client(_container(name="app_WebAppAPI.1.xyz"))):
+        with pytest.raises(FdbAgentNotFoundError):
+            DockerFdbAgent("1.2.3.4:2375").exec("fdbbackup status")
+
+
+def test_docker_read_timeout_becomes_command_timeout():
+    from requests.exceptions import ReadTimeout
+
+    container = _container()
+    container.exec_run.side_effect = ReadTimeout("read timed out")
+    with patch.object(fdb_agent_client.docker, "DockerClient",
+                      return_value=_docker_client(container)):
+        with pytest.raises(FdbCommandTimeoutError):
+            DockerFdbAgent("1.2.3.4:2375", timeout=5).exec("fdbbackup start -d file:///b -w")
+
+
+def test_quoted_command_is_split_like_the_docker_api_did():
+    """The fdbcli restore command relies on shell-style splitting.
+
+    It used to be handed to ``exec_run`` as a string, which docker split with
+    ``shlex.split``. Pre-splitting must produce the exact same argv.
+    """
+    from docker.utils import split_command
+
+    command = "fdbcli --exec \"writemode on; clearrange \\\"\\\" \\xff\""
+    assert DockerFdbAgent._argv(command) == split_command(command)
+
+
+# --- kubernetes backend ----------------------------------------------------
+
+def test_k8s_exec_returns_output_and_uses_argv():
+    api = _core_api({"app=fdb-backup-agent": [_pod()]})
+    response = _ws_response(output="backup started")
+    with patch.object(fdb_agent_client.utils, "load_kube_config_with_fallback"), \
+            patch.object(fdb_agent_client.k8s_client, "CoreV1Api", return_value=api), \
+            patch.object(fdb_agent_client, "k8s_stream", return_value=response) as stream:
+        assert KubernetesFdbAgent(namespace="simplyblock").exec("fdbbackup status") == "backup started"
+
+    assert stream.call_args.kwargs["command"] == ["fdbbackup", "status"]
+    assert stream.call_args.kwargs["name"] == "fdb-backup-agent-0"
+    assert stream.call_args.kwargs["namespace"] == "simplyblock"
+    assert stream.call_args.kwargs["_preload_content"] is False
+    response.close.assert_called_once()
+
+
+def test_k8s_exec_reads_exit_code_before_draining_output():
+    """``read_all()`` drops the channel buffers the exit code is parsed from."""
+    api = _core_api({"app=fdb-backup-agent": [_pod()]})
+    response = MagicMock()
+    response.is_open.return_value = False
+    order = []
+    type(response).returncode = property(lambda self: order.append("returncode") or 0)
+    response.read_all.side_effect = lambda: order.append("read_all") or "out"
+
+    with patch.object(fdb_agent_client.utils, "load_kube_config_with_fallback"), \
+            patch.object(fdb_agent_client.k8s_client, "CoreV1Api", return_value=api), \
+            patch.object(fdb_agent_client, "k8s_stream", return_value=response):
+        KubernetesFdbAgent().exec("fdbbackup status")
+
+    assert order == ["returncode", "read_all"]
+
+
+def test_k8s_exec_raises_on_non_zero_exit():
+    api = _core_api({"app=fdb-backup-agent": [_pod()]})
+    response = _ws_response(output="ERROR: no backup", returncode=3)
+    with patch.object(fdb_agent_client.utils, "load_kube_config_with_fallback"), \
+            patch.object(fdb_agent_client.k8s_client, "CoreV1Api", return_value=api), \
+            patch.object(fdb_agent_client, "k8s_stream", return_value=response):
+        with pytest.raises(FdbCommandError) as exc_info:
+            KubernetesFdbAgent().exec("fdbbackup list -b file:///backup")
+
+    assert exc_info.value.exit_code == 3
+    assert exc_info.value.output == "ERROR: no backup"
+
+
+def test_k8s_exec_raises_when_stream_does_not_finish():
+    api = _core_api({"app=fdb-backup-agent": [_pod()]})
+    response = _ws_response(still_open=True)
+    with patch.object(fdb_agent_client.utils, "load_kube_config_with_fallback"), \
+            patch.object(fdb_agent_client.k8s_client, "CoreV1Api", return_value=api), \
+            patch.object(fdb_agent_client, "k8s_stream", return_value=response):
+        with pytest.raises(FdbCommandTimeoutError):
+            KubernetesFdbAgent(timeout=1).exec("fdbbackup status")
+
+    response.close.assert_called_once()
+
+
+def test_k8s_falls_back_to_the_fdb_cluster_pods():
+    fallback_selector = fdb_agent_client.K8S_POD_SELECTORS[1]
+    api = _core_api({fallback_selector: [_pod(name="simplyblock-fdb-cluster-storage-1")]})
+    with patch.object(fdb_agent_client.utils, "load_kube_config_with_fallback"), \
+            patch.object(fdb_agent_client.k8s_client, "CoreV1Api", return_value=api), \
+            patch.object(fdb_agent_client, "k8s_stream", return_value=_ws_response()) as stream:
+        KubernetesFdbAgent().exec("fdbbackup status")
+
+    assert stream.call_args.kwargs["name"] == "simplyblock-fdb-cluster-storage-1"
+
+
+def test_k8s_ignores_pods_that_are_not_running():
+    api = _core_api({"app=fdb-backup-agent": [_pod(phase="Pending")]})
+    with patch.object(fdb_agent_client.utils, "load_kube_config_with_fallback"), \
+            patch.object(fdb_agent_client.k8s_client, "CoreV1Api", return_value=api):
+        with pytest.raises(FdbAgentNotFoundError):
+            KubernetesFdbAgent().exec("fdbbackup status")
+
+
+# --- backend selection & redaction ----------------------------------------
+
+def test_kubernetes_mgmt_node_gets_the_kubernetes_backend():
+    node = MgmtNode()
+    node.mode = "kubernetes"
+    assert isinstance(get_fdb_agent(node), KubernetesFdbAgent)
+
+
+@pytest.mark.parametrize("mode", ["docker", ""])
+def test_non_kubernetes_mgmt_node_gets_the_docker_backend(mode):
+    node = MgmtNode()
+    node.mode = mode
+    node.docker_ip_port = "10.0.0.1:2375"
+    agent = get_fdb_agent(node)
+    assert isinstance(agent, DockerFdbAgent)
+    assert agent._docker_ip_port == "10.0.0.1:2375"
+
+
+def test_fdb_backup_mode_env_selects_the_kubernetes_backend():
+    """``FDB_BACKUP_MODE=kubernetes`` wins without consulting the mgmt node.
+
+    The docker backend needs a mgmt node for its daemon address; the
+    kubernetes one does not, so the lookup must not even happen.
+    """
+    from simplyblock_core.controllers import fdb_backup_controller
+
+    with patch.object(fdb_backup_controller.constants, "FDB_BACKUP_MODE", "kubernetes"), \
+            patch.object(fdb_backup_controller.db_controller, "get_mgmt_nodes") as get_mgmt_nodes:
+        agent = fdb_backup_controller.__get_fdb_agent()
+
+    assert isinstance(agent, KubernetesFdbAgent)
+    get_mgmt_nodes.assert_not_called()
+
+
+def test_without_fdb_backup_mode_the_mgmt_node_decides():
+    from simplyblock_core.controllers import fdb_backup_controller
+
+    node = MgmtNode()
+    node.mode = "docker"
+    node.docker_ip_port = "10.0.0.1:2375"
+    with patch.object(fdb_backup_controller.constants, "FDB_BACKUP_MODE", ""), \
+            patch.object(fdb_backup_controller.db_controller, "get_mgmt_nodes", return_value=[node]):
+        assert isinstance(fdb_backup_controller.__get_fdb_agent(), DockerFdbAgent)
+
+
+def test_no_mgmt_node_raises_agent_not_found():
+    from simplyblock_core.controllers import fdb_backup_controller
+
+    with patch.object(fdb_backup_controller.constants, "FDB_BACKUP_MODE", ""), \
+            patch.object(fdb_backup_controller.db_controller, "get_mgmt_nodes", return_value=[]):
+        with pytest.raises(FdbAgentNotFoundError):
+            fdb_backup_controller.__get_fdb_agent()
+
+
+def test_blobstore_credentials_are_masked_in_command_rendering():
+    masked = redact(["fdbbackup", "list", "-b", BLOBSTORE_PATH])
+    assert "s3cr3t" not in masked
+    assert "AKIAKEY" not in masked
+    assert "blobstore://**********@s3.eu-west-1.amazonaws.com" in masked
+
+
+def test_command_error_message_does_not_leak_credentials():
+    error = FdbCommandError(["fdbbackup", "list", "-b", BLOBSTORE_PATH], 1, "denied")
+    assert "s3cr3t" not in str(error)
+    assert "denied" in str(error)


### PR DESCRIPTION
The current task runner to create FoundationDB backups directly uses the Docker client to run the fdbbackup command which fails on Kubernetes.

This PR adds a simple abstraction which is either backed by Docker (default) or Kubernetes (env var `FDB_BACKUP_MODE=kubernetes`).