### PR TITLE
Explicitly disable FDB backups for kubernetes

### DIFF
--- a/simplyblock_core/controllers/fdb_backup_controller.py
+++ b/simplyblock_core/controllers/fdb_backup_controller.py
@@ -180,6 +180,10 @@ def add_backup_task(cluster_id):
         logger.error(f"Failed to get cluster {cluster_id}: {e}")
         return False
 
+    if cluster.mode == "kubernetes":
+        logger.error("FDB Backups are handled by the operator")
+        return False
+
     tasks = get_backup_tasks(cluster_id)
     for task in tasks:
         if task.status != JobSchedule.STATUS_DONE:


### PR DESCRIPTION
This is handled on the operator side by instrumenting the FDB operator.